### PR TITLE
Fix smoke schema version lookup paths

### DIFF
--- a/.github/workflows/smoke-production.yml
+++ b/.github/workflows/smoke-production.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           VERSION="$(node - <<'NODE'
           const fs = require("node:fs");
-          const text = fs.readFileSync("cli/src/sonde/db/compat.py", "utf8");
+          const text = fs.readFileSync("../cli/src/sonde/db/compat.py", "utf8");
           const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
           if (!match) {
             console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");

--- a/.github/workflows/smoke-staging.yml
+++ b/.github/workflows/smoke-staging.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           VERSION="$(node - <<'NODE'
           const fs = require("node:fs");
-          const text = fs.readFileSync("cli/src/sonde/db/compat.py", "utf8");
+          const text = fs.readFileSync("../cli/src/sonde/db/compat.py", "utf8");
           const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
           if (!match) {
             console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");


### PR DESCRIPTION
## Summary
- read the CLI schema compatibility file from the smoke workflows' actual `ui/` working directory
- keep the schema-version source-of-truth fix from #106 intact
- unblock staging smoke so the final promotion can proceed

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/smoke-production.yml"); YAML.load_file(".github/workflows/smoke-staging.yml")'\n- cd ui && VERSION="$(node - <<'NODE'\nconst fs = require("node:fs");\nconst text = fs.readFileSync("../cli/src/sonde/db/compat.py", "utf8");\nconst match = text.match(/MINIMUM_SCHEMA_VERSION = (\\d+)/);\nif (!match) process.exit(1);\nprocess.stdout.write(match[1]);\nNODE\n)"\n- git diff --check