### PR TITLE
[codex] Shadow stale managed agent ids in hosted deploys

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -233,6 +233,7 @@ jobs:
             VITE_SUPABASE_ANON_KEY="${{ vars.SUPABASE_STAGING_ANON_KEY }}" \
             SONDE_AGENT_BACKEND="managed" \
             SONDE_MANAGED_ENVIRONMENT_ID="${SONDE_MANAGED_ENVIRONMENT_ID}" \
+            SONDE_MANAGED_AGENT_ID=" " \
             SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT="1" \
             SONDE_ALLOWED_ORIGINS="${{ vars.SONDE_STAGING_UI_URL }}" \
             SONDE_ENVIRONMENT="staging" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,6 +194,7 @@ jobs:
             VITE_SUPABASE_ANON_KEY="${{ vars.SUPABASE_ANON_KEY }}" \
             SONDE_AGENT_BACKEND="managed" \
             SONDE_MANAGED_ENVIRONMENT_ID="${SONDE_MANAGED_ENVIRONMENT_ID}" \
+            SONDE_MANAGED_AGENT_ID=" " \
             SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT="1" \
             SONDE_ALLOWED_ORIGINS="${{ vars.SONDE_UI_URL }}" \
             SONDE_ENVIRONMENT="production" \


### PR DESCRIPTION
## Summary
- explicitly shadow inherited `SONDE_MANAGED_AGENT_ID` values in hosted staging and production deploys
- keep the runtime on ephemeral managed agents by setting the hosted value to whitespace, which our server trims to empty
- preserve the existing delete step while preventing inherited config from winning

## Testing
- git diff --check