### PR TITLE
feat: versioning system and release CI/CD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      notes:
+        description: "Release notes (leave blank for auto-generated changelog)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history for changelog generation
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Get current version
+        id: version
+        run: |
+          VERSION=$(python -c "
+          import re
+          text = open('cli/src/sonde/__init__.py').read()
+          print(re.search(r'__version__ = \"(.+)\"', text)[1])
+          ")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Current version: $VERSION"
+
+      - name: Check tag exists
+        run: |
+          if ! git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "WARNING: Tag v${{ steps.version.outputs.version }} does not exist."
+            echo "Creating tag now..."
+            git tag "v${{ steps.version.outputs.version }}"
+            git push --tags
+          fi
+
+      - name: Generate changelog from commits
+        id: changelog
+        run: |
+          LAST_TAG=$(git tag --sort=-v:refname | grep -v "v${{ steps.version.outputs.version }}" | head -1)
+          if [ -n "$LAST_TAG" ]; then
+            RANGE="${LAST_TAG}..v${{ steps.version.outputs.version }}"
+            echo "Changelog range: $RANGE"
+          else
+            RANGE="v${{ steps.version.outputs.version }}"
+            echo "No previous tag — using last 30 commits"
+          fi
+
+          {
+            echo "log<<EOF"
+            if [ -n "$LAST_TAG" ]; then
+              git log "$RANGE" --oneline --no-merges | head -50
+            else
+              git log --oneline -30 --no-merges
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Sonde v${{ steps.version.outputs.version }}
+          body: |
+            ## Sonde v${{ steps.version.outputs.version }}
+
+            ### Install
+            ```bash
+            uv tool install "sonde @ git+https://github.com/aeolus-earth/sonde.git@v${{ steps.version.outputs.version }}#subdirectory=cli"
+            ```
+
+            ### Changes
+            ${{ inputs.notes || steps.changelog.outputs.log }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,56 @@
+name: Version Bump
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "cli/**"
+      - "ui/**"
+      - "server/**"
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    # Don't bump on commits from this workflow (prevent infinite loop)
+    if: "!contains(github.event.head_commit.message, '[skip-bump]')"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Determine bump type from commit message
+        id: bump-type
+        run: |
+          MSG=$(git log -1 --pretty=%B)
+          if echo "$MSG" | grep -qiE "BREAKING CHANGE|^[a-z]+(\(.+\))?!:"; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif echo "$MSG" | grep -qiE "^feat(\(|:)"; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Bump type: $(cat "$GITHUB_OUTPUT" | grep type | cut -d= -f2)"
+
+      - name: Bump version
+        id: version
+        run: |
+          NEW=$(python cli/scripts/bump_version.py ${{ steps.bump-type.outputs.type }})
+          echo "version=$NEW" >> "$GITHUB_OUTPUT"
+          echo "Bumped to $NEW"
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add cli/src/sonde/__init__.py
+          git commit -m "v${{ steps.version.outputs.version }} [skip-bump]"
+          git tag "v${{ steps.version.outputs.version }}"
+          git push && git push --tags

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sonde"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Scientific discovery management CLI for the Aeolus research platform"
 readme = "README.md"
 license = "MIT"
@@ -25,6 +25,9 @@ sonde = "sonde.cli:cli"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/sonde/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/sonde"]

--- a/cli/scripts/bump_version.py
+++ b/cli/scripts/bump_version.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Bump the version in __init__.py. Usage: python bump_version.py [patch|minor|major]"""
+
+import re
+import sys
+from pathlib import Path
+
+INIT_FILE = Path(__file__).resolve().parent.parent / "src" / "sonde" / "__init__.py"
+VERSION_RE = re.compile(r'__version__\s*=\s*"(\d+)\.(\d+)\.(\d+)"')
+
+
+def bump(bump_type: str) -> str:
+    text = INIT_FILE.read_text(encoding="utf-8")
+    match = VERSION_RE.search(text)
+    if not match:
+        print(f"ERROR: Could not find __version__ in {INIT_FILE}", file=sys.stderr)
+        sys.exit(1)
+
+    major, minor, patch = int(match[1]), int(match[2]), int(match[3])
+
+    if bump_type == "major":
+        major, minor, patch = major + 1, 0, 0
+    elif bump_type == "minor":
+        major, minor, patch = major, minor + 1, 0
+    elif bump_type == "patch":
+        major, minor, patch = major, minor, patch + 1
+    else:
+        print(f"ERROR: Unknown bump type '{bump_type}'. Use: patch, minor, major", file=sys.stderr)
+        sys.exit(1)
+
+    new_version = f"{major}.{minor}.{patch}"
+    new_text = VERSION_RE.sub(f'__version__ = "{new_version}"', text)
+    INIT_FILE.write_text(new_text, encoding="utf-8")
+
+    print(new_version)
+    return new_version
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python bump_version.py [patch|minor|major]", file=sys.stderr)
+        sys.exit(1)
+    bump(sys.argv[1])


### PR DESCRIPTION
## Summary
- **Dynamic version**: `pyproject.toml` reads from `__init__.py` via hatchling — single source of truth
- **Auto-bump on merge**: commit prefix determines bump type (`fix:` → patch, `feat:` → minor, `feat!:` → major), creates git tag
- **Manual release**: GitHub Actions `workflow_dispatch` creates GitHub Release with auto-generated changelog

## How it works

| Commit prefix | Bump | Example |
|---|---|---|
| `fix:` | patch | `0.1.0` → `0.1.1` |
| `feat:` | minor | `0.1.1` → `0.2.0` |
| `feat!:` / `BREAKING CHANGE` | major | `0.2.0` → `1.0.0` |

To release: GitHub Actions → "Release" → "Run workflow" → writes release notes or auto-generates from commits.

## Test plan
- [ ] Merge a `fix:` PR → verify version bumps and tag created
- [ ] Merge a `feat:` PR → verify minor bump
- [ ] Run Release workflow → verify GitHub Release created with changelog
- [ ] `sonde --version` shows new version after install
- [ ] `[skip-bump]` in commit message prevents double-bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)