### PR TITLE
Harden hosted audit and chat smoke readiness

### DIFF
--- a/.github/workflows/cli-hosted-audit.yml
+++ b/.github/workflows/cli-hosted-audit.yml
@@ -59,6 +59,8 @@ jobs:
           CLI_AUDIT_ALLOW_WRITE: "1"
           CLI_AUDIT_PROGRAM: shared
           CLI_AUDIT_EXPECT_EXPERIMENT_ID: EXP-9001
+          CLI_AUDIT_WAIT_TIMEOUT_MS: "600000"
+          CLI_AUDIT_WAIT_INTERVAL_MS: "10000"
         run: node scripts/run-cli-hosted-audit.mjs
 
   production-cli-audit:
@@ -100,4 +102,6 @@ jobs:
           CLI_AUDIT_ENV: production
           CLI_AUDIT_PROGRAM: shared
           CLI_AUDIT_EXPECT_EXPERIMENT_ID: EXP-0128
+          CLI_AUDIT_WAIT_TIMEOUT_MS: "600000"
+          CLI_AUDIT_WAIT_INTERVAL_MS: "10000"
         run: node scripts/run-cli-hosted-audit.mjs

--- a/.github/workflows/smoke-production.yml
+++ b/.github/workflows/smoke-production.yml
@@ -155,6 +155,7 @@ jobs:
         env:
           CHAT_PREWARM_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
           CHAT_PREWARM_TIMEOUT_MS: "300000"
+          CHAT_PREWARM_RETRY_INTERVAL_MS: "10000"
           CHAT_SMOKE_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
           CHAT_SMOKE_PROMPT: "Use Sonde tools to list one accessible program id, then reply with SONDE_SMOKE_OK."
           CHAT_SMOKE_STALE_SESSION: "1"

--- a/.github/workflows/smoke-staging.yml
+++ b/.github/workflows/smoke-staging.yml
@@ -147,6 +147,7 @@ jobs:
         env:
           CHAT_PREWARM_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
           CHAT_PREWARM_TIMEOUT_MS: "300000"
+          CHAT_PREWARM_RETRY_INTERVAL_MS: "10000"
           CHAT_SMOKE_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
           CHAT_SMOKE_PROMPT: "Use Sonde tools to list one accessible program id, then reply with SONDE_SMOKE_OK."
           CHAT_SMOKE_STALE_SESSION: "1"

--- a/server/scripts/prewarm-chat-session.mjs
+++ b/server/scripts/prewarm-chat-session.mjs
@@ -11,31 +11,74 @@ function parsePositiveInt(value, fallback) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function isRetryablePrewarmFailure(status, bodyText) {
+  if ([502, 503, 504].includes(status)) {
+    return true;
+  }
+  return /chat sandbox is not ready/i.test(bodyText);
+}
+
 async function main() {
   const httpBase = requiredEnv("CHAT_PREWARM_HTTP_BASE").replace(/\/$/, "");
   const token = requiredEnv("CHAT_PREWARM_TOKEN");
   const timeoutMs = parsePositiveInt(process.env.CHAT_PREWARM_TIMEOUT_MS, 300_000);
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const retryIntervalMs = parsePositiveInt(
+    process.env.CHAT_PREWARM_RETRY_INTERVAL_MS,
+    10_000
+  );
+  const deadline = Date.now() + timeoutMs;
 
-  try {
-    console.log(`[chat-prewarm] Prewarming via ${httpBase}/chat/prewarm`);
-    const response = await fetch(`${httpBase}/chat/prewarm`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      signal: controller.signal,
-    });
-    const bodyText = await response.text();
-    if (!response.ok) {
-      throw new Error(
-        `Prewarm request failed (${response.status}): ${bodyText.slice(0, 240)}`
-      );
+  while (true) {
+    const controller = new AbortController();
+    const remainingMs = Math.max(1_000, deadline - Date.now());
+    const timer = setTimeout(
+      () => controller.abort(),
+      Math.min(remainingMs, retryIntervalMs)
+    );
+
+    try {
+      console.log(`[chat-prewarm] Prewarming via ${httpBase}/chat/prewarm`);
+      const response = await fetch(`${httpBase}/chat/prewarm`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        signal: controller.signal,
+      });
+      const bodyText = await response.text();
+      if (!response.ok) {
+        const message = `Prewarm request failed (${response.status}): ${bodyText.slice(0, 240)}`;
+        if (Date.now() < deadline && isRetryablePrewarmFailure(response.status, bodyText)) {
+          console.log(`[chat-prewarm] Waiting for chat readiness: ${message}`);
+          await sleep(retryIntervalMs);
+          continue;
+        }
+        throw new Error(message);
+      }
+      console.log(`[chat-prewarm] Success ${bodyText}`);
+      return;
+    } catch (error) {
+      if (Date.now() >= deadline) {
+        throw error;
+      }
+      if (
+        error instanceof Error &&
+        (error.name === "AbortError" || /fetch failed/i.test(error.message))
+      ) {
+        console.log(`[chat-prewarm] Waiting for chat readiness: ${error.message}`);
+        await sleep(retryIntervalMs);
+        continue;
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
     }
-    console.log(`[chat-prewarm] Success ${bodyText}`);
-  } finally {
-    clearTimeout(timer);
   }
 }
 

--- a/server/scripts/run-cli-hosted-audit.mjs
+++ b/server/scripts/run-cli-hosted-audit.mjs
@@ -28,12 +28,53 @@ async function requestJson(url, init) {
   return body;
 }
 
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function decodeExecOutput(value) {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString("utf-8");
+  }
+  return "";
+}
+
+function buildCliFailureMessage(command, args, error) {
+  const stderr = decodeExecOutput(error?.stderr).trim();
+  const stdout = decodeExecOutput(error?.stdout).trim();
+  const details = [stderr, stdout].filter(Boolean).join("\n");
+  const fallback = error instanceof Error ? error.message : String(error);
+  const suffix = details || fallback;
+  return `${command} ${args.join(" ")} failed: ${suffix}`;
+}
+
+function isRetryableCliReadinessError(message) {
+  return (
+    /Remote schema version .*< required/.test(message) ||
+    /needs a migration update/i.test(message)
+  );
+}
+
 function runCli(command, args, env) {
-  return execFileSync(command, args, {
-    encoding: "utf-8",
-    env,
-    stdio: ["ignore", "pipe", "inherit"],
-  }).trim();
+  try {
+    return execFileSync(command, args, {
+      encoding: "utf-8",
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    throw new Error(buildCliFailureMessage(command, args, error));
+  }
 }
 
 function parseJsonOutput(raw, label) {
@@ -41,6 +82,34 @@ function parseJsonOutput(raw, label) {
     return JSON.parse(raw);
   } catch (error) {
     throw new Error(`Failed to parse ${label} JSON output: ${error.message}`);
+  }
+}
+
+async function waitForCliReadiness({
+  command,
+  args,
+  env,
+  timeoutMs,
+  intervalMs,
+}) {
+  if (timeoutMs <= 0) {
+    return;
+  }
+
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    try {
+      runCli(command, args, env);
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!isRetryableCliReadinessError(message) || Date.now() >= deadline) {
+        throw error;
+      }
+      console.log(`[run-cli-hosted-audit] Waiting for hosted CLI readiness: ${message}`);
+      await sleep(intervalMs);
+    }
   }
 }
 
@@ -67,6 +136,8 @@ async function main() {
   const expectedExperimentId = process.env.CLI_AUDIT_EXPECT_EXPERIMENT_ID?.trim() || "";
   const allowWrite = (process.env.CLI_AUDIT_ALLOW_WRITE ?? "") === "1";
   const sondeExecutable = process.env.CLI_AUDIT_SONDE_BIN?.trim() || "sonde";
+  const waitTimeoutMs = parsePositiveInt(process.env.CLI_AUDIT_WAIT_TIMEOUT_MS, 0);
+  const waitIntervalMs = parsePositiveInt(process.env.CLI_AUDIT_WAIT_INTERVAL_MS, 10_000);
 
   const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "sonde-cli-audit-"));
   fs.chmodSync(configDir, 0o700);
@@ -94,6 +165,14 @@ async function main() {
       { mode: 0o600 }
     );
   }
+
+  await waitForCliReadiness({
+    command: sondeExecutable,
+    args: ["program", "list", "--json"],
+    env: cliEnv,
+    timeoutMs: waitTimeoutMs,
+    intervalMs: waitIntervalMs,
+  });
 
   const whoami = parseJsonOutput(
     runCli(sondeExecutable, ["whoami", "--json"], cliEnv),


### PR DESCRIPTION
## Summary
- wait for hosted CLI readiness before running the staged/production CLI audit
- retry chat prewarm during sandbox warmup instead of failing on transient 5xx readiness responses
- wire the new wait/retry controls into the audit and smoke workflows

## Testing
- node --check server/scripts/run-cli-hosted-audit.mjs
- node --check server/scripts/prewarm-chat-session.mjs
- npm --prefix server test
- npm --prefix server run build
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cli-hosted-audit.yml"); YAML.load_file(".github/workflows/smoke-production.yml"); YAML.load_file(".github/workflows/smoke-staging.yml")'\n- git diff --check