### PR TITLE
fix: detect shadow sonde installations in doctor

### DIFF
--- a/cli/src/sonde/diagnostics.py
+++ b/cli/src/sonde/diagnostics.py
@@ -139,12 +139,64 @@ def collect_next_steps(sections: list[DoctorSection], *, limit: int = 3) -> list
     return fixes
 
 
+def check_install_shadows() -> DoctorCheck:
+    """Detect if another sonde installation shadows this one on PATH."""
+    import shutil
+    import sys
+
+    this_exe = sys.argv[0]
+    path_exe = shutil.which("sonde")
+
+    if not path_exe:
+        return DoctorCheck(
+            title="Installation",
+            status="warn",
+            summary="sonde not found on PATH",
+            details=["The current invocation works but 'sonde' may not resolve in other shells."],
+        )
+
+    this_resolved = Path(this_exe).resolve()
+    path_resolved = Path(path_exe).resolve()
+
+    if this_resolved != path_resolved:
+        return DoctorCheck(
+            title="Installation",
+            status="warn",
+            summary="Multiple sonde installations detected",
+            details=[
+                f"Running:  {this_resolved}",
+                f"PATH has: {path_resolved}",
+                "Another install is shadowing this one. Commands may be missing.",
+            ],
+            fix=f"pip uninstall sonde -y  # remove the shadow at {path_resolved}",
+        )
+
+    from sonde.cli import cli
+
+    cmd_count = len(cli.commands)
+    if cmd_count < 25:
+        return DoctorCheck(
+            title="Installation",
+            status="warn",
+            summary=f"Only {cmd_count} commands registered (expected 30+)",
+            details=["Some command modules may be failing to import silently."],
+            fix="pip install --force-reinstall 'sonde @ git+https://github.com/aeolus-earth/sonde.git@main#subdirectory=cli'",
+        )
+
+    return DoctorCheck(
+        title="Installation",
+        status="ok",
+        summary=f"{cmd_count} commands, no shadow installs",
+    )
+
+
 def build_local_section(*, deep: bool = False) -> DoctorSection:
     """Inspect local runtime, skills, and MCP readiness."""
     project_root = find_project_root()
     root = project_root or Path.home()
     runtimes = detect_runtimes(root)
     checks = [
+        check_install_shadows(),
         check_runtime_detection(project_root, runtimes),
         check_skill_freshness(root, runtimes),
         check_mcp_configuration(project_root, runtimes),


### PR DESCRIPTION
## Summary
- `sonde doctor` now detects when multiple sonde installations exist on PATH
- Warns when one shadows the other (e.g., pip install in conda env shadowing uv tool install)
- Also checks that expected command count is registered — catches silent import failures

## Context
We hit this exact issue: `uv tool install` installed the latest sonde, but an older pip-installed version in a conda env was shadowing it on PATH. Result: `sonde artifact --help` → "No such command 'artifact'" despite the code being correct.

## Test plan
- [ ] Install sonde via both pip and uv → `sonde doctor` warns about shadow
- [ ] Single install → `sonde doctor` shows "ok" with command count
- [ ] Missing commands (< 25) → warns with reinstall fix command

🤖 Generated with [Claude Code](https://claude.com/claude-code)