### PR TITLE
[codex] Pin hosted deploys to managed backend

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -222,6 +222,7 @@ jobs:
             --skip-deploys \
             VITE_SUPABASE_URL="https://${{ vars.SUPABASE_STAGING_PROJECT_REF }}.supabase.co" \
             VITE_SUPABASE_ANON_KEY="${{ vars.SUPABASE_STAGING_ANON_KEY }}" \
+            SONDE_AGENT_BACKEND="managed" \
             SONDE_ALLOWED_ORIGINS="${{ vars.SONDE_STAGING_UI_URL }}" \
             SONDE_ENVIRONMENT="staging" \
             SONDE_COMMIT_SHA="${GITHUB_SHA}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,6 +183,7 @@ jobs:
             --skip-deploys \
             VITE_SUPABASE_URL="https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co" \
             VITE_SUPABASE_ANON_KEY="${{ vars.SUPABASE_ANON_KEY }}" \
+            SONDE_AGENT_BACKEND="managed" \
             SONDE_ALLOWED_ORIGINS="${{ vars.SONDE_UI_URL }}" \
             SONDE_ENVIRONMENT="production" \
             SONDE_COMMIT_SHA="${GITHUB_SHA}" \

--- a/server/example.env
+++ b/server/example.env
@@ -33,15 +33,12 @@ VITE_SUPABASE_ANON_KEY=
 # UPSTASH_REDIS_REST_URL=https://your-instance.upstash.io
 # UPSTASH_REDIS_REST_TOKEN=replace-me
 
-# Hosted agent mode. Use `sandbox` when Daytona is configured.
-# SONDE_AGENT_BACKEND=sandbox
+# Hosted agent mode. Managed agents are the only supported backend.
+# SONDE_AGENT_BACKEND=managed
 
-# Optional explicit git ref for sandbox CLI install. Falls back to SONDE_COMMIT_SHA.
+# Optional explicit git ref for hosted CLI install. Falls back to SONDE_COMMIT_SHA.
 # SONDE_CLI_GIT_REF=main
 # SONDE_COMMIT_SHA=abc123def456
-
-# Required for sandbox mode.
-# DAYTONA_API_KEY=
 
 # Override auto-detection (repo ../cli from server/) when deploying elsewhere:
 # SONDE_CLI_DIR=/absolute/path/to/sonde/cli


### PR DESCRIPTION
## Summary
- pin staging and production Railway deploys to 
- refresh the hosted example env to match the managed-only runtime
- prevent stale legacy Daytona/direct backend values from crashing hosted deploys

## Testing
- npm --prefix server test
- npm --prefix server run build
- git diff --check