### PR TITLE
[codex] Pin hosted managed environment for deploys

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -210,11 +210,16 @@ jobs:
       - name: Pin deployed commit metadata
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_STAGING_PROJECT_TOKEN }}
+          SONDE_MANAGED_ENVIRONMENT_ID: ${{ vars.SONDE_ANTHROPIC_MANAGED_ENVIRONMENT_ID }}
           SONDE_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
           SONDE_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN }}
           SONDE_WS_TOKEN_SECRET: ${{ secrets.SONDE_STAGING_WS_TOKEN_SECRET }}
           SONDE_GITHUB_ALLOWED_REPOS: ${{ vars.SONDE_GITHUB_ALLOWED_REPOS }}
         run: |
+          if [ -z "$SONDE_MANAGED_ENVIRONMENT_ID" ]; then
+            echo "::error::Missing SONDE_ANTHROPIC_MANAGED_ENVIRONMENT_ID repository variable"
+            exit 1
+          fi
           SCHEMA_VERSION="${SONDE_SCHEMA_VERSION:-unknown}"
           railway variable set \
             -s "${{ vars.RAILWAY_STAGING_SERVICE_NAME }}" \
@@ -223,6 +228,9 @@ jobs:
             VITE_SUPABASE_URL="https://${{ vars.SUPABASE_STAGING_PROJECT_REF }}.supabase.co" \
             VITE_SUPABASE_ANON_KEY="${{ vars.SUPABASE_STAGING_ANON_KEY }}" \
             SONDE_AGENT_BACKEND="managed" \
+            SONDE_MANAGED_ENVIRONMENT_ID="${SONDE_MANAGED_ENVIRONMENT_ID}" \
+            SONDE_MANAGED_AGENT_ID="" \
+            SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT="1" \
             SONDE_ALLOWED_ORIGINS="${{ vars.SONDE_STAGING_UI_URL }}" \
             SONDE_ENVIRONMENT="staging" \
             SONDE_COMMIT_SHA="${GITHUB_SHA}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,11 +171,16 @@ jobs:
       - name: Pin deployed commit metadata
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_PROJECT_TOKEN }}
+          SONDE_MANAGED_ENVIRONMENT_ID: ${{ vars.SONDE_ANTHROPIC_MANAGED_ENVIRONMENT_ID }}
           SONDE_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
           SONDE_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN }}
           SONDE_WS_TOKEN_SECRET: ${{ secrets.SONDE_PRODUCTION_WS_TOKEN_SECRET }}
           SONDE_GITHUB_ALLOWED_REPOS: ${{ vars.SONDE_GITHUB_ALLOWED_REPOS }}
         run: |
+          if [ -z "$SONDE_MANAGED_ENVIRONMENT_ID" ]; then
+            echo "::error::Missing SONDE_ANTHROPIC_MANAGED_ENVIRONMENT_ID repository variable"
+            exit 1
+          fi
           SCHEMA_VERSION="${SONDE_SCHEMA_VERSION:-unknown}"
           railway variable set \
             -s "${{ vars.RAILWAY_PRODUCTION_SERVICE_NAME }}" \
@@ -184,6 +189,9 @@ jobs:
             VITE_SUPABASE_URL="https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co" \
             VITE_SUPABASE_ANON_KEY="${{ vars.SUPABASE_ANON_KEY }}" \
             SONDE_AGENT_BACKEND="managed" \
+            SONDE_MANAGED_ENVIRONMENT_ID="${SONDE_MANAGED_ENVIRONMENT_ID}" \
+            SONDE_MANAGED_AGENT_ID="" \
+            SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT="1" \
             SONDE_ALLOWED_ORIGINS="${{ vars.SONDE_UI_URL }}" \
             SONDE_ENVIRONMENT="production" \
             SONDE_COMMIT_SHA="${GITHUB_SHA}" \


### PR DESCRIPTION
## Summary
- pin hosted deploys to a known Anthropic managed environment
- force hosted deploys onto ephemeral managed agents instead of stale pinned agent ids
- make staging and production deploys fail fast if the managed environment variable is missing

## Testing
- git diff --check
- verified SONDE_ANTHROPIC_MANAGED_ENVIRONMENT_ID repo variable is set