### PR TITLE
[codex] Delete stale managed agent pin in deploy workflows

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -221,6 +221,10 @@ jobs:
             exit 1
           fi
           SCHEMA_VERSION="${SONDE_SCHEMA_VERSION:-unknown}"
+          railway variable delete \
+            -s "${{ vars.RAILWAY_STAGING_SERVICE_NAME }}" \
+            -e production \
+            SONDE_MANAGED_AGENT_ID || true
           railway variable set \
             -s "${{ vars.RAILWAY_STAGING_SERVICE_NAME }}" \
             -e production \
@@ -229,7 +233,6 @@ jobs:
             VITE_SUPABASE_ANON_KEY="${{ vars.SUPABASE_STAGING_ANON_KEY }}" \
             SONDE_AGENT_BACKEND="managed" \
             SONDE_MANAGED_ENVIRONMENT_ID="${SONDE_MANAGED_ENVIRONMENT_ID}" \
-            SONDE_MANAGED_AGENT_ID="" \
             SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT="1" \
             SONDE_ALLOWED_ORIGINS="${{ vars.SONDE_STAGING_UI_URL }}" \
             SONDE_ENVIRONMENT="staging" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,6 +182,10 @@ jobs:
             exit 1
           fi
           SCHEMA_VERSION="${SONDE_SCHEMA_VERSION:-unknown}"
+          railway variable delete \
+            -s "${{ vars.RAILWAY_PRODUCTION_SERVICE_NAME }}" \
+            -e production \
+            SONDE_MANAGED_AGENT_ID || true
           railway variable set \
             -s "${{ vars.RAILWAY_PRODUCTION_SERVICE_NAME }}" \
             -e production \
@@ -190,7 +194,6 @@ jobs:
             VITE_SUPABASE_ANON_KEY="${{ vars.SUPABASE_ANON_KEY }}" \
             SONDE_AGENT_BACKEND="managed" \
             SONDE_MANAGED_ENVIRONMENT_ID="${SONDE_MANAGED_ENVIRONMENT_ID}" \
-            SONDE_MANAGED_AGENT_ID="" \
             SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT="1" \
             SONDE_ALLOWED_ORIGINS="${{ vars.SONDE_UI_URL }}" \
             SONDE_ENVIRONMENT="production" \


### PR DESCRIPTION
## Summary
- delete the legacy `SONDE_MANAGED_AGENT_ID` Railway variable before setting managed deploy metadata
- stop sending an empty `SONDE_MANAGED_AGENT_ID` assignment that Railway rejects
- keep staging and production deploy workflows aligned for managed-agent hosting

## Testing
- git diff --check
- verified `railway variable delete --help` and patched workflows accordingly