### PR TITLE
[codex] productionize Playwright smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,10 +222,82 @@ jobs:
         working-directory: server
         run: npm run build
 
+  legacy-provider-guard:
+    name: legacy-provider-guard
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fail on stale legacy-provider references in active first-party paths
+        run: bash scripts/check-legacy-provider-refs.sh
+
+  browser-regression:
+    name: browser-regression
+    runs-on: ubuntu-latest
+    needs: [changes, ui-core, server-core]
+    env:
+      VITE_SUPABASE_URL: https://utvmqjssbkzpumsdpgdy.supabase.co
+      VITE_SUPABASE_ANON_KEY: sb_publishable_tWTyul-LMC9QDFYID8pOZA_wKM2e2AL
+      E2E_AUTH_BYPASS_TOKEN: playwright-smoke-token
+      VITE_AGENT_PROXY_TARGET: http://127.0.0.1:3004
+      VITE_AGENT_WS_URL: ws://127.0.0.1:3004
+
+    steps:
+      - id: gate
+        run: |
+          if [[ "${{ needs.changes.outputs.ui }}" == "true" || "${{ needs.changes.outputs.server }}" == "true" || "${{ needs.changes.outputs.infra }}" == "true" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.gate.outputs.run != 'true'
+        run: echo "No UI, server, or CI changes; skipping browser regression."
+
+      - if: steps.gate.outputs.run == 'true'
+        uses: actions/checkout@v6
+
+      - if: steps.gate.outputs.run == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: |
+            ui/package-lock.json
+            server/package-lock.json
+
+      - if: steps.gate.outputs.run == 'true'
+        name: Install UI dependencies
+        working-directory: ui
+        run: npm ci
+
+      - if: steps.gate.outputs.run == 'true'
+        name: Install server dependencies
+        working-directory: server
+        run: npm ci
+
+      - if: steps.gate.outputs.run == 'true'
+        name: Install Playwright browsers
+        working-directory: ui
+        run: npx playwright install chromium --with-deps
+
+      - if: steps.gate.outputs.run == 'true'
+        name: Run browser regression
+        working-directory: ui
+        run: npm run test:e2e:regression
+
+      - if: failure() && steps.gate.outputs.run == 'true'
+        name: Upload regression report on failure
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-regression-report
+          path: ui/playwright-report/
+
   browser-smoke:
     name: browser-smoke
     runs-on: ubuntu-latest
-    needs: [changes, ui-core, server-core]
+    needs: [changes, ui-core, server-core, browser-regression]
     env:
       VITE_SUPABASE_URL: https://utvmqjssbkzpumsdpgdy.supabase.co
       VITE_SUPABASE_ANON_KEY: sb_publishable_tWTyul-LMC9QDFYID8pOZA_wKM2e2AL
@@ -315,7 +387,7 @@ jobs:
       - if: steps.gate.outputs.run == 'true'
         name: Run browser smoke
         working-directory: ui
-        run: npx playwright test e2e/ci-smoke.spec.ts --project=chromium --project=firefox
+        run: npm run test:e2e:smoke
 
       - if: failure() && steps.gate.outputs.run == 'true'
         name: Upload report on failure

--- a/.github/workflows/smoke-production.yml
+++ b/.github/workflows/smoke-production.yml
@@ -179,6 +179,7 @@ jobs:
       - name: Run production smoke tests
         env:
           E2E_BASE_URL: ${{ steps.targets.outputs.ui_url }}
+          E2E_DEPLOY_ENVIRONMENT: production
           E2E_AGENT_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
           E2E_AGENT_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN }}
           E2E_SUPABASE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co
@@ -191,7 +192,7 @@ jobs:
             E2E_AUTH_SESSION_JSON="$(cat "$PRODUCTION_SMOKE_SESSION_FILE")"
             export E2E_AUTH_SESSION_JSON
           fi
-          npx playwright test e2e/deployed.spec.ts --project=chromium --project=firefox --reporter=github
+          npm run test:e2e:hosted
 
       - name: Upload report on failure
         uses: actions/upload-artifact@v7

--- a/.github/workflows/smoke-staging.yml
+++ b/.github/workflows/smoke-staging.yml
@@ -178,6 +178,7 @@ jobs:
       - name: Run staging smoke tests
         env:
           E2E_BASE_URL: ${{ steps.targets.outputs.ui_url }}
+          E2E_DEPLOY_ENVIRONMENT: staging
           E2E_AGENT_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
           E2E_AGENT_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN }}
           E2E_SUPABASE_URL: https://${{ vars.SUPABASE_STAGING_PROJECT_REF }}.supabase.co
@@ -191,7 +192,7 @@ jobs:
             E2E_AUTH_SESSION_JSON="$(cat "$STAGING_SMOKE_SESSION_FILE")"
             export E2E_AUTH_SESSION_JSON
           fi
-          npx playwright test e2e/deployed.spec.ts --project=chromium --project=firefox --reporter=github
+          npm run test:e2e:hosted
 
       - name: Upload report on failure
         uses: actions/upload-artifact@v7

--- a/scripts/check-legacy-provider-refs.sh
+++ b/scripts/check-legacy-provider-refs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+legacy_pattern='rail'"'"'way|day'"'"'tona'
+
+matches="$(
+  rg -n -i "$legacy_pattern" . \
+    --glob '!**/node_modules/**' \
+    --glob '!**/.git/**' \
+    --glob '!**/dist/**' \
+    --glob '!**/playwright-report/**' \
+    --glob '!**/test-results/**' \
+    --glob '!repos/deepagents/**' \
+    --glob '!tickets/**' \
+    --glob '!notes/**' \
+    --glob '!AGENTS-repo-exploration.md' \
+    --glob '!**/*.png' \
+    --glob '!**/*.svg' \
+    || true
+)"
+
+if [[ -n "$matches" ]]; then
+  echo "::error::Found legacy provider references in active first-party paths"
+  echo "$matches"
+  exit 1
+fi
+
+echo "No legacy provider references found in active first-party paths."

--- a/server/example.env
+++ b/server/example.env
@@ -15,7 +15,7 @@ VITE_SUPABASE_ANON_KEY=
 # Optional — defaults to Claude Sonnet 4.6 (claude-sonnet-4-6)
 # AGENT_MODEL=claude-sonnet-4-6
 
-# Hosted runtime: Railway/Render inject PORT automatically.
+# Hosted runtime: your process manager may inject PORT automatically.
 # PORT=3001
 # SONDE_SERVER_PORT=3001
 

--- a/server/scripts/audit-deployed-stack.mjs
+++ b/server/scripts/audit-deployed-stack.mjs
@@ -19,6 +19,13 @@ function parseNumber(value, fallback) {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+function parseCsv(value) {
+  return (value ?? "")
+    .split(",")
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+}
+
 async function fetchJson(url, init) {
   const response = await fetch(url, init);
   const bodyText = await response.text();
@@ -64,8 +71,14 @@ function ensure(condition, message) {
   }
 }
 
-function isRailwayHostname(hostname) {
-  return hostname.endsWith(".railway.app") || hostname.endsWith(".up.railway.app");
+function matchesDisallowedHostSuffix(hostname, disallowedSuffixes) {
+  const normalizedHostname = hostname.toLowerCase();
+  return disallowedSuffixes.some((suffix) => normalizedHostname.endsWith(suffix));
+}
+
+function htmlContainsDisallowedSuffix(html, disallowedSuffixes) {
+  const normalizedHtml = html.toLowerCase();
+  return disallowedSuffixes.some((suffix) => normalizedHtml.includes(suffix));
 }
 
 function sleep(ms) {
@@ -112,6 +125,7 @@ async function main() {
   const requireFirstPartyAgent = parseBooleanFlag(
     (process.env.AUDIT_REQUIRE_FIRST_PARTY_AGENT || "1").trim().toLowerCase()
   );
+  const disallowedHostSuffixes = parseCsv(process.env.AUDIT_DISALLOWED_HOST_SUFFIXES);
   const requireSharedRateLimit = parseBooleanFlag(
     (process.env.AUDIT_REQUIRE_SHARED_RATE_LIMIT ?? "").trim().toLowerCase()
   );
@@ -138,7 +152,10 @@ async function main() {
 
   let { uiVersion, agentHealth, agentRuntime } = state;
   const agentHostname = new URL(agentBase).hostname;
-  const agentHostIsFirstParty = !isRailwayHostname(agentHostname);
+  const agentHostMatchesDisallowedSuffix = matchesDisallowedHostSuffix(
+    agentHostname,
+    disallowedHostSuffixes,
+  );
 
   while (true) {
     try {
@@ -262,17 +279,21 @@ async function main() {
 
       if (requireFirstPartyAgent) {
         ensure(
-          agentHostIsFirstParty,
-          `Agent host is still provider-branded: ${agentHostname}`
+          disallowedHostSuffixes.length > 0,
+          "AUDIT_REQUIRE_FIRST_PARTY_AGENT requires AUDIT_DISALLOWED_HOST_SUFFIXES to be configured",
+        );
+        ensure(
+          !agentHostMatchesDisallowedSuffix,
+          `Agent host matches a disallowed suffix: ${agentHostname}`
         );
 
         const loginHtml = await fetchText(`${uiBase}/login`);
         ensure(
-          !loginHtml.includes(".railway.app"),
-          "UI HTML still exposes a Railway hostname"
+          !htmlContainsDisallowedSuffix(loginHtml, disallowedHostSuffixes),
+          "UI HTML still exposes a disallowed hosted-domain suffix"
         );
-      } else if (!agentHostIsFirstParty) {
-        warnings.push(`Agent host is provider-branded (non-blocking): ${agentHostname}`);
+      } else if (agentHostMatchesDisallowedSuffix) {
+        warnings.push(`Agent host matches a disallowed suffix (non-blocking): ${agentHostname}`);
       }
 
       break;
@@ -304,8 +325,11 @@ async function main() {
           agentCommitMatchesExpectation: expectedCommitSha
             ? agentRuntime.commitSha === expectedCommitSha
             : null,
+          disallowedHostSuffixes,
           agentHostname,
-          agentHostIsFirstParty,
+          agentHostMatchesDisallowedSuffix: disallowedHostSuffixes.length
+            ? agentHostMatchesDisallowedSuffix
+            : null,
           warnings,
         },
         ui: uiVersion,

--- a/server/src/agent-trace.test.ts
+++ b/server/src/agent-trace.test.ts
@@ -13,7 +13,7 @@ describe("agent tool trace hooks", () => {
     const base = {
       session_id: "session-1",
       transcript_path: "/tmp/transcript.jsonl",
-      cwd: "/home/daytona/sessions/session-1",
+      cwd: "/workspace/sessions/session-1",
     };
 
     await hooks.PreToolUse![0]!.hooks[0]!(
@@ -22,7 +22,7 @@ describe("agent tool trace hooks", () => {
         hook_event_name: "PreToolUse",
         tool_name: "bash",
         tool_use_id: "tool-1",
-        tool_input: { command: "rg CCN /home/daytona/.sonde" },
+        tool_input: { command: "rg CCN /workspace/.sonde" },
       },
       "tool-1",
       { signal }
@@ -34,7 +34,7 @@ describe("agent tool trace hooks", () => {
         hook_event_name: "PostToolUse",
         tool_name: "bash",
         tool_use_id: "tool-1",
-        tool_input: { command: "rg CCN /home/daytona/.sonde" },
+        tool_input: { command: "rg CCN /workspace/.sonde" },
         tool_response: {
           content: [{ type: "text", text: "EXP-0001.md:CCN increased" }],
         },
@@ -61,7 +61,7 @@ describe("agent tool trace hooks", () => {
         type: "tool_use_start",
         id: "tool-1",
         tool: "bash",
-        input: { command: "rg CCN /home/daytona/.sonde" },
+        input: { command: "rg CCN /workspace/.sonde" },
       },
       {
         type: "tool_use_end",

--- a/server/src/command-approval-policy.test.ts
+++ b/server/src/command-approval-policy.test.ts
@@ -4,15 +4,15 @@ import { classifyCommand } from "./command-approval-policy.js";
 
 describe("command-approval-policy", () => {
   it("classifies read-only shell commands", () => {
-    assert.equal(classifyCommand('rg "CCN" /home/daytona/.sonde/'), "read");
-    assert.equal(classifyCommand('grep -rl "CCN" /home/daytona/.sonde/'), "read");
+    assert.equal(classifyCommand('rg "CCN" /workspace/.sonde/'), "read");
+    assert.equal(classifyCommand('grep -rl "CCN" /workspace/.sonde/'), "read");
     assert.equal(classifyCommand('grep -C 5 "keyword" .sonde/EXP-001.md'), "read");
     assert.equal(
       classifyCommand('grep -rl "^status: complete" .sonde/ --include="*.md"'),
       "read",
     );
     assert.equal(classifyCommand("find .sonde/ -name '*.md' -type f"), "read");
-    assert.equal(classifyCommand("cat /home/daytona/.sonde/tree.md"), "read");
+    assert.equal(classifyCommand("cat /workspace/.sonde/tree.md"), "read");
     assert.equal(classifyCommand("cat .sonde/tree.md"), "read");
     assert.equal(classifyCommand("head -20 .sonde/experiments/EXP-001.md"), "read");
     assert.equal(classifyCommand("tail -5 .sonde/tree.md"), "read");
@@ -46,7 +46,7 @@ describe("command-approval-policy", () => {
 
   it("classifies destructive commands", () => {
     assert.equal(classifyCommand("sonde experiment delete EXP-001"), "destructive");
-    assert.equal(classifyCommand("rm -rf /home/daytona/.sonde/"), "destructive");
+    assert.equal(classifyCommand("rm -rf /workspace/.sonde/"), "destructive");
   });
 
   it("classifies session-local commands", () => {

--- a/ui/e2e/hosted-smoke.spec.ts
+++ b/ui/e2e/hosted-smoke.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Production smoke tests — run against the real deployed URL.
+ * Hosted smoke tests — run against a real deployed URL.
  *
  * These verify what actual users experience after a deploy.
  * Only runs when E2E_BASE_URL is set (CI post-deploy or manual dispatch).
@@ -9,6 +9,7 @@ import { test, expect, type Locator, type Page } from "@playwright/test";
 import { seedActiveProgram, seedConfiguredSession } from "./helpers";
 
 const BASE_URL = process.env.E2E_BASE_URL;
+const DEPLOY_ENVIRONMENT = process.env.E2E_DEPLOY_ENVIRONMENT?.trim() || "hosted";
 const AGENT_HTTP_BASE = process.env.E2E_AGENT_HTTP_BASE ?? null;
 const AGENT_RUNTIME_AUDIT_TOKEN =
   process.env.E2E_AGENT_RUNTIME_AUDIT_TOKEN?.trim() || null;
@@ -20,6 +21,12 @@ const EXPECT_TIMELINE_AUTH_MODE =
 const CHAT_PROMPT =
   process.env.E2E_CHAT_PROMPT?.trim() ||
   "Use Sonde tools to list one accessible program id, then reply with SONDE_SMOKE_OK.";
+const ENVIRONMENT_LABEL =
+  DEPLOY_ENVIRONMENT.charAt(0).toUpperCase() + DEPLOY_ENVIRONMENT.slice(1);
+const SUITE_LABEL =
+  DEPLOY_ENVIRONMENT === "hosted"
+    ? "Hosted smoke"
+    : `${ENVIRONMENT_LABEL} hosted smoke`;
 async function waitForHostedChatResponse(
   page: Page,
   assistantMessage: Locator,
@@ -63,7 +70,7 @@ async function waitForHostedChatResponse(
   );
 }
 
-test.describe("Production deployment", () => {
+test.describe(SUITE_LABEL, () => {
   test.skip(!BASE_URL, "Skipped: E2E_BASE_URL not set (local dev)");
 
   test("no Vercel auth gate — serves app, not Vercel login", async ({
@@ -195,7 +202,7 @@ test.describe("Production deployment", () => {
   });
 });
 
-test.describe("Production deployment authenticated flows", () => {
+test.describe(`${SUITE_LABEL} authenticated flows`, () => {
   test.skip(
     !BASE_URL || !AUTH_SESSION_JSON,
     "Skipped: authenticated smoke requires E2E_BASE_URL and E2E_AUTH_SESSION_JSON"

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,6 +8,9 @@
     "build": "tsc -b && vite build",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:e2e:regression": "playwright test e2e/auth.spec.ts e2e/navigation.spec.ts e2e/smoke.spec.ts --project=chromium",
+    "test:e2e:smoke": "playwright test e2e/ci-smoke.spec.ts --project=chromium --project=firefox",
+    "test:e2e:hosted": "playwright test e2e/hosted-smoke.spec.ts --project=chromium --project=firefox --reporter=github",
     "test:e2e:headed": "playwright test --headed",
     "lint": "eslint .",
     "preview": "vite preview"


### PR DESCRIPTION
## What changed
- clarified the Playwright suite structure into regression, local smoke, and hosted smoke entrypoints
- renamed the hosted Playwright suite so staging and production use environment-aware hosted smoke wording instead of stale production-only naming
- wired the previously unwired Playwright regression suites into PR CI
- replaced first-party Railway/Daytona residue in runtime audit logic, example config, and server test fixtures
- added a CI guard that fails if legacy provider references reappear in active first-party paths

## Why it changed
The Playwright surface was useful, but it was not fully aligned with what CI actually ran, and the repo still had stale Railway/Daytona references in active first-party code. This change makes the E2E structure clearer, keeps CI coverage honest, and prevents that stale provider residue from creeping back in.

## Impact
- PR CI now exercises more of the Playwright suite instead of leaving `auth`, `navigation`, and `smoke` as manual-only coverage
- hosted smoke uses a shared `ui/e2e/hosted-smoke.spec.ts` entrypoint for both staging and production
- active first-party Sonde code no longer carries Railway/Daytona wording

## Validation
- `bash scripts/check-legacy-provider-refs.sh`
- `node --check server/scripts/audit-deployed-stack.mjs`
- `cd server && node --import tsx --test src/command-approval-policy.test.ts src/agent-trace.test.ts`
- `cd ui && npm run lint`
- `cd ui && npm run test:e2e:regression`
- `cd ui && npm run test:e2e:smoke`
- `cd ui && npm run test:e2e:hosted -- --list`
