### PR TITLE
Nested hierarchy for .sonde/ directory layout

### DIFF
--- a/cli/src/sonde/commands/pull.py
+++ b/cli/src/sonde/commands/pull.py
@@ -31,7 +31,15 @@ from sonde.db.artifacts import (
     is_text_artifact,
     list_for_experiments,
 )
-from sonde.local import ensure_subdir, find_sonde_dir, render_record, write_record
+from sonde.local import (
+    build_direction_index,
+    compute_record_dir,
+    ensure_subdir,
+    find_sonde_dir,
+    render_record,
+    write_nested_record,
+    write_record,
+)
 from sonde.output import err, print_error, print_json, print_success
 
 ARTIFACT_CHOICES = ("none", "text", "media", "all")
@@ -281,11 +289,11 @@ def pull_direction(ctx: click.Context, direction_id: str) -> None:
         )
         raise SystemExit(1)
 
-    path = _write_record_with_body(
-        sonde_dir, "directions", direction.id, direction.model_dump(mode="json")
-    )
+    d_dict = direction.model_dump(mode="json")
+    rel_dir = compute_record_dir("direction", d_dict)
+    path = write_nested_record(sonde_dir, rel_dir, "direction.md", render_record(d_dict))
     if ctx.obj.get("json"):
-        print_json(direction.model_dump(mode="json"))
+        print_json(d_dict)
     else:
         print_success(f"Pulled {direction.id} → {path.relative_to(sonde_dir.parent)}")
 
@@ -299,9 +307,9 @@ def pull_directions(ctx: click.Context) -> None:
     sonde_dir = find_sonde_dir()
     directions = dir_db.list_directions(program=program, statuses=None, limit=10000)
     for direction in directions:
-        _write_record_with_body(
-            sonde_dir, "directions", direction.id, direction.model_dump(mode="json")
-        )
+        d_dict = direction.model_dump(mode="json")
+        rel_dir = compute_record_dir("direction", d_dict)
+        write_nested_record(sonde_dir, rel_dir, "direction.md", render_record(d_dict))
     if ctx.obj.get("json"):
         print_json({"count": len(directions), "ids": [d.id for d in directions]})
         return
@@ -342,6 +350,10 @@ def _run_experiment_pull(
         roots=roots,
         program=program,
     )
+
+    # Build direction_index for nested placement
+    direction_index = _build_direction_index_for_experiments(experiments)
+
     sync = _sync_experiments(
         sonde_dir,
         experiments,
@@ -349,6 +361,7 @@ def _run_experiment_pull(
         artifact_mode=mode,
         use_json=bool(ctx.obj.get("json")),
         follow_up_command=_media_follow_up(selector_summary, program),
+        direction_index=direction_index,
     )
     if selector_kind == "single":
         sync.next_steps = _pull_next_steps(experiments[0]["id"], sync)
@@ -369,7 +382,8 @@ def _run_experiment_pull(
         return
 
     if selector_kind == "single":
-        path = sonde_dir / "experiments" / f"{experiments[0]['id']}.md"
+        rel_dir = compute_record_dir("experiment", experiments[0], direction_index=direction_index)
+        path = sonde_dir / rel_dir / f"{experiments[0]['id']}.md"
         print_success(f"Pulled {experiments[0]['id']} → {path.relative_to(sonde_dir.parent)}")
     else:
         print_success(f"Pulled {len(experiments)} experiment(s)")
@@ -504,30 +518,11 @@ def _pull_all(ctx: click.Context) -> None:
     findings = find_db.list_findings(program=program, include_superseded=True, limit=10000)
     questions = q_db.list_questions(program=program, include_all=True, limit=10000)
     directions = dir_db.list_directions(program=program, statuses=None, limit=10000)
-    sync = _sync_experiments(
-        sonde_dir,
-        experiments,
-        selector={"kind": "program", "program": program},
-        artifact_mode=ctx.obj.get("pull_artifacts", "text"),
-        use_json=bool(ctx.obj.get("json")),
-        follow_up_command=f"sonde pull -p {program} --artifacts media",
-    )
+    dir_dicts = [d.model_dump(mode="json") for d in directions]
+    direction_index = build_direction_index(dir_dicts)
 
-    for finding in findings:
-        _write_record_with_body(sonde_dir, "findings", finding.id, finding.model_dump(mode="json"))
-    for question in questions:
-        _write_record_with_body(
-            sonde_dir, "questions", question.id, question.model_dump(mode="json")
-        )
-    for direction in directions:
-        _write_record_with_body(
-            sonde_dir, "directions", direction.id, direction.model_dump(mode="json")
-        )
-
-    tw = takeaways_db.get(program)
-    takeaways_db.write_takeaways_file(sonde_dir, tw.body if tw else None)
-
-    # Pull project takeaways (best-effort — table may not exist yet)
+    # Write projects (best-effort — fetch for hierarchy + takeaways)
+    projects: list[Any] = []
     project_takeaways_count = 0
     try:
         from sonde.db import project_takeaways as ptw_db
@@ -535,12 +530,54 @@ def _pull_all(ctx: click.Context) -> None:
 
         projects = proj_db.list_projects(program=program, statuses=None, limit=200)
         for p in projects:
+            p_data = p.model_dump(mode="json")
+            rel_dir = compute_record_dir("project", p_data)
+            write_nested_record(sonde_dir, rel_dir, "project.md", render_record(p_data))
             ptw = ptw_db.get(p.id)
             if ptw and ptw.body.strip():
                 ptw_db.write_takeaways_file(sonde_dir, p.id, ptw.body)
                 project_takeaways_count += 1
     except (Exception, SystemExit):
         pass
+
+    # Write directions nested under projects
+    for d_dict in dir_dicts:
+        rel_dir = compute_record_dir("direction", d_dict)
+        write_nested_record(sonde_dir, rel_dir, "direction.md", render_record(d_dict))
+
+    # Write experiments nested under directions/projects
+    sync = _sync_experiments(
+        sonde_dir,
+        experiments,
+        selector={"kind": "program", "program": program},
+        artifact_mode=ctx.obj.get("pull_artifacts", "text"),
+        use_json=bool(ctx.obj.get("json")),
+        follow_up_command=f"sonde pull -p {program} --artifacts media",
+        direction_index=direction_index,
+    )
+
+    # Findings and questions stay flat
+    for finding in findings:
+        _write_record_with_body(sonde_dir, "findings", finding.id, finding.model_dump(mode="json"))
+    for question in questions:
+        _write_record_with_body(
+            sonde_dir, "questions", question.id, question.model_dump(mode="json")
+        )
+
+    tw = takeaways_db.get(program)
+    takeaways_db.write_takeaways_file(sonde_dir, tw.body if tw else None)
+
+    # Generate tree.md index
+    from sonde.local import generate_tree_md
+
+    tree_content = generate_tree_md(
+        projects=[p.model_dump(mode="json") for p in projects],
+        directions=dir_dicts,
+        experiments=experiments,
+        findings=[f.model_dump(mode="json") for f in findings],
+        questions=[q.model_dump(mode="json") for q in questions],
+    )
+    (sonde_dir / "tree.md").write_text(tree_content, encoding="utf-8")
 
     if ctx.obj.get("json"):
         print_json(
@@ -578,14 +615,20 @@ def _sync_experiments(
     artifact_mode: str,
     use_json: bool,
     follow_up_command: str | None,
+    direction_index: dict[str, dict[str, Any]] | None = None,
 ) -> ArtifactSyncSummary:
+    # Build a map of exp_id → resolved base dir for artifact placement
+    exp_base_dirs: dict[str, Path] = {}
+
     for exp in experiments:
-        _write_record_with_body(sonde_dir, "experiments", exp["id"], exp)
-        ensure_subdir(sonde_dir, f"experiments/{exp['id']}")
+        rel_dir = compute_record_dir("experiment", exp, direction_index=direction_index)
+        write_nested_record(sonde_dir, rel_dir, f"{exp['id']}.md", render_record(exp))
+        exp_base = ensure_subdir(sonde_dir, f"{rel_dir}/{exp['id']}")
+        exp_base_dirs[exp["id"]] = exp_base
         try:
             notes = notes_db.list_by_experiment(exp["id"])
             if notes:
-                _write_notes(sonde_dir, exp["id"], notes)
+                _write_notes(exp_base, notes)
         except APIError as exc:
             from sonde.db import classify_api_error
 
@@ -603,6 +646,7 @@ def _sync_experiments(
         mode=artifact_mode,
         use_json=use_json,
         follow_up_command=follow_up_command,
+        exp_base_dirs=exp_base_dirs,
     )
 
 
@@ -614,6 +658,7 @@ def _download_selected_artifacts(
     mode: str,
     use_json: bool,
     follow_up_command: str | None,
+    exp_base_dirs: dict[str, Path] | None = None,
 ) -> ArtifactSyncSummary:
     summary = ArtifactSyncSummary(mode=mode)
     if mode == "none" or not experiments:
@@ -643,7 +688,9 @@ def _download_selected_artifacts(
         if not should_select:
             continue
 
-        local_path, local_action = _planned_pull_target(sonde_dir, artifact)
+        local_path, local_action = _planned_pull_target(
+            sonde_dir, artifact, exp_base_dirs=exp_base_dirs
+        )
         fingerprint = build_fingerprint(
             storage_path,
             local_action,
@@ -736,12 +783,23 @@ def _download_selected_artifacts(
     return summary
 
 
-def _planned_pull_target(sonde_dir: Path, artifact: dict[str, Any]) -> tuple[Path, str]:
+def _planned_pull_target(
+    sonde_dir: Path,
+    artifact: dict[str, Any],
+    *,
+    exp_base_dirs: dict[str, Path] | None = None,
+) -> tuple[Path, str]:
     from sonde.db.validate import contained_path
 
     experiment_id = str(artifact.get("experiment_id") or "")
     storage_path = str(artifact.get("storage_path") or "")
-    exp_dir = sonde_dir / "experiments" / experiment_id
+
+    # Use resolved nested dir if available, fall back to flat layout
+    if exp_base_dirs and experiment_id in exp_base_dirs:
+        exp_dir = exp_base_dirs[experiment_id]
+    else:
+        exp_dir = sonde_dir / "experiments" / experiment_id
+
     if storage_path.startswith(f"{experiment_id}/"):
         relative = storage_path[len(experiment_id) + 1 :]
     else:
@@ -865,6 +923,28 @@ def _format_bytes(value: int) -> str:
     return f"{value} B"
 
 
+def _build_direction_index_for_experiments(
+    experiments: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Build a minimal direction_index by fetching directions referenced by experiments."""
+    dir_ids = {exp.get("direction_id") for exp in experiments if exp.get("direction_id")}
+    if not dir_ids:
+        return {}
+    index: dict[str, dict[str, Any]] = {}
+    for dir_id in dir_ids:
+        try:
+            d = dir_db.get(dir_id)
+            if d:
+                data = d.model_dump(mode="json")
+                index[dir_id] = {
+                    "project_id": data.get("project_id"),
+                    "parent_direction_id": data.get("parent_direction_id"),
+                }
+        except Exception:
+            pass
+    return index
+
+
 def _write_record_with_body(
     sonde_dir: Path,
     category: str,
@@ -874,8 +954,9 @@ def _write_record_with_body(
     return write_record(sonde_dir, category, record_id, render_record(record))
 
 
-def _write_notes(sonde_dir: Path, experiment_id: str, notes: list[dict[str, Any]]) -> None:
-    notes_dir = ensure_subdir(sonde_dir, f"experiments/{experiment_id}/notes")
+def _write_notes(exp_base_dir: Path, notes: list[dict[str, Any]]) -> None:
+    notes_dir = exp_base_dir / "notes"
+    notes_dir.mkdir(parents=True, exist_ok=True)
     for note in notes:
         timestamp = note.get("created_at", "")[:19].replace(":", "-")
         filename = f"{timestamp}.md"

--- a/cli/src/sonde/commands/push.py
+++ b/cli/src/sonde/commands/push.py
@@ -74,11 +74,7 @@ def _dry_run_report(ctx: click.Context) -> None:
 
     counts: dict[str, int] = {}
     for category in _DRY_RUN_CATEGORIES:
-        cat_dir = sonde_dir / category
-        if cat_dir.is_dir():
-            counts[category] = len(list(cat_dir.glob("*.md")))
-        else:
-            counts[category] = 0
+        counts[category] = len(_discover_record_files(sonde_dir, category))
 
     takeaways_exists = (sonde_dir / "takeaways.md").exists()
 
@@ -161,20 +157,21 @@ def push_all(ctx: click.Context) -> None:
     except (Exception, SystemExit):
         pass
 
-    # Sync direction and project notes (best-effort)
+    # Sync direction and project notes (best-effort) — search flat and nested
     notes_synced = 0
     try:
-        for subdir_name, record_type, prefix in [
-            ("directions", "direction", "DIR-"),
-            ("projects", "project", "PROJ-"),
-        ]:
-            parent_dir = sonde_dir / subdir_name
-            if parent_dir.is_dir():
-                for record_dir in parent_dir.iterdir():
-                    if record_dir.is_dir() and record_dir.name.startswith(prefix):
-                        notes_synced += _sync_record_notes(
-                            record_type, record_dir.name, record_dir / "notes"
-                        )
+        for search_root in [sonde_dir / "directions", sonde_dir / "projects"]:
+            if not search_root.is_dir():
+                continue
+            for notes_dir in search_root.rglob("notes"):
+                if not notes_dir.is_dir():
+                    continue
+                record_dir = notes_dir.parent
+                name = record_dir.name
+                if name.startswith("DIR-"):
+                    notes_synced += _sync_record_notes("direction", name, notes_dir)
+                elif name.startswith("PROJ-"):
+                    notes_synced += _sync_record_notes("project", name, notes_dir)
     except (Exception, SystemExit):
         pass
 
@@ -320,15 +317,71 @@ def _push_directory(category: str, *, use_json: bool | None = None) -> int:
         ctx = click.get_current_context(silent=True)
         use_json = bool(ctx and ctx.obj and ctx.obj.get("json"))
     sonde_dir = find_sonde_dir()
-    directory = sonde_dir / category
-    if not directory.exists():
-        return 0
 
+    files = _discover_record_files(sonde_dir, category)
+    seen_ids: set[str] = set()
     count = 0
-    for filepath in sorted(directory.glob("*.md")):
+    for filepath in files:
+        # Deduplicate: same record may exist in flat and nested layouts
+        fm, _ = parse_markdown(filepath.read_text(encoding="utf-8"))
+        record_id = str(fm.get("id", "")).upper()
+        if record_id and record_id in seen_ids:
+            continue
+        if record_id:
+            seen_ids.add(record_id)
         _push_file(category, filepath, use_json=use_json)
         count += 1
     return count
+
+
+def _discover_record_files(sonde_dir: Path, category: str) -> list[Path]:
+    """Discover all record files for a category across flat and nested layouts."""
+    files: list[Path] = []
+
+    if category in ("findings", "questions"):
+        # Findings and questions are always flat
+        flat_dir = sonde_dir / category
+        if flat_dir.is_dir():
+            files.extend(flat_dir.glob("*.md"))
+        return sorted(files)
+
+    if category == "experiments":
+        # Flat layout
+        flat_dir = sonde_dir / "experiments"
+        if flat_dir.is_dir():
+            files.extend(flat_dir.glob("*.md"))
+        # Nested under projects/
+        projects_dir = sonde_dir / "projects"
+        if projects_dir.is_dir():
+            files.extend(p for p in projects_dir.rglob("EXP-*.md") if p.is_file())
+        # Nested under orphan directions/
+        dirs_dir = sonde_dir / "directions"
+        if dirs_dir.is_dir():
+            files.extend(p for p in dirs_dir.rglob("EXP-*.md") if p.is_file())
+        return sorted(set(files))
+
+    if category == "directions":
+        # Flat layout (legacy DIR-xxx.md files)
+        flat_dir = sonde_dir / "directions"
+        if flat_dir.is_dir():
+            files.extend(flat_dir.glob("DIR-*.md"))
+            # Nested direction.md inside directions/DIR-xxx/
+            for d in flat_dir.iterdir():
+                if d.is_dir() and d.name.startswith("DIR-"):
+                    dm = d / "direction.md"
+                    if dm.is_file():
+                        files.append(dm)
+        # Nested under projects/
+        projects_dir = sonde_dir / "projects"
+        if projects_dir.is_dir():
+            files.extend(p for p in projects_dir.rglob("direction.md") if p.is_file())
+        return sorted(set(files))
+
+    # Fallback for unknown categories
+    flat_dir = sonde_dir / category
+    if flat_dir.is_dir():
+        files.extend(flat_dir.glob("*.md"))
+    return sorted(files)
 
 
 def _push_one(category: str, name: str, *, use_json: bool | None = None) -> dict[str, Any]:
@@ -479,6 +532,7 @@ def _upsert_experiment(
         "metadata": frontmatter.get("metadata") or {},
         "data_sources": frontmatter.get("data_sources") or [],
         "direction_id": frontmatter.get("direction_id"),
+        "project_id": frontmatter.get("project_id"),
         "related": frontmatter.get("related") or [],
         "parent_id": frontmatter.get("parent_id"),
         "branch_type": frontmatter.get("branch_type"),
@@ -618,12 +672,15 @@ def _upsert_direction(frontmatter: dict[str, Any], body: str, filepath: Path) ->
     source = _resolve_source(frontmatter)
     title = frontmatter.get("title") or _extract_heading(body, filepath.stem.replace("-", " "))
     question = frontmatter.get("question") or _extract_context(body) or title
-    payload = {
+    payload: dict[str, Any] = {
         "program": program,
         "title": title,
         "question": question,
         "status": frontmatter.get("status", "active"),
         "source": source,
+        "project_id": frontmatter.get("project_id"),
+        "parent_direction_id": frontmatter.get("parent_direction_id"),
+        "spawned_from_experiment_id": frontmatter.get("spawned_from_experiment_id"),
     }
 
     existing_id = str(frontmatter.get("id", "")).upper()

--- a/cli/src/sonde/commands/remove.py
+++ b/cli/src/sonde/commands/remove.py
@@ -8,14 +8,12 @@ from pathlib import Path
 import click
 
 from sonde.cli_options import pass_output_options
-from sonde.db.validate import contained_path
 from sonde.local import find_sonde_dir, resolve_record_path
 from sonde.output import print_error, print_json, print_success
 
 
 def _remove_local_record(category: str, name: str) -> Path:
     sonde_dir = find_sonde_dir()
-    directory = sonde_dir / category
     try:
         candidate = resolve_record_path(sonde_dir, category, name)
     except ValueError:
@@ -28,14 +26,15 @@ def _remove_local_record(category: str, name: str) -> Path:
     if candidate is not None:
         candidate.unlink()
         if category == "experiments":
-            exp_dir = contained_path(directory, candidate.stem)
-            if exp_dir.exists():
+            # Artifact dir is a sibling directory named after the experiment ID
+            exp_dir = candidate.parent / candidate.stem
+            if exp_dir.is_dir():
                 shutil.rmtree(exp_dir)
         return candidate
 
     print_error(
         f"Local record not found: {name}",
-        f"No .md file matching '{name}' in .sonde/{category}/",
+        f"No .md file matching '{name}' in .sonde/",
         "Use the exact local filename stem or record ID.",
     )
     raise SystemExit(1)

--- a/cli/src/sonde/commands/sync.py
+++ b/cli/src/sonde/commands/sync.py
@@ -3,13 +3,22 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import click
 
 from sonde.cli_options import pass_output_options
 from sonde.config import get_settings
-from sonde.local import ensure_subdir, find_sonde_dir, render_record, write_record
+from sonde.local import (
+    build_direction_index,
+    compute_record_dir,
+    ensure_subdir,
+    find_sonde_dir,
+    render_record,
+    write_nested_record,
+    write_record,
+)
 from sonde.output import err, print_error, print_json, print_success
 
 
@@ -58,25 +67,45 @@ def sync(ctx: click.Context, program: str | None) -> None:
     all_findings = find_db.list_findings(program=program, include_superseded=True, limit=10000)
     questions = q_db.list_questions(program=program, include_all=True, limit=10000)
     directions = dir_db.list_directions(program=program, statuses=None, limit=10000)
+    dir_dicts = [d.model_dump(mode="json") for d in directions]
+    direction_index = build_direction_index(dir_dicts)
 
-    # Write experiment records + notes
+    # Write projects (best-effort)
+    projects: list[Any] = []
+    try:
+        from sonde.db import projects as proj_db
+
+        projects = proj_db.list_projects(program=program, statuses=None, limit=200)
+        for p in projects:
+            p_data = p.model_dump(mode="json")
+            rel_dir = compute_record_dir("project", p_data)
+            write_nested_record(sonde_dir, rel_dir, "project.md", render_record(p_data))
+    except (Exception, SystemExit):
+        pass
+
+    # Write directions nested under projects
+    for d_dict in dir_dicts:
+        rel_dir = compute_record_dir("direction", d_dict)
+        write_nested_record(sonde_dir, rel_dir, "direction.md", render_record(d_dict))
+
+    # Write experiment records + notes (nested)
     for exp in experiments:
         data = exp.model_dump(mode="json")
-        write_record(sonde_dir, "experiments", exp.id, render_record(data))
-        ensure_subdir(sonde_dir, f"experiments/{exp.id}")
+        rel_dir = compute_record_dir("experiment", data, direction_index=direction_index)
+        write_nested_record(sonde_dir, rel_dir, f"{exp.id}.md", render_record(data))
+        exp_base = ensure_subdir(sonde_dir, f"{rel_dir}/{exp.id}")
         try:
             notes = notes_db.list_by_experiment(exp.id)
             if notes:
-                _write_notes(sonde_dir, exp.id, notes)
+                _write_notes(exp_base, notes)
         except Exception:
             pass  # Non-critical — notes may not be available
 
+    # Findings and questions stay flat
     for f in all_findings:
         write_record(sonde_dir, "findings", f.id, render_record(f.model_dump(mode="json")))
     for q in questions:
         write_record(sonde_dir, "questions", q.id, render_record(q.model_dump(mode="json")))
-    for d in directions:
-        write_record(sonde_dir, "directions", d.id, render_record(d.model_dump(mode="json")))
 
     tw = takeaways_db.get(program)
     takeaways_db.write_takeaways_file(sonde_dir, tw.body if tw else None)
@@ -126,6 +155,21 @@ def sync(ctx: click.Context, program: str | None) -> None:
 
     if not use_json:
         err.print("  [sonde.muted]Generated index.jsonl[/]")
+
+    # -- Generate tree.md --
+    from sonde.local import generate_tree_md
+
+    tree_content = generate_tree_md(
+        projects=[p.model_dump(mode="json") for p in projects],
+        directions=dir_dicts,
+        experiments=[e.model_dump(mode="json") for e in experiments],
+        findings=[f.model_dump(mode="json") for f in all_findings],
+        questions=[q.model_dump(mode="json") for q in questions],
+    )
+    (sonde_dir / "tree.md").write_text(tree_content, encoding="utf-8")
+
+    if not use_json:
+        err.print("  [sonde.muted]Generated tree.md[/]")
 
     # -- Summary --
     running = [e for e in experiments if e.status == "running"]
@@ -189,8 +233,9 @@ def _one_line(exp: Any) -> str:
     return exp.finding[:60] if exp.finding else ""
 
 
-def _write_notes(sonde_dir: Any, experiment_id: str, notes: list[dict[str, Any]]) -> None:
-    notes_dir = ensure_subdir(sonde_dir, f"experiments/{experiment_id}/notes")
+def _write_notes(exp_base_dir: Path, notes: list[dict[str, Any]]) -> None:
+    notes_dir = exp_base_dir / "notes"
+    notes_dir.mkdir(parents=True, exist_ok=True)
     for note in notes:
         timestamp = note.get("created_at", "")[:19].replace(":", "-")
         filename = f"{timestamp}.md"

--- a/cli/src/sonde/local.py
+++ b/cli/src/sonde/local.py
@@ -33,8 +33,12 @@ _FRONTMATTER_KEYS = {
     "git_branch",
     "data_sources",
     "direction_id",
+    "project_id",
     "parent_id",
     "branch_type",
+    # Directions
+    "parent_direction_id",
+    "spawned_from_experiment_id",
     "claimed_by",
     "claimed_at",
     "run_at",
@@ -98,25 +102,23 @@ def ensure_subdir(sonde_dir: Path, name: str) -> Path:
 
 
 def resolve_record_path(sonde_dir: Path, category: str, name: str) -> Path | None:
-    """Resolve an existing record path under ``.sonde/<category>`` safely.
+    """Resolve an existing record path under ``.sonde/`` safely.
 
-    Handles two layouts:
-      - ``<category>/EXP-0001.md``          (file-only, from log/new)
-      - ``<category>/EXP-0001/EXP-0001.md`` (directory, from pull with artifacts)
+    Searches the flat layout first (``<category>/EXP-0001.md``), then
+    falls back to the nested hierarchy (``projects/**/EXP-0001.md``).
     """
     from sonde.db.validate import contained_path
 
     base_dir = sonde_dir / category
     stem = name.removesuffix(".md")
 
-    # Build candidates: flat files first, then files inside directories
+    # 1. Flat layout: check <category>/<name>.md and <category>/<name>/<name>.md
     candidates = [
         f"{stem}.md",
         f"{stem.upper()}.md",
         f"{stem}/{stem}.md",
         f"{stem}/{stem.upper()}.md",
     ]
-    # Deduplicate while preserving order
     seen: set[str] = set()
     unique: list[str] = []
     for c in candidates:
@@ -131,6 +133,35 @@ def resolve_record_path(sonde_dir: Path, category: str, name: str) -> Path | Non
             raise ValueError(f"Unsafe local record path: {name!r}") from None
         if path.exists() and path.is_file():
             return path
+
+    # 2. Nested layout: search under projects/ and directions/
+    result = _search_nested_record(sonde_dir, category, stem)
+    if result is not None:
+        return result
+
+    return None
+
+
+def _search_nested_record(sonde_dir: Path, category: str, stem: str) -> Path | None:
+    """Search nested hierarchy for a record by ID stem."""
+    stem_upper = stem.upper()
+
+    if category == "experiments":
+        # Experiments: EXP-xxx.md under projects/ or directions/
+        for search_root in [sonde_dir / "projects", sonde_dir / "directions"]:
+            if search_root.is_dir():
+                for candidate in search_root.rglob(f"{stem_upper}.md"):
+                    if candidate.is_file():
+                        return candidate
+
+    elif category == "directions":
+        # Directions: direction.md inside a DIR-xxx/ directory, or DIR-xxx.md flat
+        for search_root in [sonde_dir / "projects", sonde_dir / "directions"]:
+            if search_root.is_dir():
+                for candidate in search_root.rglob("direction.md"):
+                    if candidate.is_file() and candidate.parent.name == stem_upper:
+                        return candidate
+
     return None
 
 
@@ -250,12 +281,82 @@ def parse_markdown(content: str) -> tuple[dict[str, Any], str]:
 
 
 # ---------------------------------------------------------------------------
+# Nested hierarchy — path resolution
+# ---------------------------------------------------------------------------
+
+DirectionIndex = dict[str, dict[str, Any]]
+"""Mapping of direction ID → {project_id, parent_direction_id}."""
+
+
+def compute_record_dir(
+    record_type: str,
+    record: dict[str, Any],
+    *,
+    direction_index: DirectionIndex | None = None,
+) -> str:
+    """Compute the directory path for a record, relative to .sonde/.
+
+    Returns a string like ``"projects/PROJ-001/DIR-001"`` or ``"experiments"``.
+    The caller appends the filename (e.g. ``EXP-001.md`` or ``direction.md``).
+    """
+    if record_type == "finding":
+        return "findings"
+    if record_type == "question":
+        return "questions"
+    if record_type == "project":
+        return f"projects/{record['id']}"
+
+    if record_type == "direction":
+        project_id = record.get("project_id")
+        parent_dir_id = record.get("parent_direction_id")
+        dir_id = record["id"]
+        if project_id and parent_dir_id:
+            return f"projects/{project_id}/{parent_dir_id}/{dir_id}"
+        if project_id:
+            return f"projects/{project_id}/{dir_id}"
+        return f"directions/{dir_id}"
+
+    if record_type == "experiment":
+        dir_id = record.get("direction_id")
+        if dir_id and direction_index and dir_id in direction_index:
+            dir_info = direction_index[dir_id]
+            # Reuse direction path logic
+            dir_record = {"id": dir_id, **dir_info}
+            return compute_record_dir("direction", dir_record)
+        project_id = record.get("project_id")
+        if project_id:
+            return f"projects/{project_id}"
+        return "experiments"
+
+    raise ValueError(f"Unknown record type: {record_type}")
+
+
+def build_direction_index(directions: list[dict[str, Any]]) -> DirectionIndex:
+    """Build a direction lookup from a list of direction records."""
+    return {
+        d["id"]: {
+            "project_id": d.get("project_id"),
+            "parent_direction_id": d.get("parent_direction_id"),
+        }
+        for d in directions
+    }
+
+
+def write_nested_record(sonde_dir: Path, relative_dir: str, filename: str, content: str) -> Path:
+    """Write a record to a nested path under .sonde/."""
+    subdir = ensure_subdir(sonde_dir, relative_dir)
+    filepath = subdir / filename
+    filepath.write_text(content, encoding="utf-8")
+    return filepath
+
+
+# ---------------------------------------------------------------------------
 # File operations
 # ---------------------------------------------------------------------------
 
 
 def write_record(sonde_dir: Path, category: str, record_id: str, content: str) -> Path:
-    """Write a rendered record to .sonde/."""
+    """Write a rendered record to .sonde/ (flat layout)."""
     from sonde.db.validate import validate_id
 
     validate_id(record_id)
@@ -339,6 +440,99 @@ tags: []
 Write your observations, analysis, or literature review here.
 """,
 }
+
+
+# ---------------------------------------------------------------------------
+# Tree index generation
+# ---------------------------------------------------------------------------
+
+
+def generate_tree_md(
+    *,
+    projects: list[dict[str, Any]],
+    directions: list[dict[str, Any]],
+    experiments: list[dict[str, Any]],
+    findings: list[dict[str, Any]],
+    questions: list[dict[str, Any]],
+) -> str:
+    """Generate a tree.md index showing the full research hierarchy."""
+    from collections import defaultdict
+
+    lines = ["# Research Tree", ""]
+
+    # Build lookup structures
+    dirs_by_project: dict[str | None, list[dict[str, Any]]] = defaultdict(list)
+    sub_dirs: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for d in directions:
+        if d.get("parent_direction_id"):
+            sub_dirs[d["parent_direction_id"]].append(d)
+        else:
+            dirs_by_project[d.get("project_id")].append(d)
+
+    exps_by_dir: dict[str | None, list[dict[str, Any]]] = defaultdict(list)
+    exps_by_project_no_dir: dict[str | None, list[dict[str, Any]]] = defaultdict(list)
+    orphan_exps: list[dict[str, Any]] = []
+    for exp in experiments:
+        if exp.get("direction_id"):
+            exps_by_dir[exp["direction_id"]].append(exp)
+        elif exp.get("project_id"):
+            exps_by_project_no_dir[exp["project_id"]].append(exp)
+        else:
+            orphan_exps.append(exp)
+
+    def _exp_line(exp: dict[str, Any], indent: int) -> str:
+        title = exp.get("title") or exp.get("hypothesis") or exp["id"]
+        status = exp.get("status", "")
+        prefix = "  " * indent + "- "
+        return f"{prefix}{exp['id']}: {title} [{status}]"
+
+    def _render_dir(d: dict[str, Any], indent: int) -> None:
+        title = d.get("title") or d["id"]
+        status = d.get("status", "")
+        prefix = "  " * indent + "- "
+        lines.append(f"{prefix}{d['id']}: {title} ({status})")
+        for child_dir in sub_dirs.get(d["id"], []):
+            _render_dir(child_dir, indent + 1)
+        for exp in exps_by_dir.get(d["id"], []):
+            lines.append(_exp_line(exp, indent + 1))
+
+    # Projects
+    for project in projects:
+        name = project.get("name") or project["id"]
+        lines.append(f"## {project['id']}: {name}")
+        for d in dirs_by_project.get(project["id"], []):
+            _render_dir(d, 0)
+        for exp in exps_by_project_no_dir.get(project["id"], []):
+            lines.append(_exp_line(exp, 0))
+        lines.append("")
+
+    # Orphan directions (no project)
+    orphan_dirs = dirs_by_project.get(None, [])
+    if orphan_dirs or orphan_exps:
+        lines.append("## Unassigned")
+        for d in orphan_dirs:
+            _render_dir(d, 0)
+        for exp in orphan_exps:
+            lines.append(_exp_line(exp, 0))
+        lines.append("")
+
+    # Findings
+    if findings:
+        lines.append(f"## Findings ({len(findings)})")
+        for f in findings:
+            topic = f.get("topic") or f["id"]
+            lines.append(f"- {f['id']}: {topic} [{f.get('confidence', '')}]")
+        lines.append("")
+
+    # Questions
+    if questions:
+        lines.append(f"## Questions ({len(questions)})")
+        for q in questions:
+            question = q.get("question") or q["id"]
+            lines.append(f"- {q['id']}: {question} [{q.get('status', '')}]")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Pull/sync writes records into nested `project → direction → experiment` directories** instead of flat `experiments/`, `directions/` dirs. Agents can now `grep -r` a subtree and navigate the research hierarchy by walking directories.
- **Fixes silent frontmatter data loss**: `project_id`, `parent_direction_id`, `spawned_from_experiment_id` were missing from `_FRONTMATTER_KEYS` — hierarchy metadata was dropped on pull.
- **Push discovers records recursively** across flat and nested layouts with dedup, so both old and new layouts work.
- **Generates `tree.md`** on pull/sync — a quick index of the full research hierarchy for agent consumption.

### Directory structure after `sonde pull`

```
.sonde/
├── projects/
│   └── PROJ-001/
│       ├── project.md
│       ├── DIR-001/
│       │   ├── direction.md
│       │   ├── EXP-001.md
│       │   └── EXP-001/          (artifacts)
│       └── DIR-002/              (sub-direction)
│           ├── direction.md
│           └── EXP-003.md
├── directions/                   (orphan: no project)
│   └── DIR-003/
│       └── direction.md
├── experiments/                  (orphan: no project or direction)
│   └── EXP-006.md
├── findings/                     (flat)
├── questions/                    (flat)
├── tree.md                       (auto-generated)
└── ...
```

Closes #48, related to #14

## Test plan

- [x] `ruff check` + `ruff format` — clean
- [x] CLI tests: 509 passed, 0 failed
- [x] UI: tsc, eslint, vitest — all clean (52 tests passed)
- [ ] Manual: `sonde pull -p <program>` → verify nested dirs + tree.md
- [ ] Manual: `sonde push` → verify records found in nested paths
- [ ] Manual: `sonde push experiment EXP-xxx` → single record in nested path

🤖 Generated with [Claude Code](https://claude.com/claude-code)