### PR TITLE
Add question entry points throughout the research workflow

### DIFF
--- a/.claude/skills/sonde-research.md
+++ b/.claude/skills/sonde-research.md
@@ -146,6 +146,24 @@ sonde fork EXP-0001 --env CUDA_VERSION=12.0
 - When the user says "log this", "record this", "save this experiment"
 - When you've helped design and run an experiment to completion
 
+### Raising questions while logging
+
+If results are **inconclusive**, **surprising**, or suggest a follow-up investigation,
+raise a question at the same time you log the experiment:
+
+```bash
+# Raise a question as a side-effect of logging
+sonde log -p <program> "Ran CCN sweep ..." --question "Does saturation shift with humidity?"
+
+# Or raise separately after logging
+sonde question create -p <program> "What explains the anomalous LWC spike at CCN=800?"
+```
+
+Use `--question` whenever:
+- Results don't match the hypothesis
+- You see an unexpected pattern that warrants follow-up
+- You closed an experiment and immediately thought "but what about...?"
+
 ---
 
 ## What makes a good experiment

--- a/cli/src/sonde/commands/brief_render.py
+++ b/cli/src/sonde/commands/brief_render.py
@@ -264,7 +264,10 @@ def render_human(
             title="Open Questions",
         )
     else:
-        err.print("\n[sonde.muted]No open questions. Use [dim]sonde question create[/] to capture unknowns.[/]")
+        err.print(
+            "\n[sonde.muted]No open questions. "
+            "Use [dim]sonde question create[/] to capture unknowns.[/]"
+        )
 
     # Coverage — active branch first if available
     if data.get("coverage_active"):

--- a/cli/src/sonde/commands/brief_render.py
+++ b/cli/src/sonde/commands/brief_render.py
@@ -263,6 +263,8 @@ def render_human(
             ],
             title="Open Questions",
         )
+    else:
+        err.print("\n[sonde.muted]No open questions. Use [dim]sonde question create[/] to capture unknowns.[/]")
 
     # Coverage — active branch first if available
     if data.get("coverage_active"):
@@ -502,6 +504,10 @@ def render_markdown(data: dict) -> str:
         lines.append("## Open questions\n")
         for q in data["open_questions"]:
             lines.append(f"- **{q['id']}** {q['question']}")
+        lines.append("")
+    else:
+        lines.append("## Open questions\n")
+        lines.append("No open questions. Use `sonde question create` to capture unknowns.")
         lines.append("")
 
     if data.get("coverage_active"):

--- a/cli/src/sonde/commands/log.py
+++ b/cli/src/sonde/commands/log.py
@@ -75,6 +75,7 @@ def _inherit_project(direction_id: str | None) -> str | None:
 @click.option("--status", default="complete", type=click.Choice(["open", "running", "complete"]))
 @click.option("--quick", is_flag=True, help="Minimal record — just params + result")
 @click.option("--open", "open_exp", is_flag=True, help="Log as open/backlog (not yet run)")
+@click.option("--question", "question_text", help="Raise a question linked to this experiment")
 @structured_metadata_options
 @pass_output_options
 @click.pass_context
@@ -99,6 +100,7 @@ def log(
     status: str,
     quick: bool,
     open_exp: bool,
+    question_text: str | None,
     repro: str | None,
     evidence: tuple[str, ...],
     env_vars: tuple[str, ...],
@@ -132,6 +134,9 @@ def log(
 
       # Open an experiment (backlog item)
       sonde log --open -p weather-intervention "Test combined BL heating + seeding"
+
+      # Raise a question alongside the experiment
+      sonde log -p weather-intervention "Ran CCN sweep" --question "Does saturation shift with humidity?"
     """
     settings = get_settings()
 
@@ -274,3 +279,22 @@ def log(
                 "Attach to a research direction:",
                 f"sonde update {exp.id} --direction DIR-XXX",
             )
+
+    # Create linked question if --question was provided
+    if question_text:
+        from sonde.db import questions as q_db
+        from sonde.models.question import QuestionCreate
+
+        q_data = QuestionCreate(
+            program=resolved_program,
+            question=question_text,
+            context=f"Raised while logging {exp.id}",
+            source=resolved_source,
+        )
+        q_record = q_db.create(q_data)
+        from sonde.db.activity import log_activity as _log_q_activity
+
+        _log_q_activity(q_record.id, "question", "created")
+        if not ctx.obj.get("json"):
+            err.print(f"\n  Question logged: {q_record.id}")
+            err.print(f"  View: sonde question show {q_record.id}")

--- a/cli/src/sonde/commands/log.py
+++ b/cli/src/sonde/commands/log.py
@@ -136,7 +136,8 @@ def log(
       sonde log --open -p weather-intervention "Test combined BL heating + seeding"
 
       # Raise a question alongside the experiment
-      sonde log -p weather-intervention "Ran CCN sweep" --question "Does saturation shift with humidity?"
+      sonde log -p weather-intervention "Ran CCN sweep" \
+        --question "Does saturation shift with humidity?"
     """
     settings = get_settings()
 

--- a/cli/src/sonde/data/skills/sonde-research.md
+++ b/cli/src/sonde/data/skills/sonde-research.md
@@ -146,6 +146,24 @@ sonde fork EXP-0001 --env CUDA_VERSION=12.0
 - When the user says "log this", "record this", "save this experiment"
 - When you've helped design and run an experiment to completion
 
+### Raising questions while logging
+
+If results are **inconclusive**, **surprising**, or suggest a follow-up investigation,
+raise a question at the same time you log the experiment:
+
+```bash
+# Raise a question as a side-effect of logging
+sonde log -p <program> "Ran CCN sweep ..." --question "Does saturation shift with humidity?"
+
+# Or raise separately after logging
+sonde question create -p <program> "What explains the anomalous LWC spike at CCN=800?"
+```
+
+Use `--question` whenever:
+- Results don't match the hypothesis
+- You see an unexpected pattern that warrants follow-up
+- You closed an experiment and immediately thought "but what about...?"
+
 ---
 
 ## What makes a good experiment

--- a/ui/src/components/layout/sidebar.tsx
+++ b/ui/src/components/layout/sidebar.tsx
@@ -35,6 +35,7 @@ const navPrimitives = [
   { to: "/directions", label: "Directions", icon: Compass },
   { to: "/experiments", label: "Experiments", icon: FlaskConical },
   { to: "/findings", label: "Findings", icon: Lightbulb },
+  { to: "/questions", label: "Questions", icon: MessageCircleQuestion },
 ] as const;
 
 /** Graph / structure views */
@@ -44,7 +45,6 @@ const navGraph = [
 ] as const;
 
 const navInboxActivity = [
-  { to: "/questions", label: "Inbox", icon: MessageCircleQuestion },
   { to: "/activity", label: "Activity", icon: Activity },
 ] as const;
 


### PR DESCRIPTION
## Summary

Closes #68

The Questions feature was fully implemented but had no natural entry points in the research workflow, resulting in `question_count: 0` even after full extraction projects.

- **`sonde log --question "..."`** — raises a question as a side-effect of logging, linked to the experiment via context. Shown as `Question logged: Q-XXX` in the output.
- **`sonde-research` skill** — new "Raising questions while logging" subsection instructs agents to use `--question` when results are inconclusive, surprising, or suggest follow-up. Both the `cli/src/sonde/data/skills/` and `.claude/skills/` copies updated.
- **Brief empty-state hint** — both human (`render_human`) and markdown (`render_markdown`) output now show `No open questions. Use sonde question create to capture unknowns.` when the questions list is empty.

## Test plan

- [ ] `sonde log -p <program> "..." --question "Why did X happen?"` creates both an experiment and a linked question
- [ ] `sonde brief -p <program>` shows the empty-state hint when there are no questions
- [ ] `sonde brief -p <program>` (markdown mode) includes the hint in the `## Open questions` section
- [ ] `sonde brief -p <program>` with questions present shows the table as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)