### PR TITLE
fix: align hosted audit with question workflow

### DIFF
--- a/server/scripts/run-cli-hosted-audit.mjs
+++ b/server/scripts/run-cli-hosted-audit.mjs
@@ -227,11 +227,37 @@ async function main() {
   }
 
   if (allowWrite) {
-    const questionText = `CLI hosted audit ${new Date().toISOString()}`;
+    const stamp = new Date().toISOString();
+    const directionTitle = `CLI hosted audit ${stamp.slice(11, 19)}`;
+    const questionText = `CLI hosted audit ${stamp}`;
+    const createdDirection = parseJsonOutput(
+      runCli(
+        sondeExecutable,
+        [
+          "direction",
+          "create",
+          "--program",
+          auditProgram,
+          "--title",
+          directionTitle,
+          questionText,
+          "--json",
+        ],
+        cliEnv
+      ),
+      "direction create"
+    );
     const created = parseJsonOutput(
       runCli(
         sondeExecutable,
-        ["question", "create", "-p", auditProgram, questionText, "--json"],
+        [
+          "question",
+          "create",
+          "--direction",
+          createdDirection.id,
+          questionText,
+          "--json",
+        ],
         cliEnv
       ),
       "question create"
@@ -250,6 +276,7 @@ async function main() {
     }
 
     summary.createdQuestionId = created.id;
+    summary.createdDirectionId = createdDirection.id;
   } else {
     const recent = parseJsonOutput(
       runCli(sondeExecutable, ["recent", "--json"], cliEnv),


### PR DESCRIPTION
## Summary
- update the hosted CLI audit to create a temporary direction before creating a question
- keep the audit aligned with the new direction-owned question model
- unblock staging verification so promotion to main can proceed

## Testing
- node --check server/scripts/run-cli-hosted-audit.mjs
- npm run lint (server)
