### PR TITLE
[codex] Recover stale managed chat sessions

### DIFF
--- a/server/src/managed-chat.test.ts
+++ b/server/src/managed-chat.test.ts
@@ -14,6 +14,7 @@ interface ManagedMockScenario {
   sessionId: string;
   streamBodies: string[];
   eventLists?: Array<Array<Record<string, unknown>>>;
+  invalidSessionIds?: string[];
   onEvents?: (events: Array<Record<string, unknown>>) => void;
   onEventPost?: (events: Array<Record<string, unknown>>) => Response | null | undefined;
 }
@@ -34,6 +35,7 @@ function sseBody(events: Array<Record<string, unknown> | "[DONE]">): string {
 function createManagedMockFetch(scenario: ManagedMockScenario) {
   let nextStreamIndex = 0;
   let nextEventListIndex = 0;
+  const invalidSessionIds = new Set(scenario.invalidSessionIds ?? []);
   return async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const url = typeof input === "string"
       ? new URL(input)
@@ -47,6 +49,23 @@ function createManagedMockFetch(scenario: ManagedMockScenario) {
 
     if (url.pathname === "/v1/sessions") {
       return jsonResponse({ id: scenario.sessionId });
+    }
+
+    const sessionMatch = url.pathname.match(/^\/v1\/sessions\/([^/]+)\/(events|stream)$/);
+    if (sessionMatch && invalidSessionIds.has(sessionMatch[1] ?? "")) {
+      return new Response(
+        JSON.stringify({
+          type: "error",
+          error: {
+            type: "invalid_request_error",
+            message: `Invalid session ID: ${sessionMatch[1]}`,
+          },
+        }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }
+      );
     }
 
     if (
@@ -1220,5 +1239,89 @@ describe("managed chat websocket", () => {
       ),
       false
     );
+  });
+
+  it("replaces a stale requested session id with a fresh managed session", async () => {
+    const sessionId = "sesn_test_fresh_after_stale";
+    globalThis.fetch = createManagedMockFetch({
+      sessionId,
+      invalidSessionIds: ["deadbeef-dead-beef-dead-beefdeadbeef"],
+      streamBodies: [
+        sseBody([
+          {
+            id: "msg-fresh-final",
+            type: "agent.message",
+            content: [{ type: "text", text: "Fresh session recovered." }],
+          },
+          {
+            id: "idle-fresh-final",
+            type: "session.status_idle",
+            stop_reason: { type: "end_turn" },
+          },
+          "[DONE]",
+        ]),
+      ],
+    });
+
+    const server = createWebSocketServer();
+    await once(server, "listening");
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+
+    const messages: Array<Record<string, unknown>> = [];
+    await new Promise<void>((resolve, reject) => {
+      const wsToken = issueWsSessionToken("playwright-smoke-token", {
+        id: "e2e-user",
+        email: "ci-smoke@aeolus.earth",
+        name: "CI Smoke",
+      });
+      const ws = new WebSocket(
+        `ws://127.0.0.1:${address.port}/chat?ws_token=${encodeURIComponent(wsToken)}`
+      );
+      const timeout = setTimeout(() => {
+        ws.close();
+        reject(new Error("Timed out waiting for managed stale-session recovery"));
+      }, 10_000);
+
+      ws.on("open", () => {
+        ws.send(
+          JSON.stringify({
+            type: "message",
+            content: "Say hello briefly.",
+            sessionId: "deadbeef-dead-beef-dead-beefdeadbeef",
+          })
+        );
+      });
+
+      ws.on("message", (data) => {
+        const message = JSON.parse(String(data)) as Record<string, unknown>;
+        messages.push(message);
+        if (message.type === "done") {
+          clearTimeout(timeout);
+          ws.close();
+          resolve();
+        }
+      });
+
+      ws.on("error", (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+    }).finally(() => {
+      server.close();
+    });
+
+    const errors = messages
+      .filter((message) => message.type === "error")
+      .map((message) => String(message.message ?? ""));
+    assert.equal(errors.length, 0);
+
+    const sessionEvent = messages.find((message) => message.type === "session");
+    assert.ok(sessionEvent);
+    assert.equal(sessionEvent.sessionId, sessionId);
+
+    const finalText = messages.find((message) => message.type === "text_done");
+    assert.ok(finalText);
+    assert.equal(finalText.content, "Fresh session recovered.");
   });
 });

--- a/server/src/managed/session.ts
+++ b/server/src/managed/session.ts
@@ -349,6 +349,12 @@ function isWaitingOnManagedResponsesError(error: unknown): boolean {
   );
 }
 
+function isInvalidManagedSessionError(error: unknown): boolean {
+  const message =
+    error instanceof Error ? error.message : String(error ?? "");
+  return message.includes("Invalid session ID");
+}
+
 async function reconcileManagedSessionHistory(options: {
   sessionId: string;
   sondeTools: Map<string, ReturnType<typeof createSondeToolDefinitions>[number]>;
@@ -459,6 +465,18 @@ export function createManagedAgentSession(
     createSondeToolDefinitions(options.sondeToken).map((tool) => [tool.name, tool])
   );
 
+  async function startFreshSession(): Promise<string> {
+    currentSessionId = await createManagedSession({
+      user: options.user,
+      sondeToken: options.sondeToken,
+      pageContext: options.pageContext,
+      mentions: options.mentions,
+    });
+    rememberManagedSession(currentSessionId);
+    announcedSessionId = false;
+    return currentSessionId;
+  }
+
   async function ensureSession(
     requestedSessionId?: string
   ): Promise<{ sessionId: string; created: boolean }> {
@@ -471,15 +489,41 @@ export function createManagedAgentSession(
     if (currentSessionId) {
       return { sessionId: currentSessionId, created: false };
     }
-    currentSessionId = await createManagedSession({
-      user: options.user,
-      sondeToken: options.sondeToken,
-      pageContext: options.pageContext,
-      mentions: options.mentions,
-    });
-    rememberManagedSession(currentSessionId);
-    announcedSessionId = false;
-    return { sessionId: currentSessionId, created: true };
+    return { sessionId: await startFreshSession(), created: true };
+  }
+
+  async function reconcileOrRefreshSession(
+    sessionId: string
+  ): Promise<{
+    sessionId: string;
+    recovery: ManagedHistorySyncResult;
+    createdFresh: boolean;
+  }> {
+    try {
+      return {
+        sessionId,
+        recovery: await reconcileManagedSessionHistory({
+          sessionId,
+          sondeTools,
+          approvalBridge: options.approvalBridge,
+        }),
+        createdFresh: false,
+      };
+    } catch (error) {
+      if (!isInvalidManagedSessionError(error)) {
+        throw error;
+      }
+      return {
+        sessionId: await startFreshSession(),
+        recovery: {
+          emitted: [],
+          continueStreaming: false,
+          blocked: false,
+          settled: false,
+        },
+        createdFresh: true,
+      };
+    }
   }
 
   async function* drainManagedSession(
@@ -523,18 +567,18 @@ export function createManagedAgentSession(
           return false;
         }
 
-                if (event.type === "session.status_idle") {
-                    sawIdleEvent = true;
-                    idleStopReasonType =
-                        typeof event.stop_reason?.type === "string"
-                            ? (event.stop_reason.type as string)
-                            : null;
-                    if (idleStopReasonType === null) {
-                        break;
-                    }
-                    if (idleStopReasonType !== "requires_action") {
-                        return true;
-                    }
+        if (event.type === "session.status_idle") {
+          sawIdleEvent = true;
+          idleStopReasonType =
+            typeof event.stop_reason?.type === "string"
+              ? (event.stop_reason.type as string)
+              : null;
+          if (idleStopReasonType === null) {
+            break;
+          }
+          if (idleStopReasonType !== "requires_action") {
+            return true;
+          }
 
           const blockingIds = eventActionIds(event);
           const blockingEvents = actionEvents.filter(
@@ -607,19 +651,25 @@ export function createManagedAgentSession(
     ): AsyncIterable<AgentEvent> {
       abortController = new AbortController();
       clearPendingTasks();
-      const { sessionId, created } = await ensureSession(queryOptions?.resumeSessionId);
+      let { sessionId, created } = await ensureSession(queryOptions?.resumeSessionId);
+      let recovery: ManagedHistorySyncResult | null = null;
+
+      if (!created) {
+        const reconciled = await reconcileOrRefreshSession(sessionId);
+        sessionId = reconciled.sessionId;
+        recovery = reconciled.recovery;
+        if (reconciled.createdFresh) {
+          created = true;
+        }
+      }
+
       if (created || queryOptions?.resumeSessionId || !announcedSessionId) {
         yield { type: "session", sessionId };
         announcedSessionId = true;
       }
       yield { type: "model_info", model: resolveAgentModel() };
 
-      if (!created) {
-        const recovery = await reconcileManagedSessionHistory({
-          sessionId,
-          sondeTools,
-          approvalBridge: options.approvalBridge,
-        });
+      if (recovery) {
         for (const event of recovery.emitted) {
           yield event;
         }
@@ -687,25 +737,21 @@ export function createManagedAgentSession(
 
     async *recover(sessionId: string): AsyncIterable<AgentEvent> {
       abortController = new AbortController();
-      currentSessionId = sessionId;
-      rememberManagedSession(sessionId);
+      const reconciled = await reconcileOrRefreshSession(sessionId);
+      currentSessionId = reconciled.sessionId;
+      rememberManagedSession(currentSessionId);
       announcedSessionId = true;
-      yield { type: "session", sessionId };
+      yield { type: "session", sessionId: currentSessionId };
       yield { type: "model_info", model: resolveAgentModel() };
 
-      const recovery = await reconcileManagedSessionHistory({
-        sessionId,
-        sondeTools,
-        approvalBridge: options.approvalBridge,
-      });
-      for (const event of recovery.emitted) {
+      for (const event of reconciled.recovery.emitted) {
         yield event;
       }
-      if (recovery.blocked) {
+      if (reconciled.recovery.blocked) {
         return;
       }
-      if (recovery.continueStreaming) {
-        const settled = yield* drainManagedSession(sessionId);
+      if (reconciled.recovery.continueStreaming) {
+        const settled = yield* drainManagedSession(currentSessionId);
         if (!settled) {
           return;
         }


### PR DESCRIPTION
## Summary
- treat stale client-managed session ids as recoverable instead of surfacing Anthropic invalid-session errors
- create a fresh managed session before announcing it to the client when the old one is gone
- add a regression test that exercises the stale-session smoke path against the managed fetch mock

## Testing
- npm --prefix server test -- src/managed-chat.test.ts src/chat-session-recovery.test.ts
- npm --prefix server run build
- git diff --check