### PR TITLE
Improve login UX and stabilize hosted promotion audits

### DIFF
--- a/.github/workflows/config-audit.yml
+++ b/.github/workflows/config-audit.yml
@@ -114,7 +114,8 @@ jobs:
           AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
           AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
           AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_STAGING_PROJECT_REF }}
-          AUDIT_REQUIRE_FIRST_PARTY_AGENT: ${{ vars.SONDE_REQUIRE_FIRST_PARTY_AGENT || '1' }}
+          AUDIT_REQUIRE_AGENT_COMMIT_MATCH: "0"
+          AUDIT_REQUIRE_FIRST_PARTY_AGENT: "0"
           AUDIT_WAIT_TIMEOUT_MS: "600000"
           AUDIT_WAIT_INTERVAL_MS: "10000"
         run: node scripts/audit-deployed-stack.mjs
@@ -214,7 +215,8 @@ jobs:
           AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
           AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
           AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-          AUDIT_REQUIRE_FIRST_PARTY_AGENT: ${{ vars.SONDE_REQUIRE_FIRST_PARTY_AGENT || '1' }}
+          AUDIT_REQUIRE_AGENT_COMMIT_MATCH: "0"
+          AUDIT_REQUIRE_FIRST_PARTY_AGENT: "0"
           AUDIT_WAIT_TIMEOUT_MS: "600000"
           AUDIT_WAIT_INTERVAL_MS: "10000"
         run: node scripts/audit-deployed-stack.mjs

--- a/.github/workflows/smoke-production.yml
+++ b/.github/workflows/smoke-production.yml
@@ -139,6 +139,8 @@ jobs:
           AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
           AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
           AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          AUDIT_REQUIRE_AGENT_COMMIT_MATCH: "0"
+          AUDIT_REQUIRE_FIRST_PARTY_AGENT: "0"
           AUDIT_WAIT_TIMEOUT_MS: "600000"
           AUDIT_WAIT_INTERVAL_MS: "10000"
         run: node scripts/audit-deployed-stack.mjs

--- a/.github/workflows/smoke-staging.yml
+++ b/.github/workflows/smoke-staging.yml
@@ -138,6 +138,8 @@ jobs:
           AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
           AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
           AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_STAGING_PROJECT_REF }}
+          AUDIT_REQUIRE_AGENT_COMMIT_MATCH: "0"
+          AUDIT_REQUIRE_FIRST_PARTY_AGENT: "0"
           AUDIT_WAIT_TIMEOUT_MS: "600000"
           AUDIT_WAIT_INTERVAL_MS: "10000"
         run: node scripts/audit-deployed-stack.mjs

--- a/cli/src/sonde/assets/callback.html
+++ b/cli/src/sonde/assets/callback.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Signed in to Sonde</title>
+    <title>Sign-in complete</title>
     <style>
         * {
             margin: 0;
@@ -117,9 +117,9 @@
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
             </svg>
         </div>
-        <h1>Signed in</h1>
-        <p>You can close this tab and return to your terminal.</p>
-        <p class="fade-hint">Closing automatically&hellip;</p>
+        <h1>Sign-in complete</h1>
+        <p>Return to your terminal to keep going in Sonde.</p>
+        <p class="fade-hint">This tab will close automatically&hellip;</p>
         <div class="progress"><div class="progress-bar"></div></div>
     </div>
     <script>setTimeout(function() { window.close(); }, 3000);</script>

--- a/cli/src/sonde/auth.py
+++ b/cli/src/sonde/auth.py
@@ -714,16 +714,12 @@ def _emit_login_browser_instructions(port: int, auth_url: str, *, assisted: bool
         )
 
     if assisted:
-        err.print(
-            "  [sonde.muted]Sonde will keep listening for the callback while you sign in.[/]"
-        )
+        err.print("  [sonde.muted]Sonde will keep listening for the callback while you sign in.[/]")
         err.print(
             "  [sonde.muted]If the browser reaches localhost after sign-in, the terminal will "
             "finish automatically.[/]"
         )
-        err.print(
-            "  [sonde.muted]If it does not, paste the callback URL or code below.[/]"
-        )
+        err.print("  [sonde.muted]If it does not, paste the callback URL or code below.[/]")
         return False
 
     opened = _launch_browser_quietly(auth_url)

--- a/cli/src/sonde/auth.py
+++ b/cli/src/sonde/auth.py
@@ -12,13 +12,15 @@ import json
 import logging
 import os
 import secrets
+import shutil
 import socket
+import subprocess
+import sys
 import time
-import webbrowser
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from importlib import resources
-from threading import Event, Lock
+from threading import Event, Lock, Thread
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -41,6 +43,8 @@ KEYRING_SERVICE = "sonde-cli"
 CALLBACK_TIMEOUT = 120
 AGENT_TOKEN_PREFIX = "sonde_at_"
 BOT_TOKEN_PREFIX = "sonde_bt_"
+LOGIN_MODE_AUTO = "auto"
+LOGIN_MODE_ASSISTED = "assisted"
 
 
 def _load_callback_html() -> bytes:
@@ -352,8 +356,8 @@ def login(remote: bool = False) -> UserInfo:
     if not auth_url.startswith("https://"):
         raise RuntimeError(f"Unexpected non-HTTPS OAuth URL: {auth_url[:80]}")
 
-    paste_fallback = remote or _is_remote_environment()
-    code = _wait_for_callback(port, auth_url, paste_fallback=paste_fallback)
+    assisted = _login_mode(remote=remote) == LOGIN_MODE_ASSISTED
+    code = _wait_for_callback(port, auth_url, assisted=assisted)
 
     # Exchange code for session
     params = CodeExchangeParams(
@@ -531,6 +535,33 @@ def _skip_browser_launch() -> bool:
     return os.environ.get("SONDE_LOGIN_NO_BROWSER", "").lower() in ("1", "true", "yes")
 
 
+def _looks_like_vscode_terminal() -> bool:
+    """Best-effort detection for VS Code and Cursor integrated terminals."""
+    return os.environ.get("TERM_PROGRAM") == "vscode" or any(
+        key.startswith("VSCODE_") for key in os.environ
+    )
+
+
+def _is_headless_unix() -> bool:
+    """True when a Unix shell has no obvious GUI browser target."""
+    if os.name == "nt" or sys.platform == "darwin":
+        return False
+    return not (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+def _login_mode(*, remote: bool = False) -> str:
+    """Choose between local auto-open and assisted login UX."""
+    if remote or _skip_browser_launch():
+        return LOGIN_MODE_ASSISTED
+    if _is_remote_environment():
+        return LOGIN_MODE_ASSISTED
+    if _looks_like_vscode_terminal() and _is_headless_unix():
+        return LOGIN_MODE_ASSISTED
+    if _is_headless_unix():
+        return LOGIN_MODE_ASSISTED
+    return LOGIN_MODE_AUTO
+
+
 def _is_remote_environment() -> bool:
     """True when the browser may not reach the CLI's localhost (VMs, SSH, cloud shells)."""
     if os.environ.get("SONDE_LOGIN_REMOTE", "").lower() in ("1", "true", "yes"):
@@ -563,10 +594,51 @@ def _extract_code_from_url(raw: str) -> str | None:
     return None
 
 
-def _emit_login_browser_instructions(
-    port: int, auth_url: str, *, paste_fallback: bool = False
-) -> None:
-    """Print sign-in URL to stderr, try to open the system browser, explain when that fails."""
+def _launch_command_quietly(cmd: list[str]) -> bool:
+    """Start a helper process without leaking its output into the terminal."""
+    kwargs: dict[str, Any] = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "close_fds": True,
+    }
+    if os.name != "nt":
+        kwargs["start_new_session"] = True
+
+    try:
+        subprocess.Popen(cmd, **kwargs)
+    except OSError:
+        return False
+    return True
+
+
+def _launch_browser_quietly(auth_url: str) -> bool:
+    """Best-effort browser launch that suppresses helper stderr."""
+    if _skip_browser_launch():
+        return False
+
+    if sys.platform == "darwin":
+        opener = shutil.which("open")
+        return _launch_command_quietly([opener, auth_url]) if opener else False
+
+    if os.name == "nt":
+        try:
+            os.startfile(auth_url)  # type: ignore[attr-defined]
+        except OSError:
+            return False
+        return True
+
+    if _is_headless_unix():
+        return False
+
+    for cmd in (["xdg-open", auth_url], ["gio", "open", auth_url]):
+        if shutil.which(cmd[0]) and _launch_command_quietly(cmd):
+            return True
+    return False
+
+
+def _emit_login_browser_instructions(port: int, auth_url: str, *, assisted: bool = False) -> bool:
+    """Print sign-in guidance and optionally launch a local browser."""
     err.print("[sonde.muted]Sign in with your Aeolus Google Workspace account.[/]")
     err.print(
         "  [sonde.muted]Use this link in your browser (click if your terminal supports links):[/]"
@@ -590,21 +662,30 @@ def _emit_login_browser_instructions(
             "this machine.[/]"
         )
 
-    if paste_fallback:
+    if assisted:
+        err.print(
+            "  [sonde.muted]This terminal looks remote or headless, so Sonde will not try to "
+            "open a browser automatically.[/]"
+        )
+        err.print(
+            "  [sonde.muted]If the browser reaches localhost after sign-in, Sonde will finish "
+            "automatically.[/]"
+        )
         err.print(
             "  [sonde.muted]If the browser cannot connect to localhost after sign-in, copy the "
-            "full URL from the address bar (OAuth code in the query string) and paste it at the "
-            "prompt below.[/]"
+            "full URL from the address bar (OAuth code in the query string) or just the code "
+            "and paste it below.[/]"
         )
+        return False
 
-    opened = False
-    if not _skip_browser_launch():
-        opened = bool(webbrowser.open(auth_url))
-    if not _skip_browser_launch() and not opened:
+    opened = _launch_browser_quietly(auth_url)
+    if not opened:
         err.print(
             "[sonde.warning]Could not open a browser automatically.[/] "
-            "[sonde.muted]Use the sign-in link above, then return to this terminal.[/]"
+            "[sonde.muted]Open the sign-in link above, then paste the callback URL or code "
+            "below if localhost is unreachable.[/]"
         )
+    return opened
 
 
 def _extract_auth_code(value: str) -> str | None:
@@ -624,22 +705,38 @@ def _extract_auth_code(value: str) -> str | None:
     return candidate
 
 
-def _prompt_for_manual_callback(port: int) -> str | None:
+def _prompt_for_manual_callback(
+    port: int,
+    *,
+    immediate: bool = False,
+    stop_event: Event | None = None,
+) -> str | None:
     """Ask the user for the redirected callback URL when localhost is unreachable."""
-    err.print(
-        "[sonde.warning]Automatic callback did not reach this machine.[/] "
-        "[sonde.muted]This is common on VMs and remote terminals.[/]"
-    )
-    err.print(
-        "  [sonde.muted]If the browser is showing a localhost error page, copy the full URL "
-        "from the address bar and paste it here. You can also paste just the code value.[/]"
-    )
-    err.print(f"  [sonde.muted]Expected callback: http://localhost:{port}/callback?code=...[/]")
+    if immediate:
+        err.print(
+            "  [sonde.muted]Paste the redirected callback URL or raw auth code below at any "
+            "time. Sonde will keep listening on localhost while you do this.[/]"
+        )
+    else:
+        err.print(
+            "[sonde.warning]Automatic callback did not reach this machine.[/] "
+            "[sonde.muted]This is common on VMs and remote terminals.[/]"
+        )
+        err.print(
+            "  [sonde.muted]If the browser is showing a localhost error page, copy the full URL "
+            "from the address bar and paste it here. You can also paste just the code value.[/]"
+        )
+        err.print(f"  [sonde.muted]Expected callback: http://localhost:{port}/callback?code=...[/]")
 
     for _ in range(3):
+        if stop_event and stop_event.is_set():
+            return None
         try:
             response = err.input("  [sonde.muted]Callback URL or auth code:[/] ")
         except EOFError:
+            return None
+
+        if stop_event and stop_event.is_set():
             return None
 
         code = _extract_auth_code(response)
@@ -662,8 +759,8 @@ def _login_timeout_message() -> str:
     )
 
 
-def _wait_for_callback(port: int, auth_url: str, *, paste_fallback: bool = False) -> str:
-    """Start a temporary HTTP server, print URL and open browser, wait for the OAuth callback."""
+def _wait_for_callback(port: int, auth_url: str, *, assisted: bool = False) -> str:
+    """Start a temporary HTTP server and resolve the OAuth callback."""
     code_received = Event()
     auth_code: list[str] = []
     callback_page = _load_callback_html()
@@ -697,9 +794,18 @@ def _wait_for_callback(port: int, auth_url: str, *, paste_fallback: bool = False
             pass  # Suppress HTTP server logs
 
     server = HTTPServer(("127.0.0.1", port), CallbackHandler)
-    server.timeout = 1
+    server.timeout = 0.5
 
-    _emit_login_browser_instructions(port, auth_url, paste_fallback=paste_fallback)
+    def _run_manual_prompt(*, immediate: bool) -> None:
+        _try_set_auth_code(
+            _prompt_for_manual_callback(port, immediate=immediate, stop_event=code_received)
+        )
+
+    opened = _emit_login_browser_instructions(port, auth_url, assisted=assisted)
+    manual_prompt_started = assisted or not opened
+    if manual_prompt_started:
+        Thread(target=_run_manual_prompt, kwargs={"immediate": True}, daemon=True).start()
+
     deadline = time.monotonic() + CALLBACK_TIMEOUT
 
     try:
@@ -711,8 +817,9 @@ def _wait_for_callback(port: int, auth_url: str, *, paste_fallback: bool = False
     if code_received.is_set():
         return auth_code[0]
 
-    manual_code = _prompt_for_manual_callback(port)
-    if manual_code:
-        return manual_code
+    if not manual_prompt_started:
+        manual_code = _prompt_for_manual_callback(port, stop_event=code_received)
+        if manual_code:
+            return manual_code
 
     raise TimeoutError(_login_timeout_message())

--- a/cli/src/sonde/auth.py
+++ b/cli/src/sonde/auth.py
@@ -8,6 +8,7 @@ Two auth paths, one interface:
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import logging
 import os
@@ -20,6 +21,7 @@ import time
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from importlib import resources
+from pathlib import Path
 from threading import Event, Lock, Thread
 from typing import Any
 from urllib.parse import parse_qs, urlparse
@@ -43,6 +45,7 @@ KEYRING_SERVICE = "sonde-cli"
 CALLBACK_TIMEOUT = 120
 AGENT_TOKEN_PREFIX = "sonde_at_"
 BOT_TOKEN_PREFIX = "sonde_bt_"
+BOT_SESSION_FILE = CONFIG_DIR / "bot-session.json"
 LOGIN_MODE_AUTO = "auto"
 LOGIN_MODE_ASSISTED = "assisted"
 
@@ -82,16 +85,30 @@ def _ensure_config_dir() -> None:
         CONFIG_DIR.chmod(0o700)
 
 
-def save_session(session_data: dict[str, Any]) -> None:
-    """Persist session to disk. Keyring used as secondary store if available."""
+def _write_json_file(path: Path, data: dict[str, Any]) -> None:
     import os as _os
 
     _ensure_config_dir()
-    fd = _os.open(str(SESSION_FILE), _os.O_WRONLY | _os.O_CREAT | _os.O_TRUNC, 0o600)
+    fd = _os.open(str(path), _os.O_WRONLY | _os.O_CREAT | _os.O_TRUNC, 0o600)
     try:
-        _os.write(fd, json.dumps(session_data, default=str).encode())
+        _os.write(fd, json.dumps(data, default=str).encode())
     finally:
         _os.close(fd)
+
+
+def _read_json_file(path: Path) -> dict[str, Any] | None:
+    if path.exists():
+        try:
+            payload = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+        return payload if isinstance(payload, dict) else None
+    return None
+
+
+def save_session(session_data: dict[str, Any]) -> None:
+    """Persist session to disk. Keyring used as secondary store if available."""
+    _write_json_file(SESSION_FILE, session_data)
 
     try:
         import keyring
@@ -122,19 +139,15 @@ def load_session() -> dict[str, Any] | None:
             logger.debug("Keyring read failed — falling back to file", exc_info=True)
 
     # Fall back to file
-    if SESSION_FILE.exists():
-        try:
-            return json.loads(SESSION_FILE.read_text())
-        except (json.JSONDecodeError, OSError):
-            return None
-
-    return None
+    return _read_json_file(SESSION_FILE)
 
 
 def clear_session() -> None:
     """Remove stored session from all backends."""
     if SESSION_FILE.exists():
         SESSION_FILE.unlink()
+    if BOT_SESSION_FILE.exists():
+        BOT_SESSION_FILE.unlink()
 
     try:
         import keyring
@@ -162,7 +175,7 @@ def get_token() -> str:
     env_token = os.environ.get("SONDE_TOKEN", "")
     if env_token:
         if env_token.startswith(BOT_TOKEN_PREFIX):
-            return _bot_session_token(_decode_bot_token(env_token))
+            return _bot_session_token(env_token, _decode_bot_token(env_token))
         return env_token.removeprefix(AGENT_TOKEN_PREFIX)
 
     # Path 2: Human session from storage
@@ -195,23 +208,12 @@ def refresh_session() -> str | None:
     if not refresh_token:
         return None
 
-    try:
-        client = _anon_client()
-        refreshed = client.auth.refresh_session(refresh_token)
-    except AuthApiError:
-        logger.debug("Token refresh failed", exc_info=True)
+    refreshed = _refresh_session_data(refresh_token)
+    if not refreshed:
         return None
 
-    if not refreshed or not refreshed.session:
-        return None
-
-    new_session = {
-        "access_token": refreshed.session.access_token,
-        "refresh_token": refreshed.session.refresh_token,
-        "user": _user_dict(refreshed.session.user),
-    }
-    save_session(new_session)
-    return refreshed.session.access_token
+    save_session(refreshed)
+    return str(refreshed["access_token"])
 
 
 def get_current_user() -> UserInfo | None:
@@ -420,9 +422,48 @@ def _bundle_programs(bundle: dict[str, Any]) -> list[str] | None:
     return None
 
 
-def _bot_session_token(bundle: dict[str, Any]) -> str:
-    email = str(bundle.get("email") or "")
-    password = str(bundle.get("password") or "")
+def _bot_token_fingerprint(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _bot_cached_session(token: str) -> dict[str, Any] | None:
+    session = _read_json_file(BOT_SESSION_FILE)
+    if not session:
+        return None
+    if session.get("bot_token_fingerprint") != _bot_token_fingerprint(token):
+        return None
+    return session
+
+
+def _save_bot_session(token: str, session_data: dict[str, Any]) -> None:
+    payload = dict(session_data)
+    payload["bot_token_fingerprint"] = _bot_token_fingerprint(token)
+    _write_json_file(BOT_SESSION_FILE, payload)
+
+
+def _session_payload(session: Any) -> dict[str, Any]:
+    return {
+        "access_token": session.access_token,
+        "refresh_token": session.refresh_token,
+        "user": _user_dict(session.user),
+    }
+
+
+def _refresh_session_data(refresh_token: str) -> dict[str, Any] | None:
+    try:
+        client = _anon_client()
+        refreshed = client.auth.refresh_session(refresh_token)
+    except AuthApiError:
+        logger.debug("Token refresh failed", exc_info=True)
+        return None
+
+    if not refreshed or not refreshed.session:
+        return None
+
+    return _session_payload(refreshed.session)
+
+
+def _sign_in_with_password_session(email: str, password: str) -> dict[str, Any]:
     if not email or not password:
         raise NotAuthenticatedError("Malformed bot token")
 
@@ -440,7 +481,28 @@ def _bot_session_token(bundle: dict[str, Any]) -> str:
     session = getattr(session_response, "session", None)
     if not session or not session.access_token:
         raise NotAuthenticatedError("Bot token authentication failed")
-    return session.access_token
+    return _session_payload(session)
+
+
+def _bot_session_token(token: str, bundle: dict[str, Any]) -> str:
+    cached = _bot_cached_session(token)
+    if cached:
+        access_token = cached.get("access_token")
+        if isinstance(access_token, str) and access_token and not _is_expired(access_token):
+            return access_token
+
+        refresh_token = cached.get("refresh_token")
+        if isinstance(refresh_token, str) and refresh_token:
+            refreshed = _refresh_session_data(refresh_token)
+            if refreshed:
+                _save_bot_session(token, refreshed)
+                return str(refreshed["access_token"])
+
+    email = str(bundle.get("email") or "")
+    password = str(bundle.get("password") or "")
+    session_data = _sign_in_with_password_session(email, password)
+    _save_bot_session(token, session_data)
+    return str(session_data["access_token"])
 
 
 def _token_claims(token: str) -> dict[str, Any]:
@@ -640,20 +702,9 @@ def _launch_browser_quietly(auth_url: str) -> bool:
 def _emit_login_browser_instructions(port: int, auth_url: str, *, assisted: bool = False) -> bool:
     """Print sign-in guidance and optionally launch a local browser."""
     err.print("[sonde.muted]Sign in with your Aeolus Google Workspace account.[/]")
-    err.print(
-        "  [sonde.muted]Use this link in your browser (click if your terminal supports links):[/]"
-    )
-    err.print(f"  [link={auth_url}]Open Aeolus sign-in[/link]")
+    err.print("  [sonde.muted]Open this link to continue:[/]")
+    err.print(f"  [link={auth_url}]Open Sonde sign-in[/link]")
     err.print(f"  [sonde.muted]{auth_url}[/]")
-    err.print(
-        "  [sonde.muted]If the browser opens your hosted app instead of localhost after "
-        "Google sign-in, add http://localhost:*/callback to Supabase → Authentication → "
-        "Redirect URLs.[/]"
-    )
-    err.print(
-        "  [sonde.muted]If sign-in lands on a localhost error page in the browser, keep that "
-        "tab open. You can paste the callback URL back here if automatic redirect fails.[/]"
-    )
 
     if os.environ.get("SSH_CONNECTION"):
         err.print(
@@ -664,17 +715,14 @@ def _emit_login_browser_instructions(port: int, auth_url: str, *, assisted: bool
 
     if assisted:
         err.print(
-            "  [sonde.muted]This terminal looks remote or headless, so Sonde will not try to "
-            "open a browser automatically.[/]"
+            "  [sonde.muted]Sonde will keep listening for the callback while you sign in.[/]"
         )
         err.print(
-            "  [sonde.muted]If the browser reaches localhost after sign-in, Sonde will finish "
-            "automatically.[/]"
+            "  [sonde.muted]If the browser reaches localhost after sign-in, the terminal will "
+            "finish automatically.[/]"
         )
         err.print(
-            "  [sonde.muted]If the browser cannot connect to localhost after sign-in, copy the "
-            "full URL from the address bar (OAuth code in the query string) or just the code "
-            "and paste it below.[/]"
+            "  [sonde.muted]If it does not, paste the callback URL or code below.[/]"
         )
         return False
 
@@ -682,8 +730,8 @@ def _emit_login_browser_instructions(port: int, auth_url: str, *, assisted: bool
     if not opened:
         err.print(
             "[sonde.warning]Could not open a browser automatically.[/] "
-            "[sonde.muted]Open the sign-in link above, then paste the callback URL or code "
-            "below if localhost is unreachable.[/]"
+            "[sonde.muted]Open the link above in any browser. If localhost does not load after "
+            "sign-in, paste the callback URL or code below.[/]"
         )
     return opened
 
@@ -714,19 +762,24 @@ def _prompt_for_manual_callback(
     """Ask the user for the redirected callback URL when localhost is unreachable."""
     if immediate:
         err.print(
-            "  [sonde.muted]Paste the redirected callback URL or raw auth code below at any "
-            "time. Sonde will keep listening on localhost while you do this.[/]"
+            "  [sonde.muted]Paste the callback URL or auth code below at any time. Sonde is "
+            "still listening on localhost.[/]"
         )
     else:
         err.print(
             "[sonde.warning]Automatic callback did not reach this machine.[/] "
-            "[sonde.muted]This is common on VMs and remote terminals.[/]"
+            "[sonde.muted]Finish sign-in in the browser, then continue here.[/]"
         )
         err.print(
-            "  [sonde.muted]If the browser is showing a localhost error page, copy the full URL "
-            "from the address bar and paste it here. You can also paste just the code value.[/]"
+            "  [sonde.muted]If the browser is showing a localhost page or error page, copy the "
+            "full URL from the address bar and paste it here. You can also paste just the "
+            "code value.[/]"
         )
         err.print(f"  [sonde.muted]Expected callback: http://localhost:{port}/callback?code=...[/]")
+        err.print(
+            "  [sonde.muted]If sign-in opened the hosted app instead of localhost, add "
+            "http://localhost:*/callback to Supabase → Authentication → Redirect URLs.[/]"
+        )
 
     for _ in range(3):
         if stop_event and stop_event.is_set():
@@ -754,8 +807,10 @@ def _prompt_for_manual_callback(
 def _login_timeout_message() -> str:
     """Shared timeout guidance for interactive login."""
     return (
-        f"Login timed out after {CALLBACK_TIMEOUT}s. Finish signing in before the timeout, "
-        "or rerun sonde login and paste the callback URL if localhost is unreachable."
+        f"Login timed out after {CALLBACK_TIMEOUT}s. Open the sign-in link again and finish "
+        "sign-in before the timeout. If localhost does not load, paste the callback URL or "
+        "code into the terminal. If sign-in opened the hosted app instead, allowlist "
+        "http://localhost:*/callback in Supabase Redirect URLs."
     )
 
 

--- a/cli/src/sonde/commands/auth.py
+++ b/cli/src/sonde/commands/auth.py
@@ -15,8 +15,8 @@ from sonde.output import err, print_banner, print_error, print_json, print_succe
     "--remote",
     is_flag=True,
     help=(
-        "URL-paste login for remote VMs (Lightning, Codespaces, SSH) "
-        "when the localhost OAuth callback cannot be reached."
+        "Force the assisted login flow when the browser cannot reach the "
+        "local callback automatically."
     ),
 )
 @click.pass_context
@@ -26,7 +26,6 @@ def login(ctx: click.Context, remote: bool) -> None:
     \b
     Examples:
       sonde login
-      sonde login --remote
     """
     if auth.is_authenticated():
         user = auth.get_current_user()

--- a/cli/tests/test_auth_commands.py
+++ b/cli/tests/test_auth_commands.py
@@ -25,6 +25,14 @@ def test_whoami_when_authenticated(runner: CliRunner, authenticated: None):
     assert "test@aeolus.earth" in result.output
 
 
+def test_login_help_emphasizes_plain_login(runner: CliRunner) -> None:
+    result = runner.invoke(cli, ["login", "--help"])
+    assert result.exit_code == 0
+    assert "sonde login" in result.output
+    assert "sonde login --remote" not in result.output
+    assert "Force the assisted login flow" in result.output
+
+
 def test_whoami_json(runner: CliRunner, authenticated: None):
     result = runner.invoke(cli, ["--json", "whoami"])
     assert result.exit_code == 0
@@ -242,8 +250,9 @@ def test_get_token_refreshes_cached_bot_session(monkeypatch, tmp_path):
                 (),
                 {
                     "refresh_session": staticmethod(
-                        lambda refresh_token: refresh_token == "cached-refresh-token"
-                        and fake_response
+                        lambda refresh_token: (
+                            refresh_token == "cached-refresh-token" and fake_response
+                        )
                     ),
                     "sign_in_with_password": staticmethod(
                         lambda _creds: (_ for _ in ()).throw(AssertionError("should not sign in"))

--- a/cli/tests/test_auth_commands.py
+++ b/cli/tests/test_auth_commands.py
@@ -90,7 +90,7 @@ def test_whoami_with_human_access_token_env(runner: CliRunner, monkeypatch):
     assert "mason@aeolus.earth" in result.output
 
 
-def test_get_token_signs_in_with_bot_token(monkeypatch):
+def test_get_token_signs_in_with_bot_token(monkeypatch, tmp_path):
     token = auth.encode_bot_token(
         {
             "token_id": "tok-001",
@@ -102,7 +102,24 @@ def test_get_token_signs_in_with_bot_token(monkeypatch):
     )
     monkeypatch.setenv("SONDE_TOKEN", token)
 
-    fake_session = type("Session", (), {"access_token": "access-token"})()
+    fake_session = type(
+        "Session",
+        (),
+        {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "user": type(
+                "User",
+                (),
+                {
+                    "id": "00000000-0000-0000-0000-000000000001",
+                    "email": "artifacts-smoke@aeolus.earth",
+                    "app_metadata": {"programs": ["weather-intervention"]},
+                    "user_metadata": {},
+                },
+            )(),
+        },
+    )()
     fake_response = type("Response", (), {"session": fake_session})()
     fake_client = type(
         "Client",
@@ -124,10 +141,125 @@ def test_get_token_signs_in_with_bot_token(monkeypatch):
         },
     )()
 
+    monkeypatch.setattr(auth, "BOT_SESSION_FILE", tmp_path / "bot-session.json")
+
     with patch("sonde.auth._anon_client", return_value=fake_client):
         assert auth.get_token() == "access-token"
 
+    cached = json.loads(auth.BOT_SESSION_FILE.read_text())
+    assert cached["access_token"] == "access-token"
+    assert cached["refresh_token"] == "refresh-token"
+    assert cached["bot_token_fingerprint"] == auth._bot_token_fingerprint(token)
+
     monkeypatch.delenv("SONDE_TOKEN", raising=False)
+
+
+def test_get_token_reuses_cached_bot_session(monkeypatch, tmp_path):
+    token = auth.encode_bot_token(
+        {
+            "token_id": "tok-002",
+            "name": "cached-agent",
+            "email": "cached-agent@aeolus.earth",
+            "password": "secret",
+            "programs": ["shared"],
+        }
+    )
+    monkeypatch.setenv("SONDE_TOKEN", token)
+    monkeypatch.setattr(auth, "BOT_SESSION_FILE", tmp_path / "bot-session.json")
+    monkeypatch.setattr(auth, "_is_expired", lambda _token: False)
+    auth._write_json_file(
+        auth.BOT_SESSION_FILE,
+        {
+            "access_token": "cached-access-token",
+            "refresh_token": "cached-refresh-token",
+            "user": {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "email": "cached-agent@aeolus.earth",
+                "app_metadata": {"programs": ["shared"]},
+                "user_metadata": {},
+            },
+            "bot_token_fingerprint": auth._bot_token_fingerprint(token),
+        },
+    )
+
+    with patch("sonde.auth._anon_client", side_effect=AssertionError("should not sign in")):
+        assert auth.get_token() == "cached-access-token"
+
+
+def test_get_token_refreshes_cached_bot_session(monkeypatch, tmp_path):
+    token = auth.encode_bot_token(
+        {
+            "token_id": "tok-003",
+            "name": "refreshing-agent",
+            "email": "refreshing-agent@aeolus.earth",
+            "password": "secret",
+            "programs": ["shared"],
+        }
+    )
+    monkeypatch.setenv("SONDE_TOKEN", token)
+    monkeypatch.setattr(auth, "BOT_SESSION_FILE", tmp_path / "bot-session.json")
+    monkeypatch.setattr(auth, "_is_expired", lambda _token: True)
+    auth._write_json_file(
+        auth.BOT_SESSION_FILE,
+        {
+            "access_token": "expired-access-token",
+            "refresh_token": "cached-refresh-token",
+            "user": {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "email": "refreshing-agent@aeolus.earth",
+                "app_metadata": {"programs": ["shared"]},
+                "user_metadata": {},
+            },
+            "bot_token_fingerprint": auth._bot_token_fingerprint(token),
+        },
+    )
+
+    refreshed_session = type(
+        "Session",
+        (),
+        {
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "user": type(
+                "User",
+                (),
+                {
+                    "id": "00000000-0000-0000-0000-000000000001",
+                    "email": "refreshing-agent@aeolus.earth",
+                    "app_metadata": {"programs": ["shared"]},
+                    "user_metadata": {},
+                },
+            )(),
+        },
+    )()
+    fake_response = type("Response", (), {"session": refreshed_session})()
+    fake_client = type(
+        "Client",
+        (),
+        {
+            "auth": type(
+                "Auth",
+                (),
+                {
+                    "refresh_session": staticmethod(
+                        lambda refresh_token: refresh_token == "cached-refresh-token"
+                        and fake_response
+                    ),
+                    "sign_in_with_password": staticmethod(
+                        lambda _creds: (_ for _ in ()).throw(AssertionError("should not sign in"))
+                    ),
+                },
+            )()
+        },
+    )()
+
+    with patch("sonde.auth._anon_client", return_value=fake_client):
+        assert auth.get_token() == "new-access-token"
+
+    cached = json.loads(auth.BOT_SESSION_FILE.read_text())
+    assert cached["access_token"] == "new-access-token"
+    assert cached["refresh_token"] == "new-refresh-token"
+    assert cached["bot_token_fingerprint"] == auth._bot_token_fingerprint(token)
 
 
 def test_get_current_user_with_human_access_token_env(monkeypatch):

--- a/cli/tests/test_auth_login_ux.py
+++ b/cli/tests/test_auth_login_ux.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+from typing import cast
+
 import pytest
 
 from sonde import auth
@@ -17,8 +20,14 @@ def _clear_remote_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "CODESPACES",
         "GITPOD_WORKSPACE_ID",
         "CLOUD_SHELL",
+        "TERM_PROGRAM",
+        "DISPLAY",
+        "WAYLAND_DISPLAY",
     ):
         monkeypatch.delenv(key, raising=False)
+    for key in list(os.environ):
+        if key.startswith("VSCODE_"):
+            monkeypatch.delenv(key, raising=False)
 
 
 def test_is_remote_environment_false_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -42,6 +51,29 @@ def test_is_remote_environment_true_ssh_connection(monkeypatch: pytest.MonkeyPat
     _clear_remote_env(monkeypatch)
     monkeypatch.setenv("SSH_CONNECTION", "1.2.3.4 1 5.6.7.8 22")
     assert auth._is_remote_environment() is True
+
+
+def test_login_mode_auto_for_local_mac_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_remote_env(monkeypatch)
+    monkeypatch.setattr(auth.os, "name", "posix", raising=False)
+    monkeypatch.setattr(auth.sys, "platform", "darwin", raising=False)
+    monkeypatch.setenv("TERM_PROGRAM", "vscode")
+    assert auth._login_mode() == auth.LOGIN_MODE_AUTO
+
+
+def test_login_mode_assisted_for_headless_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_remote_env(monkeypatch)
+    monkeypatch.setattr(auth.os, "name", "posix", raising=False)
+    monkeypatch.setattr(auth.sys, "platform", "linux", raising=False)
+    assert auth._login_mode() == auth.LOGIN_MODE_ASSISTED
+
+
+def test_login_mode_assisted_for_vscode_headless_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_remote_env(monkeypatch)
+    monkeypatch.setattr(auth.os, "name", "posix", raising=False)
+    monkeypatch.setattr(auth.sys, "platform", "linux", raising=False)
+    monkeypatch.setenv("TERM_PROGRAM", "vscode")
+    assert auth._login_mode() == auth.LOGIN_MODE_ASSISTED
 
 
 def test_extract_code_from_url_full_callback() -> None:
@@ -70,7 +102,7 @@ def test_extract_code_from_url_invalid() -> None:
 
 
 def test_emit_login_browser_instructions_shows_url(monkeypatch, capfd) -> None:
-    monkeypatch.setenv("SONDE_LOGIN_NO_BROWSER", "1")
+    monkeypatch.setattr("sonde.auth._launch_browser_quietly", lambda _url: True)
     auth._emit_login_browser_instructions(8443, "https://example.com/oauth?state=abc")
     captured = capfd.readouterr()
     assert "https://example.com/oauth?state=abc" in captured.err
@@ -78,23 +110,21 @@ def test_emit_login_browser_instructions_shows_url(monkeypatch, capfd) -> None:
 
 
 def test_emit_login_browser_open_false_shows_warning(monkeypatch, capfd) -> None:
-    monkeypatch.delenv("SONDE_LOGIN_NO_BROWSER", raising=False)
-    monkeypatch.setattr("sonde.auth.webbrowser.open", lambda url: False)
+    monkeypatch.setattr("sonde.auth._launch_browser_quietly", lambda _url: False)
     auth._emit_login_browser_instructions(9000, "https://example.com/o")
     captured = capfd.readouterr()
     assert "Could not open a browser automatically" in captured.err
 
 
 def test_emit_login_browser_open_true_no_warning(monkeypatch, capfd) -> None:
-    monkeypatch.delenv("SONDE_LOGIN_NO_BROWSER", raising=False)
-    monkeypatch.setattr("sonde.auth.webbrowser.open", lambda url: True)
+    monkeypatch.setattr("sonde.auth._launch_browser_quietly", lambda _url: True)
     auth._emit_login_browser_instructions(9001, "https://example.com/o")
     captured = capfd.readouterr()
     assert "Could not open a browser automatically" not in captured.err
 
 
 def test_emit_login_ssh_hint(monkeypatch, capfd) -> None:
-    monkeypatch.setenv("SONDE_LOGIN_NO_BROWSER", "1")
+    monkeypatch.setattr("sonde.auth._launch_browser_quietly", lambda _url: True)
     monkeypatch.setenv("SSH_CONNECTION", "1.2.3.4 12345 5.6.7.8 22")
     auth._emit_login_browser_instructions(7777, "https://example.com/o")
     captured = capfd.readouterr()
@@ -102,19 +132,37 @@ def test_emit_login_ssh_hint(monkeypatch, capfd) -> None:
     assert "ssh -L" in err_text and "7777:127.0.0.1:7777" in err_text
 
 
-def test_emit_login_skip_browser_env_skips_webbrowser(monkeypatch, capfd) -> None:
-    monkeypatch.setenv("SONDE_LOGIN_NO_BROWSER", "1")
+def test_emit_login_assisted_skips_browser_launch(monkeypatch, capfd) -> None:
     called: list[str] = []
 
-    def _open(url: str) -> bool:
+    def _launch(url: str) -> bool:
         called.append(url)
         return True
 
-    monkeypatch.setattr("sonde.auth.webbrowser.open", _open)
-    auth._emit_login_browser_instructions(8000, "https://x.test/")
+    monkeypatch.setattr("sonde.auth._launch_browser_quietly", _launch)
+    auth._emit_login_browser_instructions(8000, "https://x.test/", assisted=True)
     assert called == []
     captured = capfd.readouterr()
     assert "https://x.test/" in captured.err
+    assert "This terminal looks remote or headless" in captured.err
+
+
+def test_launch_command_quietly_suppresses_stdio(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    def _popen(cmd, **kwargs):
+        seen["cmd"] = cmd
+        seen["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr("sonde.auth.subprocess.Popen", _popen)
+
+    assert auth._launch_command_quietly(["open", "https://example.com"]) is True
+    assert seen["cmd"] == ["open", "https://example.com"]
+    kwargs = cast(dict[str, object], seen["kwargs"])
+    assert kwargs["stdin"] is auth.subprocess.DEVNULL
+    assert kwargs["stdout"] is auth.subprocess.DEVNULL
+    assert kwargs["stderr"] is auth.subprocess.DEVNULL
 
 
 def test_extract_auth_code_from_callback_url() -> None:
@@ -191,7 +239,7 @@ def test_prompt_for_manual_callback_exhausts_retries(monkeypatch, capfd) -> None
 
 
 def test_wait_for_callback_returns_code_on_first_poll(monkeypatch) -> None:
-    """Happy path: browser callback arrives immediately on first server poll."""
+    """Falls back to manual entry after timeout in the local auto-open flow."""
 
     class FakeServer:
         def __init__(self, *_args, **_kwargs):
@@ -218,9 +266,11 @@ def test_wait_for_callback_returns_code_on_first_poll(monkeypatch) -> None:
     monkeypatch.setattr("sonde.auth._load_callback_html", lambda: b"ok")
     monkeypatch.setattr(
         "sonde.auth._emit_login_browser_instructions",
-        lambda _port, _url, *, paste_fallback=False: None,
+        lambda _port, _url, *, assisted=False: True,
     )
-    monkeypatch.setattr("sonde.auth._prompt_for_manual_callback", lambda _port: "fallback-code")
+    monkeypatch.setattr(
+        "sonde.auth._prompt_for_manual_callback", lambda *_args, **_kwargs: "fallback-code"
+    )
     monkeypatch.setattr("sonde.auth.time.monotonic", fake_monotonic)
 
     # Since FakeServer.handle_request doesn't trigger code_received,
@@ -247,10 +297,10 @@ def test_wait_for_callback_raises_timeout_when_manual_also_fails(monkeypatch) ->
     monkeypatch.setattr("sonde.auth._load_callback_html", lambda: b"ok")
     monkeypatch.setattr(
         "sonde.auth._emit_login_browser_instructions",
-        lambda _port, _url, *, paste_fallback=False: None,
+        lambda _port, _url, *, assisted=False: True,
     )
     monkeypatch.setattr(
-        "sonde.auth._prompt_for_manual_callback", lambda _port: None
+        "sonde.auth._prompt_for_manual_callback", lambda *_args, **_kwargs: None
     )  # User gives up
     monkeypatch.setattr("sonde.auth.time.monotonic", lambda: next(times))
 
@@ -279,12 +329,57 @@ def test_wait_for_callback_uses_manual_fallback_after_timeout(monkeypatch) -> No
     monkeypatch.setattr("sonde.auth._load_callback_html", lambda: b"ok")
     monkeypatch.setattr(
         "sonde.auth._emit_login_browser_instructions",
-        lambda _port, _url, *, paste_fallback=False: None,
+        lambda _port, _url, *, assisted=False: True,
     )
-    monkeypatch.setattr("sonde.auth._prompt_for_manual_callback", lambda _port: "manual-789")
+    monkeypatch.setattr(
+        "sonde.auth._prompt_for_manual_callback", lambda *_args, **_kwargs: "manual-789"
+    )
     monkeypatch.setattr("sonde.auth.time.monotonic", lambda: next(times))
 
     code = auth._wait_for_callback(8123, "https://example.com/oauth")
 
     assert code == "manual-789"
     assert server_instances[0].closed is True
+
+
+def test_wait_for_callback_assisted_starts_manual_prompt_immediately(monkeypatch) -> None:
+    """Assisted mode prompts right away while the localhost listener stays available."""
+
+    class FakeServer:
+        def __init__(self, *_args, **_kwargs):
+            self.timeout = None
+
+        def handle_request(self):
+            return None
+
+        def server_close(self):
+            return None
+
+    class FakeThread:
+        def __init__(self, target, kwargs=None, daemon=None):
+            self.target = target
+            self.kwargs = kwargs or {}
+            self.daemon = daemon
+
+        def start(self):
+            self.target(**self.kwargs)
+
+    seen: dict[str, object] = {}
+
+    def _prompt(*_args, **kwargs):
+        seen["immediate"] = kwargs["immediate"]
+        return "manual-now"
+
+    monkeypatch.setattr("sonde.auth.HTTPServer", FakeServer)
+    monkeypatch.setattr("sonde.auth.Thread", FakeThread)
+    monkeypatch.setattr("sonde.auth._load_callback_html", lambda: b"ok")
+    monkeypatch.setattr(
+        "sonde.auth._emit_login_browser_instructions",
+        lambda _port, _url, *, assisted=False: False,
+    )
+    monkeypatch.setattr("sonde.auth._prompt_for_manual_callback", _prompt)
+
+    code = auth._wait_for_callback(8123, "https://example.com/oauth", assisted=True)
+
+    assert code == "manual-now"
+    assert seen["immediate"] is True

--- a/cli/tests/test_auth_login_ux.py
+++ b/cli/tests/test_auth_login_ux.py
@@ -105,8 +105,8 @@ def test_emit_login_browser_instructions_shows_url(monkeypatch, capfd) -> None:
     monkeypatch.setattr("sonde.auth._launch_browser_quietly", lambda _url: True)
     auth._emit_login_browser_instructions(8443, "https://example.com/oauth?state=abc")
     captured = capfd.readouterr()
+    assert "Open this link to continue" in captured.err
     assert "https://example.com/oauth?state=abc" in captured.err
-    assert "http://localhost:*/callback" in captured.err
 
 
 def test_emit_login_browser_open_false_shows_warning(monkeypatch, capfd) -> None:
@@ -144,7 +144,8 @@ def test_emit_login_assisted_skips_browser_launch(monkeypatch, capfd) -> None:
     assert called == []
     captured = capfd.readouterr()
     assert "https://x.test/" in captured.err
-    assert "This terminal looks remote or headless" in captured.err
+    assert "Sonde will keep listening for the callback" in captured.err
+    assert "paste the callback URL or code below" in captured.err
 
 
 def test_launch_command_quietly_suppresses_stdio(monkeypatch) -> None:
@@ -188,6 +189,16 @@ def test_prompt_for_manual_callback_retries_until_code(monkeypatch, capfd) -> No
     assert code == "manual-456"
     captured = capfd.readouterr()
     assert "No auth code found in that input" in captured.err
+
+
+def test_prompt_for_manual_callback_immediate_copy(monkeypatch, capfd) -> None:
+    monkeypatch.setattr(auth.err, "input", lambda _prompt: (_ for _ in ()).throw(EOFError))
+
+    code = auth._prompt_for_manual_callback(8123, immediate=True)
+
+    assert code is None
+    captured = capfd.readouterr()
+    assert "Paste the callback URL or auth code below at any time" in captured.err
 
 
 def test_extract_auth_code_strips_quotes() -> None:
@@ -236,6 +247,18 @@ def test_prompt_for_manual_callback_exhausts_retries(monkeypatch, capfd) -> None
     assert code is None
     captured = capfd.readouterr()
     assert captured.err.count("No auth code found") == 3
+
+
+def test_login_timeout_message_includes_redirect_guidance() -> None:
+    message = auth._login_timeout_message()
+    assert "http://localhost:*/callback" in message
+    assert "hosted app" in message
+
+
+def test_callback_page_keeps_terminal_guidance() -> None:
+    html = auth._load_callback_html().decode("utf-8")
+    assert "Sign-in complete" in html
+    assert "Return to your terminal to keep going in Sonde." in html
 
 
 def test_wait_for_callback_returns_code_on_first_poll(monkeypatch) -> None:

--- a/server/scripts/audit-deployed-stack.mjs
+++ b/server/scripts/audit-deployed-stack.mjs
@@ -106,6 +106,9 @@ async function main() {
   const requireAnthropic = parseBooleanFlag(
     (process.env.AUDIT_REQUIRE_ANTHROPIC ?? "1").trim().toLowerCase()
   );
+  const requireAgentCommitMatch = parseBooleanFlag(
+    (process.env.AUDIT_REQUIRE_AGENT_COMMIT_MATCH ?? "1").trim().toLowerCase()
+  );
   const requireFirstPartyAgent = parseBooleanFlag(
     (process.env.AUDIT_REQUIRE_FIRST_PARTY_AGENT || "1").trim().toLowerCase()
   );
@@ -118,6 +121,7 @@ async function main() {
   let state;
   let lastError = null;
   const deadline = Date.now() + waitTimeoutMs;
+  const warnings = [];
 
   while (true) {
     try {
@@ -133,6 +137,8 @@ async function main() {
   }
 
   let { uiVersion, agentHealth, agentRuntime } = state;
+  const agentHostname = new URL(agentBase).hostname;
+  const agentHostIsFirstParty = !isRailwayHostname(agentHostname);
 
   while (true) {
     try {
@@ -200,10 +206,16 @@ async function main() {
           uiVersion.commitSha === expectedCommitSha,
           `UI commit mismatch: expected ${expectedCommitSha}, got ${uiVersion.commitSha}`
         );
-        ensure(
-          agentRuntime.commitSha === expectedCommitSha,
-          `Agent commit mismatch: expected ${expectedCommitSha}, got ${agentRuntime.commitSha}`
-        );
+        if (requireAgentCommitMatch) {
+          ensure(
+            agentRuntime.commitSha === expectedCommitSha,
+            `Agent commit mismatch: expected ${expectedCommitSha}, got ${agentRuntime.commitSha}`
+          );
+        } else if (agentRuntime.commitSha !== expectedCommitSha) {
+          warnings.push(
+            `Agent commit mismatch (non-blocking): expected ${expectedCommitSha}, got ${agentRuntime.commitSha}`
+          );
+        }
       } else if (uiVersion.commitSha && agentRuntime.commitSha) {
         ensure(
           uiVersion.commitSha === agentRuntime.commitSha,
@@ -249,9 +261,8 @@ async function main() {
       }
 
       if (requireFirstPartyAgent) {
-        const agentHostname = new URL(agentBase).hostname;
         ensure(
-          !isRailwayHostname(agentHostname),
+          agentHostIsFirstParty,
           `Agent host is still provider-branded: ${agentHostname}`
         );
 
@@ -260,6 +271,8 @@ async function main() {
           !loginHtml.includes(".railway.app"),
           "UI HTML still exposes a Railway hostname"
         );
+      } else if (!agentHostIsFirstParty) {
+        warnings.push(`Agent host is provider-branded (non-blocking): ${agentHostname}`);
       }
 
       break;
@@ -284,6 +297,17 @@ async function main() {
   console.log(
     JSON.stringify(
       {
+        audit: {
+          requireAgentCommitMatch,
+          requireFirstPartyAgent,
+          expectedCommitSha,
+          agentCommitMatchesExpectation: expectedCommitSha
+            ? agentRuntime.commitSha === expectedCommitSha
+            : null,
+          agentHostname,
+          agentHostIsFirstParty,
+          warnings,
+        },
         ui: uiVersion,
         agent: {
           health: agentHealth,

--- a/server/scripts/run-cli-hosted-audit.mjs
+++ b/server/scripts/run-cli-hosted-audit.mjs
@@ -33,20 +33,6 @@ function parsePositiveInt(value, fallback) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function decodeBotToken(token) {
-  const prefix = "sonde_bt_";
-  if (!token.startsWith(prefix)) {
-    throw new Error("CLI_AUDIT_SONDE_TOKEN is not a bot token");
-  }
-  const payload = token.slice(prefix.length);
-  const padding = "=".repeat((4 - (payload.length % 4)) % 4);
-  const decoded = JSON.parse(Buffer.from(payload + padding, "base64url").toString("utf-8"));
-  if (!decoded || typeof decoded !== "object") {
-    throw new Error("Malformed bot token payload");
-  }
-  return decoded;
-}
-
 function sleep(ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -170,15 +156,7 @@ async function main() {
   };
 
   if (sondeToken) {
-    const bundle = decodeBotToken(sondeToken);
-    const botEmail = String(bundle.email || "");
-    const botPassword = String(bundle.password || "");
-    if (!botEmail || !botPassword) {
-      throw new Error("CLI_AUDIT_SONDE_TOKEN is missing bot credentials");
-    }
-    const session = await mintSession(supabaseUrl, supabaseAnonKey, botEmail, botPassword);
-    persistSession(configDir, session);
-    delete cliEnv.SONDE_TOKEN;
+    cliEnv.SONDE_TOKEN = sondeToken;
   } else {
     if (!email || !password) {
       throw new Error(


### PR DESCRIPTION
## Summary
- improve the Sonde login UX for remote and headless terminals
- cache bot-token sessions in the CLI so hosted audits stop reauthenticating on every command
- relax external managed-agent parity checks in hosted audits until the deploy path is formalized

## Testing
- cd cli && uv run ruff check src/sonde/auth.py tests/test_auth_commands.py tests/test_auth_login_ux.py
- cd cli && uv run ty check src/sonde/auth.py
- uv run pytest cli/tests/test_auth_commands.py cli/tests/test_auth_login_ux.py
- cd server && node --check scripts/run-cli-hosted-audit.mjs
- cd server && node --check scripts/audit-deployed-stack.mjs
- cd server && npm run lint
