### PR TITLE
Use repo schema version in hosted audits

### DIFF
--- a/.github/workflows/config-audit.yml
+++ b/.github/workflows/config-audit.yml
@@ -73,18 +73,20 @@ jobs:
               ;;
           esac
 
-      - name: Resolve staging schema version
+      - name: Resolve expected staging schema version
         id: schema
         run: |
-          if VERSION=$(curl -sf \
-            -H "apikey: ${{ vars.SUPABASE_STAGING_ANON_KEY }}" \
-            -H "Authorization: Bearer ${{ vars.SUPABASE_STAGING_ANON_KEY }}" \
-            "https://${{ vars.SUPABASE_STAGING_PROJECT_REF }}.supabase.co/rest/v1/rpc/get_schema_version" | tr -d '"'); then
-            :
-          else
-            echo "::notice::Falling back to unknown schema version because staging publishable-key RPC verification is unavailable"
-            VERSION="unknown"
-          fi
+          VERSION="$(node - <<'NODE'
+          const fs = require("node:fs");
+          const text = fs.readFileSync("cli/src/sonde/db/compat.py", "utf8");
+          const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
+          if (!match) {
+            console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");
+            process.exit(1);
+          }
+          process.stdout.write(match[1]);
+          NODE
+          )"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Wait for staging UI and agent
@@ -171,18 +173,20 @@ jobs:
               ;;
           esac
 
-      - name: Resolve production schema version
+      - name: Resolve expected production schema version
         id: schema
         run: |
-          if VERSION=$(curl -sf \
-            -H "apikey: ${{ vars.SUPABASE_ANON_KEY }}" \
-            -H "Authorization: Bearer ${{ vars.SUPABASE_ANON_KEY }}" \
-            "https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co/rest/v1/rpc/get_schema_version" | tr -d '"'); then
-            :
-          else
-            echo "::notice::Falling back to unknown schema version because production publishable-key RPC verification is unavailable"
-            VERSION="unknown"
-          fi
+          VERSION="$(node - <<'NODE'
+          const fs = require("node:fs");
+          const text = fs.readFileSync("cli/src/sonde/db/compat.py", "utf8");
+          const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
+          if (!match) {
+            console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");
+            process.exit(1);
+          }
+          process.stdout.write(match[1]);
+          NODE
+          )"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Wait for production UI and agent

--- a/.github/workflows/smoke-production.yml
+++ b/.github/workflows/smoke-production.yml
@@ -67,26 +67,20 @@ jobs:
             echo "Smoke testing agent: $AGENT_URL"
           fi
 
-      - name: Resolve production schema version
+      - name: Resolve expected production schema version
         id: schema
-        env:
-          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-          SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY }}
         run: |
-          if [ -z "$SUPABASE_PROJECT_REF" ] || [ -z "$SUPABASE_ANON_KEY" ]; then
-            echo "::notice::Skipping production schema lookup because SUPABASE_PROJECT_REF or SUPABASE_ANON_KEY is not configured"
-            echo "version=unknown" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if VERSION=$(curl -sf \
-            -H "apikey: $SUPABASE_ANON_KEY" \
-            -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
-            "https://${SUPABASE_PROJECT_REF}.supabase.co/rest/v1/rpc/get_schema_version" | tr -d '"'); then
-            :
-          else
-            echo "::notice::Falling back to unknown schema version because production publishable-key RPC verification is unavailable"
-            VERSION="unknown"
-          fi
+          VERSION="$(node - <<'NODE'
+          const fs = require("node:fs");
+          const text = fs.readFileSync("cli/src/sonde/db/compat.py", "utf8");
+          const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
+          if (!match) {
+            console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");
+            process.exit(1);
+          }
+          process.stdout.write(match[1]);
+          NODE
+          )"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Wait for production UI

--- a/.github/workflows/smoke-staging.yml
+++ b/.github/workflows/smoke-staging.yml
@@ -66,19 +66,20 @@ jobs:
             echo "Smoke testing agent: $AGENT_URL"
           fi
 
-      - name: Resolve staging schema version
+      - name: Resolve expected staging schema version
         id: schema
-        if: ${{ vars.SUPABASE_STAGING_PROJECT_REF != '' && vars.SUPABASE_STAGING_ANON_KEY != '' }}
         run: |
-          if VERSION=$(curl -sf \
-            -H "apikey: ${{ vars.SUPABASE_STAGING_ANON_KEY }}" \
-            -H "Authorization: Bearer ${{ vars.SUPABASE_STAGING_ANON_KEY }}" \
-            "https://${{ vars.SUPABASE_STAGING_PROJECT_REF }}.supabase.co/rest/v1/rpc/get_schema_version" | tr -d '"'); then
-            :
-          else
-            echo "::notice::Falling back to unknown schema version because staging publishable-key RPC verification is unavailable"
-            VERSION="unknown"
-          fi
+          VERSION="$(node - <<'NODE'
+          const fs = require("node:fs");
+          const text = fs.readFileSync("cli/src/sonde/db/compat.py", "utf8");
+          const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
+          if (!match) {
+            console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");
+            process.exit(1);
+          }
+          process.stdout.write(match[1]);
+          NODE
+          )"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Wait for staging UI


### PR DESCRIPTION
## Summary
- resolve expected schema version for smoke/config audits from the repo's CLI compatibility constant
- stop snapshotting the hosted database schema too early during deploy/promotion
- keep the runtime audits strict while avoiding false negatives during migration rollout

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/config-audit.yml"); YAML.load_file(".github/workflows/smoke-production.yml"); YAML.load_file(".github/workflows/smoke-staging.yml")'\n- VERSION="$(node - <<'NODE'\nconst fs = require("node:fs");\nconst text = fs.readFileSync("cli/src/sonde/db/compat.py", "utf8");\nconst match = text.match(/MINIMUM_SCHEMA_VERSION = (\\d+)/);\nif (!match) process.exit(1);\nprocess.stdout.write(match[1]);\nNODE\n)"\n- git diff --check