### PR TITLE
Promote staging to main

### DIFF
--- a/server/src/managed/client.test.ts
+++ b/server/src/managed/client.test.ts
@@ -1,6 +1,25 @@
-import { describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { normalizeManagedSessionEvent } from "./client.js";
+import { createManagedSession, normalizeManagedSessionEvent } from "./client.js";
+
+const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  process.env = {
+    ...originalEnv,
+    NODE_ENV: "test",
+    ANTHROPIC_API_KEY: "test-key",
+    SONDE_MANAGED_ENVIRONMENT_ID: "env_test_managed",
+    SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT: "1",
+  };
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  globalThis.fetch = originalFetch;
+});
 
 describe("normalizeManagedSessionEvent", () => {
   it("maps streamed Sonde tool_use events onto the custom-tool shape", () => {
@@ -28,5 +47,66 @@ describe("normalizeManagedSessionEvent", () => {
     assert.equal(normalized.type, "agent.tool_use");
     assert.equal(normalized.name, "bash");
     assert.equal(normalized.id, "tool_456");
+  });
+
+  it("retries session creation without the repo resource when the rich payload is rejected", async () => {
+    process.env.SONDE_GITHUB_TOKEN = "github-test-token";
+    process.env.SONDE_MANAGED_DEFAULT_GITHUB_REPO_URL = "https://github.com/aeolus-earth/sonde";
+
+    const sessionBodies: Array<Record<string, unknown>> = [];
+    globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string"
+        ? new URL(input)
+        : input instanceof URL
+          ? input
+          : new URL(input.url);
+
+      if (url.pathname === "/v1/agents") {
+        return new Response(JSON.stringify({ id: "agent_test_managed" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (url.pathname === "/v1/sessions") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        sessionBodies.push(body);
+        if (sessionBodies.length === 1) {
+          return new Response(
+            JSON.stringify({
+              type: "error",
+              error: {
+                type: "invalid_request_error",
+                message: "github repository resource rejected",
+              },
+            }),
+            {
+              status: 400,
+              headers: { "content-type": "application/json" },
+            }
+          );
+        }
+        return new Response(JSON.stringify({ id: "sesn_test_retry_without_repo" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url.toString()}`);
+    };
+
+    const sessionId = await createManagedSession({
+      user: {
+        id: "user-1",
+        email: "ci-smoke@aeolus.earth",
+        name: "CI Smoke",
+      },
+      sondeToken: "sonde-token",
+    });
+
+    assert.equal(sessionId, "sesn_test_retry_without_repo");
+    assert.equal(sessionBodies.length, 2);
+    assert.equal(Array.isArray(sessionBodies[0]?.resources), true);
+    assert.equal("resources" in sessionBodies[1]!, false);
   });
 });

--- a/server/src/managed/client.ts
+++ b/server/src/managed/client.ts
@@ -291,20 +291,38 @@ export async function createManagedSession(
     options.mentions
   );
 
-  const payload: Record<string, unknown> = {
-    agent: agentId,
-    environment_id: environmentId,
-    title: `Sonde chat · ${options.user.name ?? options.user.email ?? options.user.id}`,
+  const buildPayload = (includeRepoResource: boolean): Record<string, unknown> => {
+    const payload: Record<string, unknown> = {
+      agent: agentId,
+      environment_id: environmentId,
+      title: `Sonde chat · ${options.user.name ?? options.user.email ?? options.user.id}`,
+    };
+    if (includeRepoResource && repoResource) {
+      payload.resources = [repoResource];
+    }
+    return payload;
   };
-  if (repoResource) {
-    payload.resources = [repoResource];
-  }
 
-  const response = await fetchManagedJson<ManagedSessionResponse>("/v1/sessions?beta=true", {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
-  return response.id;
+  try {
+    const response = await fetchManagedJson<ManagedSessionResponse>("/v1/sessions?beta=true", {
+      method: "POST",
+      body: JSON.stringify(buildPayload(true)),
+    });
+    return response.id;
+  } catch (error) {
+    if (!repoResource) {
+      throw error;
+    }
+    const message = error instanceof Error ? error.message : String(error ?? "");
+    console.warn(
+      `[managed] createManagedSession retrying without repo resource: ${message.slice(0, 200)}`
+    );
+    const response = await fetchManagedJson<ManagedSessionResponse>("/v1/sessions?beta=true", {
+      method: "POST",
+      body: JSON.stringify(buildPayload(false)),
+    });
+    return response.id;
+  }
 }
 
 export async function sendManagedEvents(


### PR DESCRIPTION
## Summary

This release PR promotes the current `staging` branch into `main` after the managed-session fallback fix passed on staging.

- staging commit: `ddbf4384d4fb36101e1b6c08b04340e6b08c7b53`
- release method: merge commit
- promotion guard: only `staging -> main` PRs should merge into `main`

## Staging gate

- [Deploy Staging](https://github.com/aeolus-earth/sonde/actions/runs/24277052907)
- [Config Audit](https://github.com/aeolus-earth/sonde/actions/runs/24277052904)
- [CLI Hosted Audit](https://github.com/aeolus-earth/sonde/actions/runs/24277052901)
- [Staging Smoke](https://github.com/aeolus-earth/sonde/actions/runs/24277052908)
- [CodeQL](https://github.com/aeolus-earth/sonde/actions/runs/24277052711)