### PR TITLE
[codex] Redeploy agent when deploy workflows change

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -55,6 +55,7 @@ jobs:
               - '.dockerignore'
               - 'cli/**'
               - 'server/**'
+              - '.github/workflows/deploy-staging.yml'
             ui:
               - 'ui/**'
               - 'vercel.json'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ jobs:
               - '.dockerignore'
               - 'cli/**'
               - 'server/**'
+              - '.github/workflows/deploy.yml'
 
   push-migrations:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed
Updates the staging and production deploy workflows so changes to those workflow files themselves count as agent deploy changes.

## Why it changed
The latest managed-agent rollout fix in `#118` only changed `.github/workflows/deploy-staging.yml` and `.github/workflows/deploy.yml`. Because the deploy workflows' path filters did not treat workflow-file edits as agent changes, the Railway agent deploy job was skipped, leaving the staging agent on commit `ddbf4384...` while the UI moved to `f6d6dd07...`.

## Impact
- workflow-side managed-agent env fixes now actually redeploy the hosted agent
- staging and production deploy metadata should stop drifting when the deploy logic changes without touching `server/**`
- unblocks the current `staging -> main` promotion PR `#119`

## Validation
- `git diff --check`
- observed failing staging checks for `#118` with: `Agent commit mismatch: expected f6d6dd07..., got ddbf4384...`
