### PR TITLE
fix: harden hosted auth and ci parity

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,4 +7,4 @@ cd "$ROOT"
 
 echo "[sonde pre-push] Running make ci-local"
 make ci-local
-echo "[sonde pre-push] Passed. For deeper pre-PR coverage, also run: make ci-browser ci-data"
+echo "[sonde pre-push] Passed. For deeper pre-PR coverage, also run: make ci-browser ci-data ci-auth"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,41 @@ jobs:
               - "supabase/**"
             infra:
               - ".github/workflows/**"
+              - "config/hosted-environments.json"
               - "vercel.ts"
               - "ui/vercel.ts"
               - "scripts/**"
               - ".githooks/**"
               - "Makefile"
+
+  hosted-contract:
+    name: hosted-contract
+    runs-on: ubuntu-latest
+    needs: changes
+
+    steps:
+      - id: gate
+        run: |
+          if [[ "${{ needs.changes.outputs.infra }}" == "true" || "${{ needs.changes.outputs.server }}" == "true" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.gate.outputs.run != 'true'
+        run: echo "No server or infra changes; skipping hosted contract checks."
+
+      - if: steps.gate.outputs.run == 'true'
+        uses: actions/checkout@v6
+
+      - if: steps.gate.outputs.run == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - if: steps.gate.outputs.run == 'true'
+        name: Validate hosted environment contract
+        run: node server/scripts/hosted-env-contract.mjs check-parity
 
   cli-core:
     name: cli-core
@@ -193,6 +223,7 @@ jobs:
     name: hosted-preflight
     runs-on: ubuntu-latest
     needs: [changes]
+    environment: staging
 
     steps:
       - id: gate
@@ -231,8 +262,8 @@ jobs:
       - if: steps.gate.outputs.run == 'true'
         name: Run hosted preflight
         env:
-          SONDE_HOSTED_PREFLIGHT_AGENT_HTTP_BASE: ${{ vars.SONDE_STAGING_AGENT_HTTP_BASE }}
-          SONDE_HOSTED_PREFLIGHT_APP_ORIGIN: ${{ vars.SONDE_STAGING_UI_URL }}
+          SONDE_HOSTED_PREFLIGHT_AGENT_HTTP_BASE: ${{ vars.SONDE_AGENT_HTTP_BASE || vars.SONDE_STAGING_AGENT_HTTP_BASE || '' }}
+          SONDE_HOSTED_PREFLIGHT_APP_ORIGIN: ${{ vars.SONDE_UI_URL || vars.SONDE_STAGING_UI_URL || '' }}
           SONDE_HOSTED_PREFLIGHT_REQUIRED: "1"
         run: bash scripts/ci/hosted-preflight.sh
 
@@ -349,6 +380,61 @@ jobs:
           path: |
             ui/playwright-report/
             /tmp/sonde-agent-smoke.log
+
+  managed-auth-parity:
+    name: managed-auth-parity
+    runs-on: ubuntu-latest
+    needs: [changes, cli-core, server-core]
+
+    steps:
+      - id: gate
+        run: |
+          if [[ "${{ needs.changes.outputs.cli }}" == "true" || "${{ needs.changes.outputs.server }}" == "true" || "${{ needs.changes.outputs.data }}" == "true" || "${{ needs.changes.outputs.infra }}" == "true" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.gate.outputs.run != 'true'
+        run: echo "No CLI, server, data, or CI changes; skipping managed auth parity."
+
+      - if: steps.gate.outputs.run == 'true'
+        uses: actions/checkout@v6
+
+      - if: steps.gate.outputs.run == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: |
+            server/package-lock.json
+            ui/package-lock.json
+
+      - if: steps.gate.outputs.run == 'true'
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "cli/uv.lock"
+
+      - if: steps.gate.outputs.run == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - if: steps.gate.outputs.run == 'true'
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - if: steps.gate.outputs.run == 'true'
+        name: Install server dependencies
+        working-directory: server
+        run: npm ci
+
+      - if: steps.gate.outputs.run == 'true'
+        name: Run managed auth parity
+        run: bash scripts/ci/auth.sh
 
   data-integration:
     name: data-integration

--- a/.github/workflows/cli-hosted-audit.yml
+++ b/.github/workflows/cli-hosted-audit.yml
@@ -27,6 +27,14 @@ jobs:
         github.event.inputs.target == 'both'
       }}
     runs-on: ubuntu-latest
+    environment: staging
+    env:
+      HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF || vars.SUPABASE_STAGING_PROJECT_REF || '' }}
+      HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY || vars.SONDE_STAGING_ANON_KEY || '' }}
+      HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_SMOKE_USER_EMAIL || secrets.SONDE_STAGING_SMOKE_USER_EMAIL || '' }}
+      HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_SMOKE_USER_PASSWORD || secrets.SONDE_STAGING_SMOKE_USER_PASSWORD || '' }}
+      HOSTED_CLI_AUDIT_TOKEN: ${{ secrets.SONDE_CLI_AUDIT_TOKEN || secrets.SONDE_STAGING_CLI_AUDIT_TOKEN || '' }}
+
     steps:
       - uses: actions/checkout@v6
 
@@ -44,23 +52,44 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Load hosted staging contract
+        id: contract
+        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs staging >> "$GITHUB_OUTPUT"
+
       - name: Install Sonde CLI
         run: |
           uv tool install --force ./cli
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Run staging CLI audit
+      - name: Run staging CLI audit (bot token)
         working-directory: server
         env:
-          SUPABASE_URL: https://${{ vars.SUPABASE_STAGING_PROJECT_REF }}.supabase.co
-          SUPABASE_ANON_KEY: ${{ vars.SUPABASE_STAGING_ANON_KEY }}
-          CLI_AUDIT_SONDE_TOKEN: ${{ secrets.SONDE_STAGING_CLI_AUDIT_TOKEN }}
-          CLI_AUDIT_ENV: staging
+          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
+          CLI_AUDIT_SONDE_TOKEN: ${{ env.HOSTED_CLI_AUDIT_TOKEN }}
+          CLI_AUDIT_AUTH_MODE: token
+          CLI_AUDIT_ENV: ${{ steps.contract.outputs.runtime_environment }}
           CLI_AUDIT_ALLOW_WRITE: "1"
-          CLI_AUDIT_PROGRAM: shared
-          CLI_AUDIT_EXPECT_EXPERIMENT_ID: EXP-9001
-          CLI_AUDIT_WAIT_TIMEOUT_MS: "600000"
-          CLI_AUDIT_WAIT_INTERVAL_MS: "10000"
+          CLI_AUDIT_PROGRAM: ${{ steps.contract.outputs.smoke_expected_program_id }}
+          CLI_AUDIT_EXPECT_EXPERIMENT_ID: ${{ steps.contract.outputs.smoke_expected_experiment_id }}
+          CLI_AUDIT_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
+          CLI_AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
+        run: node scripts/run-cli-hosted-audit.mjs
+
+      - name: Run staging CLI audit (human session)
+        working-directory: server
+        env:
+          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
+          CLI_AUDIT_AUTH_MODE: session
+          CLI_AUDIT_ENV: ${{ steps.contract.outputs.runtime_environment }}
+          CLI_AUDIT_ALLOW_WRITE: "1"
+          CLI_AUDIT_PROGRAM: ${{ steps.contract.outputs.smoke_expected_program_id }}
+          CLI_AUDIT_EXPECT_EXPERIMENT_ID: ${{ steps.contract.outputs.smoke_expected_experiment_id }}
+          CLI_AUDIT_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
+          CLI_AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
+          SMOKE_USER_EMAIL: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          SMOKE_USER_PASSWORD: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
         run: node scripts/run-cli-hosted-audit.mjs
 
   production-cli-audit:
@@ -71,6 +100,14 @@ jobs:
         github.event.inputs.target == 'both'
       }}
     runs-on: ubuntu-latest
+    environment: production
+    env:
+      HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF || secrets.SUPABASE_PROJECT_REF || '' }}
+      HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY || '' }}
+      HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_SMOKE_USER_EMAIL || secrets.SONDE_PRODUCTION_SMOKE_USER_EMAIL || '' }}
+      HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_SMOKE_USER_PASSWORD || secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD || '' }}
+      HOSTED_CLI_AUDIT_TOKEN: ${{ secrets.SONDE_CLI_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_CLI_AUDIT_TOKEN || '' }}
+
     steps:
       - uses: actions/checkout@v6
 
@@ -88,20 +125,40 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Load hosted production contract
+        id: contract
+        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs production >> "$GITHUB_OUTPUT"
+
       - name: Install Sonde CLI
         run: |
           uv tool install --force ./cli
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Run production CLI audit
+      - name: Run production CLI audit (bot token)
         working-directory: server
         env:
-          SUPABASE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co
-          SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY }}
-          CLI_AUDIT_SONDE_TOKEN: ${{ secrets.SONDE_PRODUCTION_CLI_AUDIT_TOKEN }}
-          CLI_AUDIT_ENV: production
-          CLI_AUDIT_PROGRAM: shared
-          CLI_AUDIT_EXPECT_EXPERIMENT_ID: EXP-0128
-          CLI_AUDIT_WAIT_TIMEOUT_MS: "600000"
-          CLI_AUDIT_WAIT_INTERVAL_MS: "10000"
+          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
+          CLI_AUDIT_SONDE_TOKEN: ${{ env.HOSTED_CLI_AUDIT_TOKEN }}
+          CLI_AUDIT_AUTH_MODE: token
+          CLI_AUDIT_ENV: ${{ steps.contract.outputs.runtime_environment }}
+          CLI_AUDIT_PROGRAM: ${{ steps.contract.outputs.smoke_expected_program_id }}
+          CLI_AUDIT_EXPECT_EXPERIMENT_ID: ${{ steps.contract.outputs.smoke_expected_experiment_id }}
+          CLI_AUDIT_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
+          CLI_AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
+        run: node scripts/run-cli-hosted-audit.mjs
+
+      - name: Run production CLI audit (human session)
+        working-directory: server
+        env:
+          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
+          CLI_AUDIT_AUTH_MODE: session
+          CLI_AUDIT_ENV: ${{ steps.contract.outputs.runtime_environment }}
+          CLI_AUDIT_PROGRAM: ${{ steps.contract.outputs.smoke_expected_program_id }}
+          CLI_AUDIT_EXPECT_EXPERIMENT_ID: ${{ steps.contract.outputs.smoke_expected_experiment_id }}
+          CLI_AUDIT_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
+          CLI_AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
+          SMOKE_USER_EMAIL: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          SMOKE_USER_PASSWORD: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
         run: node scripts/run-cli-hosted-audit.mjs

--- a/.github/workflows/config-audit.yml
+++ b/.github/workflows/config-audit.yml
@@ -3,6 +3,8 @@ name: Config Audit
 on:
   push:
     branches: [staging, main]
+  schedule:
+    - cron: "23 14 * * *"
   workflow_dispatch:
     inputs:
       target:
@@ -22,11 +24,27 @@ jobs:
   staging-config-audit:
     if: >-
       ${{
+        github.event_name == 'schedule' ||
         github.ref_name == 'staging' ||
         github.event.inputs.target == 'staging' ||
         github.event.inputs.target == 'both'
       }}
     runs-on: ubuntu-latest
+    environment: staging
+    env:
+      HOSTED_UI_URL: ${{ vars.SONDE_UI_URL || vars.SONDE_STAGING_UI_URL || '' }}
+      HOSTED_AGENT_URL: ${{ vars.SONDE_AGENT_HTTP_BASE || vars.SONDE_STAGING_AGENT_HTTP_BASE || '' }}
+      HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF || vars.SUPABASE_STAGING_PROJECT_REF || '' }}
+      HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY || vars.SUPABASE_STAGING_ANON_KEY || '' }}
+      HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_SMOKE_USER_EMAIL || secrets.SONDE_STAGING_SMOKE_USER_EMAIL || '' }}
+      HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_SMOKE_USER_PASSWORD || secrets.SONDE_STAGING_SMOKE_USER_PASSWORD || '' }}
+      HOSTED_CLI_AUDIT_TOKEN: ${{ secrets.SONDE_CLI_AUDIT_TOKEN || secrets.SONDE_STAGING_CLI_AUDIT_TOKEN || '' }}
+      HOSTED_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN || '' }}
+      HOSTED_REDIS_URL: ${{ vars.SONDE_UPSTASH_REDIS_REST_URL || vars.SONDE_STAGING_UPSTASH_REDIS_REST_URL || '' }}
+      HOSTED_REDIS_TOKEN: ${{ secrets.SONDE_UPSTASH_REDIS_REST_TOKEN || secrets.SONDE_STAGING_UPSTASH_REDIS_REST_TOKEN || '' }}
+      HOSTED_REQUIRE_SHARED_RATE_LIMIT: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT || '' }}
+      HOSTED_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID || '' }}
+      HOSTED_GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET || '' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -35,43 +53,21 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Load hosted staging contract
+        id: contract
+        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs staging >> "$GITHUB_OUTPUT"
+
       - name: Validate required staging config
+        run: node server/scripts/hosted-env-contract.mjs validate staging
+
+      - name: Verify staging smoke credentials can mint a session
+        working-directory: server
         env:
-          UI_URL: ${{ vars.SONDE_STAGING_UI_URL }}
-          AGENT_URL: ${{ vars.SONDE_STAGING_AGENT_HTTP_BASE }}
-          SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_STAGING_PROJECT_REF }}
-          SUPABASE_ANON_KEY: ${{ vars.SUPABASE_STAGING_ANON_KEY }}
-          SMOKE_USER_EMAIL: ${{ secrets.SONDE_STAGING_SMOKE_USER_EMAIL }}
-          SMOKE_USER_PASSWORD: ${{ secrets.SONDE_STAGING_SMOKE_USER_PASSWORD }}
-          CLI_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_CLI_AUDIT_TOKEN }}
-          RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN }}
-          REDIS_URL: ${{ vars.SONDE_STAGING_UPSTASH_REDIS_REST_URL }}
-          REDIS_TOKEN: ${{ secrets.SONDE_STAGING_UPSTASH_REDIS_REST_TOKEN }}
-          REQUIRE_SHARED_RATE_LIMIT: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT || '' }}
-          GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
-        run: |
-          for name in UI_URL AGENT_URL SUPABASE_PROJECT_REF SUPABASE_ANON_KEY SMOKE_USER_EMAIL SMOKE_USER_PASSWORD CLI_AUDIT_TOKEN RUNTIME_AUDIT_TOKEN GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET; do
-            if [ -z "${!name}" ]; then
-              echo "::error::Missing required staging config: $name"
-              exit 1
-            fi
-          done
-          if [ "$REQUIRE_SHARED_RATE_LIMIT" = "1" ] || [ "$REQUIRE_SHARED_RATE_LIMIT" = "true" ]; then
-            for name in REDIS_URL REDIS_TOKEN; do
-              if [ -z "${!name}" ]; then
-                echo "::error::Missing required staging config for shared rate limiting: $name"
-                exit 1
-              fi
-            done
-          fi
-          case "$SUPABASE_ANON_KEY" in
-            sb_publishable_*) ;;
-            *)
-              echo "::error::Staging SUPABASE_ANON_KEY must be a publishable key"
-              exit 1
-              ;;
-          esac
+          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
+          SMOKE_USER_EMAIL: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          SMOKE_USER_PASSWORD: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
+        run: node scripts/mint-smoke-session.mjs >/dev/null
 
       - name: Resolve expected staging schema version
         id: schema
@@ -91,7 +87,7 @@ jobs:
 
       - name: Wait for staging UI and agent
         run: |
-          for target in "${{ vars.SONDE_STAGING_UI_URL }}/version.json" "${{ vars.SONDE_STAGING_AGENT_HTTP_BASE }}/health"; do
+          for target in "${{ steps.contract.outputs.ui_url }}/version.json" "${{ steps.contract.outputs.agent_url }}/health"; do
             for attempt in $(seq 1 60); do
               if curl -fsS "$target" >/dev/null; then
                 break
@@ -107,27 +103,44 @@ jobs:
       - name: Audit staging deployed stack
         working-directory: server
         env:
-          AUDIT_UI_BASE: ${{ vars.SONDE_STAGING_UI_URL }}
-          AUDIT_AGENT_BASE: ${{ vars.SONDE_STAGING_AGENT_HTTP_BASE }}
-          AUDIT_RUNTIME_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN }}
-          AUDIT_EXPECT_ENVIRONMENT: staging
+          AUDIT_UI_BASE: ${{ steps.contract.outputs.ui_url }}
+          AUDIT_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
+          AUDIT_RUNTIME_TOKEN: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          AUDIT_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
           AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
           AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
-          AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_STAGING_PROJECT_REF }}
-          AUDIT_REQUIRE_AGENT_COMMIT_MATCH: "0"
-          AUDIT_REQUIRE_FIRST_PARTY_AGENT: "0"
-          AUDIT_WAIT_TIMEOUT_MS: "600000"
-          AUDIT_WAIT_INTERVAL_MS: "10000"
+          AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
+          AUDIT_REQUIRE_ANTHROPIC: ${{ steps.contract.outputs.audit_require_anthropic }}
+          AUDIT_REQUIRE_AGENT_COMMIT_MATCH: ${{ steps.contract.outputs.audit_require_agent_commit_match }}
+          AUDIT_REQUIRE_FIRST_PARTY_AGENT: ${{ steps.contract.outputs.audit_require_first_party_agent }}
+          AUDIT_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
+          AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
         run: node scripts/audit-deployed-stack.mjs
 
   production-config-audit:
     if: >-
       ${{
+        github.event_name == 'schedule' ||
         github.ref_name == 'main' ||
         github.event.inputs.target == 'production' ||
         github.event.inputs.target == 'both'
       }}
     runs-on: ubuntu-latest
+    environment: production
+    env:
+      HOSTED_UI_URL: ${{ vars.SONDE_UI_URL || '' }}
+      HOSTED_AGENT_URL: ${{ vars.SONDE_AGENT_HTTP_BASE || '' }}
+      HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF || secrets.SUPABASE_PROJECT_REF || '' }}
+      HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY || '' }}
+      HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_SMOKE_USER_EMAIL || secrets.SONDE_PRODUCTION_SMOKE_USER_EMAIL || '' }}
+      HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_SMOKE_USER_PASSWORD || secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD || '' }}
+      HOSTED_CLI_AUDIT_TOKEN: ${{ secrets.SONDE_CLI_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_CLI_AUDIT_TOKEN || '' }}
+      HOSTED_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN || '' }}
+      HOSTED_REDIS_URL: ${{ vars.SONDE_UPSTASH_REDIS_REST_URL || vars.SONDE_PRODUCTION_UPSTASH_REDIS_REST_URL || '' }}
+      HOSTED_REDIS_TOKEN: ${{ secrets.SONDE_UPSTASH_REDIS_REST_TOKEN || secrets.SONDE_PRODUCTION_UPSTASH_REDIS_REST_TOKEN || '' }}
+      HOSTED_REQUIRE_SHARED_RATE_LIMIT: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT || '' }}
+      HOSTED_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID || '' }}
+      HOSTED_GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET || '' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -136,43 +149,21 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Load hosted production contract
+        id: contract
+        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs production >> "$GITHUB_OUTPUT"
+
       - name: Validate required production config
+        run: node server/scripts/hosted-env-contract.mjs validate production
+
+      - name: Verify production smoke credentials can mint a session
+        working-directory: server
         env:
-          UI_URL: ${{ vars.SONDE_UI_URL }}
-          AGENT_URL: ${{ vars.SONDE_AGENT_HTTP_BASE }}
-          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-          SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY }}
-          SMOKE_USER_EMAIL: ${{ secrets.SONDE_PRODUCTION_SMOKE_USER_EMAIL }}
-          SMOKE_USER_PASSWORD: ${{ secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD }}
-          CLI_AUDIT_TOKEN: ${{ secrets.SONDE_PRODUCTION_CLI_AUDIT_TOKEN }}
-          RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN }}
-          REDIS_URL: ${{ vars.SONDE_PRODUCTION_UPSTASH_REDIS_REST_URL }}
-          REDIS_TOKEN: ${{ secrets.SONDE_PRODUCTION_UPSTASH_REDIS_REST_TOKEN }}
-          REQUIRE_SHARED_RATE_LIMIT: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT || '' }}
-          GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
-        run: |
-          for name in UI_URL AGENT_URL SUPABASE_PROJECT_REF SUPABASE_ANON_KEY SMOKE_USER_EMAIL SMOKE_USER_PASSWORD CLI_AUDIT_TOKEN RUNTIME_AUDIT_TOKEN GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET; do
-            if [ -z "${!name}" ]; then
-              echo "::error::Missing required production config: $name"
-              exit 1
-            fi
-          done
-          if [ "$REQUIRE_SHARED_RATE_LIMIT" = "1" ] || [ "$REQUIRE_SHARED_RATE_LIMIT" = "true" ]; then
-            for name in REDIS_URL REDIS_TOKEN; do
-              if [ -z "${!name}" ]; then
-                echo "::error::Missing required production config for shared rate limiting: $name"
-                exit 1
-              fi
-            done
-          fi
-          case "$SUPABASE_ANON_KEY" in
-            sb_publishable_*) ;;
-            *)
-              echo "::error::Production SUPABASE_ANON_KEY must be a publishable key"
-              exit 1
-              ;;
-          esac
+          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
+          SMOKE_USER_EMAIL: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          SMOKE_USER_PASSWORD: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
+        run: node scripts/mint-smoke-session.mjs >/dev/null
 
       - name: Resolve expected production schema version
         id: schema
@@ -192,7 +183,7 @@ jobs:
 
       - name: Wait for production UI and agent
         run: |
-          for target in "${{ vars.SONDE_UI_URL }}/version.json" "${{ vars.SONDE_AGENT_HTTP_BASE }}/health"; do
+          for target in "${{ steps.contract.outputs.ui_url }}/version.json" "${{ steps.contract.outputs.agent_url }}/health"; do
             for attempt in $(seq 1 60); do
               if curl -fsS "$target" >/dev/null; then
                 break
@@ -208,15 +199,16 @@ jobs:
       - name: Audit production deployed stack
         working-directory: server
         env:
-          AUDIT_UI_BASE: ${{ vars.SONDE_UI_URL }}
-          AUDIT_AGENT_BASE: ${{ vars.SONDE_AGENT_HTTP_BASE }}
-          AUDIT_RUNTIME_TOKEN: ${{ secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN }}
-          AUDIT_EXPECT_ENVIRONMENT: production
+          AUDIT_UI_BASE: ${{ steps.contract.outputs.ui_url }}
+          AUDIT_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
+          AUDIT_RUNTIME_TOKEN: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          AUDIT_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
           AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
           AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
-          AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-          AUDIT_REQUIRE_AGENT_COMMIT_MATCH: "0"
-          AUDIT_REQUIRE_FIRST_PARTY_AGENT: "0"
-          AUDIT_WAIT_TIMEOUT_MS: "600000"
-          AUDIT_WAIT_INTERVAL_MS: "10000"
+          AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
+          AUDIT_REQUIRE_ANTHROPIC: ${{ steps.contract.outputs.audit_require_anthropic }}
+          AUDIT_REQUIRE_AGENT_COMMIT_MATCH: ${{ steps.contract.outputs.audit_require_agent_commit_match }}
+          AUDIT_REQUIRE_FIRST_PARTY_AGENT: ${{ steps.contract.outputs.audit_require_first_party_agent }}
+          AUDIT_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
+          AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
         run: node scripts/audit-deployed-stack.mjs

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -48,14 +48,20 @@ jobs:
           filters: |
             database:
               - 'supabase/**'
+              - 'config/hosted-environments.json'
               - '.github/workflows/deploy-staging.yml'
 
   push-staging-database:
     runs-on: ubuntu-latest
+    environment: staging
     needs: changes
+    env:
+      HOSTED_UI_URL: ${{ vars.SONDE_UI_URL || vars.SONDE_STAGING_UI_URL || '' }}
+      HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF || vars.SUPABASE_STAGING_PROJECT_REF || '' }}
+      HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY || vars.SUPABASE_STAGING_ANON_KEY || '' }}
     if: >-
       ${{
-        vars.SUPABASE_STAGING_PROJECT_REF != '' &&
+        (vars.SUPABASE_PROJECT_REF || vars.SUPABASE_STAGING_PROJECT_REF) != '' &&
         (
           github.event_name == 'workflow_dispatch' ||
           needs.changes.outputs.database == 'true'
@@ -65,12 +71,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Load hosted staging contract
+        id: contract
+        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs staging >> "$GITHUB_OUTPUT"
+
       - uses: supabase/setup-cli@v1
         with:
           version: latest
 
       - name: Link to staging project
-        run: supabase link --project-ref ${{ vars.SUPABASE_STAGING_PROJECT_REF }}
+        run: supabase link --project-ref ${{ steps.contract.outputs.supabase_project_ref }}
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
@@ -96,7 +110,7 @@ jobs:
           supabase config push --workdir "$TMPDIR" --project-ref "${SUPABASE_PROJECT_REF}" --yes
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_STAGING_PROJECT_REF }}
+          SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || '' }}
           SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN: ${{ secrets.SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN || '' }}
           SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
@@ -106,17 +120,17 @@ jobs:
           S3_REGION: ${{ secrets.S3_REGION || '' }}
           S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY || '' }}
           S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY || '' }}
-          SUPABASE_HOSTED_SITE_URL: ${{ vars.SONDE_STAGING_UI_URL }}
-          SUPABASE_HOSTED_ADDITIONAL_REDIRECT_URLS: https://sonde-staging.vercel.app/auth/callback,http://localhost:5173/auth/callback,http://127.0.0.1:5173/auth/callback,http://localhost:*/callback,http://127.0.0.1:*/callback
-          SUPABASE_HOSTED_STORAGE_FILE_SIZE_LIMIT: 50MiB
+          SUPABASE_HOSTED_SITE_URL: ${{ steps.contract.outputs.site_url }}
+          SUPABASE_HOSTED_ADDITIONAL_REDIRECT_URLS: ${{ steps.contract.outputs.redirect_urls_csv }}
+          SUPABASE_HOSTED_STORAGE_FILE_SIZE_LIMIT: ${{ steps.contract.outputs.storage_file_size_limit }}
 
       - name: Verify schema version after staging deploy
-        if: ${{ vars.SUPABASE_STAGING_ANON_KEY != '' }}
+        if: ${{ steps.contract.outputs.supabase_anon_key != '' }}
         run: |
           if VERSION=$(curl -sf \
-            -H "apikey: ${{ vars.SUPABASE_STAGING_ANON_KEY }}" \
-            -H "Authorization: Bearer ${{ vars.SUPABASE_STAGING_ANON_KEY }}" \
-            "https://${{ vars.SUPABASE_STAGING_PROJECT_REF }}.supabase.co/rest/v1/rpc/get_schema_version"); then
+            -H "apikey: ${{ steps.contract.outputs.supabase_anon_key }}" \
+            -H "Authorization: Bearer ${{ steps.contract.outputs.supabase_anon_key }}" \
+            "https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co/rest/v1/rpc/get_schema_version"); then
             echo "Schema version after staging deploy: $VERSION"
           else
             echo "::notice::Skipping strict schema verification because get_schema_version is not reachable with the configured staging publishable key"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,11 +43,15 @@ jobs:
           filters: |
             database:
               - 'supabase/**'
+              - 'config/hosted-environments.json'
               - '.github/workflows/deploy.yml'
 
   push-migrations:
     runs-on: ubuntu-latest
+    environment: production
     needs: changes
+    env:
+      HOSTED_UI_URL: ${{ vars.SONDE_UI_URL || '' }}
     if: >-
       ${{
         needs.changes.outputs.database == 'true' ||
@@ -56,6 +60,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Load hosted production contract
+        id: contract
+        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs production >> "$GITHUB_OUTPUT"
 
       - uses: supabase/setup-cli@v1
         with:
@@ -90,9 +102,9 @@ jobs:
           S3_REGION: ${{ secrets.S3_REGION || '' }}
           S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY || '' }}
           S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY || '' }}
-          SUPABASE_HOSTED_SITE_URL: ${{ vars.SONDE_UI_URL }}
-          SUPABASE_HOSTED_ADDITIONAL_REDIRECT_URLS: https://sonde-neon.vercel.app/auth/callback,https://*.vercel.app/**,http://localhost:5173/auth/callback,http://127.0.0.1:5173/auth/callback,http://localhost:*/callback,http://127.0.0.1:*/callback
-          SUPABASE_HOSTED_STORAGE_FILE_SIZE_LIMIT: 50MiB
+          SUPABASE_HOSTED_SITE_URL: ${{ steps.contract.outputs.site_url }}
+          SUPABASE_HOSTED_ADDITIONAL_REDIRECT_URLS: ${{ steps.contract.outputs.redirect_urls_csv }}
+          SUPABASE_HOSTED_STORAGE_FILE_SIZE_LIMIT: ${{ steps.contract.outputs.storage_file_size_limit }}
 
       - name: Verify schema version after deploy
         run: |

--- a/.github/workflows/reconcile-managed-costs.yml
+++ b/.github/workflows/reconcile-managed-costs.yml
@@ -27,6 +27,7 @@ jobs:
   staging:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == 'staging' }}
     runs-on: ubuntu-latest
+    environment: staging
     steps:
       - uses: actions/checkout@v6
 
@@ -37,8 +38,8 @@ jobs:
       - name: Reconcile staging managed costs
         working-directory: server
         env:
-          MANAGED_COST_RECONCILE_HTTP_BASE: ${{ vars.SONDE_STAGING_AGENT_HTTP_BASE }}
-          MANAGED_COST_RECONCILE_TOKEN: ${{ secrets.SONDE_STAGING_INTERNAL_ADMIN_TOKEN }}
+          MANAGED_COST_RECONCILE_HTTP_BASE: ${{ vars.SONDE_AGENT_HTTP_BASE || vars.SONDE_STAGING_AGENT_HTTP_BASE || '' }}
+          MANAGED_COST_RECONCILE_TOKEN: ${{ secrets.SONDE_INTERNAL_ADMIN_TOKEN || secrets.SONDE_STAGING_INTERNAL_ADMIN_TOKEN || '' }}
           MANAGED_COST_RECONCILE_DAYS: ${{ inputs.days || '7' }}
         run: |
           if [ -z "$MANAGED_COST_RECONCILE_HTTP_BASE" ] || [ -z "$MANAGED_COST_RECONCILE_TOKEN" ]; then
@@ -50,6 +51,7 @@ jobs:
   production:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == 'production' }}
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v6
 
@@ -60,8 +62,8 @@ jobs:
       - name: Reconcile production managed costs
         working-directory: server
         env:
-          MANAGED_COST_RECONCILE_HTTP_BASE: ${{ vars.SONDE_AGENT_HTTP_BASE }}
-          MANAGED_COST_RECONCILE_TOKEN: ${{ secrets.SONDE_PRODUCTION_INTERNAL_ADMIN_TOKEN }}
+          MANAGED_COST_RECONCILE_HTTP_BASE: ${{ vars.SONDE_AGENT_HTTP_BASE || '' }}
+          MANAGED_COST_RECONCILE_TOKEN: ${{ secrets.SONDE_INTERNAL_ADMIN_TOKEN || secrets.SONDE_PRODUCTION_INTERNAL_ADMIN_TOKEN || '' }}
           MANAGED_COST_RECONCILE_DAYS: ${{ inputs.days || '7' }}
         run: |
           if [ -z "$MANAGED_COST_RECONCILE_HTTP_BASE" ] || [ -z "$MANAGED_COST_RECONCILE_TOKEN" ]; then

--- a/.github/workflows/smoke-production.yml
+++ b/.github/workflows/smoke-production.yml
@@ -3,7 +3,6 @@ name: Production Smoke
 on:
   push:
     branches: [main]
-  # Manual trigger for on-demand verification
   workflow_dispatch:
     inputs:
       url:
@@ -18,9 +17,18 @@ on:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    environment: production
     defaults:
       run:
         working-directory: ui
+    env:
+      HOSTED_UI_URL: ${{ vars.SONDE_UI_URL || '' }}
+      HOSTED_AGENT_URL: ${{ vars.SONDE_AGENT_HTTP_BASE || '' }}
+      HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF || secrets.SUPABASE_PROJECT_REF || '' }}
+      HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY || '' }}
+      HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_SMOKE_USER_EMAIL || secrets.SONDE_PRODUCTION_SMOKE_USER_EMAIL || '' }}
+      HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_SMOKE_USER_PASSWORD || secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD || '' }}
+      HOSTED_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN || '' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -36,6 +44,10 @@ jobs:
             ui/package-lock.json
             server/package-lock.json
 
+      - name: Load hosted production contract
+        id: contract
+        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs production >> "$GITHUB_OUTPUT"
+
       - name: Install dependencies
         run: npm ci
 
@@ -49,15 +61,15 @@ jobs:
       - name: Resolve target URL
         id: targets
         env:
-          DEFAULT_UI_URL: ${{ vars.SONDE_UI_URL }}
-          DEFAULT_AGENT_URL: ${{ vars.SONDE_AGENT_HTTP_BASE }}
+          DEFAULT_UI_URL: ${{ steps.contract.outputs.ui_url }}
+          DEFAULT_AGENT_URL: ${{ steps.contract.outputs.agent_url }}
         run: |
           RAW_URL="$(jq -r '.inputs.url // empty' "$GITHUB_EVENT_PATH")"
           RAW_AGENT_URL="$(jq -r '.inputs.agent_url // empty' "$GITHUB_EVENT_PATH")"
           UI_URL="${RAW_URL:-$DEFAULT_UI_URL}"
           AGENT_URL="${RAW_AGENT_URL:-$DEFAULT_AGENT_URL}"
           if [ -z "$UI_URL" ]; then
-            echo "::error::No URL to test. Set SONDE_UI_URL in repo variables or pass a URL via workflow dispatch."
+            echo "::error::No URL to test. Set SONDE_UI_URL for the production environment or pass a URL via workflow dispatch."
             exit 1
           fi
           echo "ui_url=$UI_URL" >> "$GITHUB_OUTPUT"
@@ -116,17 +128,12 @@ jobs:
       - name: Mint production smoke session
         working-directory: server
         env:
-          SUPABASE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co
-          SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY }}
-          SMOKE_USER_EMAIL: ${{ secrets.SONDE_PRODUCTION_SMOKE_USER_EMAIL }}
-          SMOKE_USER_PASSWORD: ${{ secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD }}
+          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
+          SMOKE_USER_EMAIL: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          SMOKE_USER_PASSWORD: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
           SMOKE_SESSION_FILE: ${{ env.PRODUCTION_SMOKE_SESSION_FILE }}
-        run: |
-          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_ANON_KEY" ] || [ -z "$SMOKE_USER_EMAIL" ] || [ -z "$SMOKE_USER_PASSWORD" ]; then
-            echo "::notice::Skipping production smoke session mint because production auth inputs are not fully configured"
-            exit 0
-          fi
-          node scripts/mint-smoke-session.mjs >/dev/null
+        run: node scripts/mint-smoke-session.mjs >/dev/null
 
       - name: Audit deployed production stack
         if: ${{ steps.targets.outputs.agent_url != '' }}
@@ -134,58 +141,44 @@ jobs:
         env:
           AUDIT_UI_BASE: ${{ steps.targets.outputs.ui_url }}
           AUDIT_AGENT_BASE: ${{ steps.targets.outputs.agent_url }}
-          AUDIT_RUNTIME_TOKEN: ${{ secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN }}
-          AUDIT_EXPECT_ENVIRONMENT: production
+          AUDIT_RUNTIME_TOKEN: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          AUDIT_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
           AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
           AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
-          AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-          AUDIT_REQUIRE_AGENT_COMMIT_MATCH: "0"
-          AUDIT_REQUIRE_FIRST_PARTY_AGENT: "0"
-          AUDIT_WAIT_TIMEOUT_MS: "600000"
-          AUDIT_WAIT_INTERVAL_MS: "10000"
+          AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
+          AUDIT_REQUIRE_ANTHROPIC: ${{ steps.contract.outputs.audit_require_anthropic }}
+          AUDIT_REQUIRE_AGENT_COMMIT_MATCH: ${{ steps.contract.outputs.audit_require_agent_commit_match }}
+          AUDIT_REQUIRE_FIRST_PARTY_AGENT: ${{ steps.contract.outputs.audit_require_first_party_agent }}
+          AUDIT_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
+          AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
         run: node scripts/audit-deployed-stack.mjs
 
-      - name: Run production agent chat smoke
+      - name: Run production managed auth audit
         if: ${{ steps.targets.outputs.agent_url != '' }}
         working-directory: server
         env:
-          CHAT_PREWARM_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
-          CHAT_PREWARM_TIMEOUT_MS: "300000"
-          CHAT_PREWARM_RETRY_INTERVAL_MS: "10000"
-          CHAT_SMOKE_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
-          CHAT_SMOKE_PROMPT: "Use Sonde tools to list one accessible program id, then reply with SONDE_SMOKE_OK."
-          CHAT_SMOKE_STALE_SESSION: "1"
-          CHAT_SMOKE_REQUIRE_TOOL_USE: "1"
-          CHAT_SMOKE_EXPECT_SUBSTRING: "SONDE_SMOKE_OK"
-          CHAT_SMOKE_TIMEOUT_MS: "180000"
-          PRODUCTION_SMOKE_SESSION_FILE: ${{ env.PRODUCTION_SMOKE_SESSION_FILE }}
-          FALLBACK_CHAT_SMOKE_TOKEN: ${{ secrets.SONDE_AGENT_CHAT_TOKEN }}
-        run: |
-          if [ -f "$PRODUCTION_SMOKE_SESSION_FILE" ]; then
-            CHAT_SMOKE_TOKEN="$(node -e 'const fs = require("node:fs"); const data = JSON.parse(fs.readFileSync(process.env.PRODUCTION_SMOKE_SESSION_FILE, "utf8")); process.stdout.write((data.access_token ?? "").trim());')"
-            export CHAT_SMOKE_TOKEN
-          fi
-          if [ -z "$CHAT_SMOKE_TOKEN" ]; then
-            export CHAT_SMOKE_TOKEN="$FALLBACK_CHAT_SMOKE_TOKEN"
-          fi
-          if [ -z "$CHAT_SMOKE_TOKEN" ]; then
-            echo "::notice::Skipping production agent chat smoke because no session token or SONDE_AGENT_CHAT_TOKEN is configured"
-            exit 0
-          fi
-          export CHAT_PREWARM_TOKEN="$CHAT_SMOKE_TOKEN"
-          node scripts/prewarm-chat-session.mjs
-          node scripts/chat-smoke.mjs
+          MANAGED_AUTH_AUDIT_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
+          MANAGED_AUTH_AUDIT_PROMPT: ${{ steps.contract.outputs.managed_auth_audit_prompt }}
+          MANAGED_AUTH_AUDIT_STALE_SESSION: ${{ steps.contract.outputs.managed_auth_audit_stale_session }}
+          MANAGED_AUTH_AUDIT_REQUIRE_TOOL_USE: ${{ steps.contract.outputs.managed_auth_audit_require_tool_use }}
+          MANAGED_AUTH_AUDIT_EXPECT_SUBSTRING: ${{ steps.contract.outputs.managed_auth_audit_expect_substring }}
+          MANAGED_AUTH_AUDIT_TIMEOUT_MS: ${{ steps.contract.outputs.managed_auth_audit_timeout_ms }}
+          MANAGED_AUTH_AUDIT_PREWARM_TIMEOUT_MS: ${{ steps.contract.outputs.managed_auth_audit_prewarm_timeout_ms }}
+          MANAGED_AUTH_AUDIT_RETRY_INTERVAL_MS: ${{ steps.contract.outputs.managed_auth_audit_retry_interval_ms }}
+          MANAGED_AUTH_AUDIT_SESSION_FILE: ${{ env.PRODUCTION_SMOKE_SESSION_FILE }}
+        run: node scripts/run-managed-auth-audit.mjs
 
       - name: Run production smoke tests
         env:
           E2E_BASE_URL: ${{ steps.targets.outputs.ui_url }}
-          E2E_DEPLOY_ENVIRONMENT: production
+          E2E_DEPLOY_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
           E2E_AGENT_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
-          E2E_AGENT_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN }}
-          E2E_SUPABASE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co
-          E2E_EXPECT_PROGRAM_ID: shared
-          E2E_EXPECT_TIMELINE_AUTH_MODE: server token
-          E2E_CHAT_PROMPT: "Use Sonde tools to list one accessible program id, then reply with SONDE_SMOKE_OK."
+          E2E_AGENT_RUNTIME_AUDIT_TOKEN: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          E2E_SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          E2E_EXPECT_PROGRAM_ID: ${{ steps.contract.outputs.smoke_expected_program_id }}
+          E2E_EXPECT_EXPERIMENT_ID: ${{ steps.contract.outputs.smoke_expected_experiment_id }}
+          E2E_EXPECT_TIMELINE_AUTH_MODE: ${{ steps.contract.outputs.smoke_expected_timeline_auth_mode }}
+          E2E_CHAT_PROMPT: ${{ steps.contract.outputs.managed_auth_audit_prompt }}
           PRODUCTION_SMOKE_SESSION_FILE: ${{ env.PRODUCTION_SMOKE_SESSION_FILE }}
         run: |
           if [ -f "$PRODUCTION_SMOKE_SESSION_FILE" ]; then

--- a/.github/workflows/smoke-staging.yml
+++ b/.github/workflows/smoke-staging.yml
@@ -17,9 +17,18 @@ on:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    environment: staging
     defaults:
       run:
         working-directory: ui
+    env:
+      HOSTED_UI_URL: ${{ vars.SONDE_UI_URL || vars.SONDE_STAGING_UI_URL || '' }}
+      HOSTED_AGENT_URL: ${{ vars.SONDE_AGENT_HTTP_BASE || vars.SONDE_STAGING_AGENT_HTTP_BASE || '' }}
+      HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF || vars.SUPABASE_STAGING_PROJECT_REF || '' }}
+      HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY || vars.SONDE_STAGING_ANON_KEY || '' }}
+      HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_SMOKE_USER_EMAIL || secrets.SONDE_STAGING_SMOKE_USER_EMAIL || '' }}
+      HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_SMOKE_USER_PASSWORD || secrets.SONDE_STAGING_SMOKE_USER_PASSWORD || '' }}
+      HOSTED_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN || '' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -35,6 +44,10 @@ jobs:
             ui/package-lock.json
             server/package-lock.json
 
+      - name: Load hosted staging contract
+        id: contract
+        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs staging >> "$GITHUB_OUTPUT"
+
       - name: Install dependencies
         run: npm ci
 
@@ -48,15 +61,15 @@ jobs:
       - name: Resolve target URLs
         id: targets
         env:
-          DEFAULT_UI_URL: ${{ vars.SONDE_STAGING_UI_URL }}
-          DEFAULT_AGENT_URL: ${{ vars.SONDE_STAGING_AGENT_HTTP_BASE }}
+          DEFAULT_UI_URL: ${{ steps.contract.outputs.ui_url }}
+          DEFAULT_AGENT_URL: ${{ steps.contract.outputs.agent_url }}
         run: |
           RAW_URL="$(jq -r '.inputs.url // empty' "$GITHUB_EVENT_PATH")"
           RAW_AGENT_URL="$(jq -r '.inputs.agent_url // empty' "$GITHUB_EVENT_PATH")"
           UI_URL="${RAW_URL:-$DEFAULT_UI_URL}"
           AGENT_URL="${RAW_AGENT_URL:-$DEFAULT_AGENT_URL}"
           if [ -z "$UI_URL" ]; then
-            echo "::error::No URL to test. Set SONDE_STAGING_UI_URL in repo variables or pass a URL via workflow dispatch."
+            echo "::error::No URL to test. Set SONDE_UI_URL for the staging environment or pass a URL via workflow dispatch."
             exit 1
           fi
           echo "ui_url=$UI_URL" >> "$GITHUB_OUTPUT"
@@ -115,17 +128,12 @@ jobs:
       - name: Mint staging smoke session
         working-directory: server
         env:
-          SUPABASE_URL: https://${{ vars.SUPABASE_STAGING_PROJECT_REF }}.supabase.co
-          SUPABASE_ANON_KEY: ${{ vars.SUPABASE_STAGING_ANON_KEY }}
-          SMOKE_USER_EMAIL: ${{ secrets.SONDE_STAGING_SMOKE_USER_EMAIL }}
-          SMOKE_USER_PASSWORD: ${{ secrets.SONDE_STAGING_SMOKE_USER_PASSWORD }}
+          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
+          SMOKE_USER_EMAIL: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          SMOKE_USER_PASSWORD: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
           SMOKE_SESSION_FILE: ${{ env.STAGING_SMOKE_SESSION_FILE }}
-        run: |
-          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_ANON_KEY" ] || [ -z "$SMOKE_USER_EMAIL" ] || [ -z "$SMOKE_USER_PASSWORD" ]; then
-            echo "::notice::Skipping staging smoke session mint because staging auth inputs are not fully configured"
-            exit 0
-          fi
-          node scripts/mint-smoke-session.mjs >/dev/null
+        run: node scripts/mint-smoke-session.mjs >/dev/null
 
       - name: Audit deployed staging stack
         if: ${{ steps.targets.outputs.agent_url != '' }}
@@ -133,59 +141,44 @@ jobs:
         env:
           AUDIT_UI_BASE: ${{ steps.targets.outputs.ui_url }}
           AUDIT_AGENT_BASE: ${{ steps.targets.outputs.agent_url }}
-          AUDIT_RUNTIME_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN }}
-          AUDIT_EXPECT_ENVIRONMENT: staging
+          AUDIT_RUNTIME_TOKEN: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          AUDIT_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
           AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
           AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
-          AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_STAGING_PROJECT_REF }}
-          AUDIT_REQUIRE_AGENT_COMMIT_MATCH: "0"
-          AUDIT_REQUIRE_FIRST_PARTY_AGENT: "0"
-          AUDIT_WAIT_TIMEOUT_MS: "600000"
-          AUDIT_WAIT_INTERVAL_MS: "10000"
+          AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
+          AUDIT_REQUIRE_ANTHROPIC: ${{ steps.contract.outputs.audit_require_anthropic }}
+          AUDIT_REQUIRE_AGENT_COMMIT_MATCH: ${{ steps.contract.outputs.audit_require_agent_commit_match }}
+          AUDIT_REQUIRE_FIRST_PARTY_AGENT: ${{ steps.contract.outputs.audit_require_first_party_agent }}
+          AUDIT_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
+          AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
         run: node scripts/audit-deployed-stack.mjs
 
-      - name: Run staging agent chat smoke
+      - name: Run staging managed auth audit
         if: ${{ steps.targets.outputs.agent_url != '' }}
         working-directory: server
         env:
-          CHAT_PREWARM_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
-          CHAT_PREWARM_TIMEOUT_MS: "300000"
-          CHAT_PREWARM_RETRY_INTERVAL_MS: "10000"
-          CHAT_SMOKE_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
-          CHAT_SMOKE_PROMPT: "Use Sonde tools to list one accessible program id, then reply with SONDE_SMOKE_OK."
-          CHAT_SMOKE_STALE_SESSION: "1"
-          CHAT_SMOKE_REQUIRE_TOOL_USE: "1"
-          CHAT_SMOKE_EXPECT_SUBSTRING: "SONDE_SMOKE_OK"
-          CHAT_SMOKE_TIMEOUT_MS: "180000"
-          STAGING_SMOKE_SESSION_FILE: ${{ env.STAGING_SMOKE_SESSION_FILE }}
-          FALLBACK_CHAT_SMOKE_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_CHAT_TOKEN }}
-        run: |
-          if [ -f "$STAGING_SMOKE_SESSION_FILE" ]; then
-            CHAT_SMOKE_TOKEN="$(node -e 'const fs = require("node:fs"); const data = JSON.parse(fs.readFileSync(process.env.STAGING_SMOKE_SESSION_FILE, "utf8")); process.stdout.write((data.access_token ?? "").trim());')"
-            export CHAT_SMOKE_TOKEN
-          fi
-          if [ -z "$CHAT_SMOKE_TOKEN" ]; then
-            export CHAT_SMOKE_TOKEN="$FALLBACK_CHAT_SMOKE_TOKEN"
-          fi
-          if [ -z "$CHAT_SMOKE_TOKEN" ]; then
-            echo "::notice::Skipping staging agent chat smoke because no session token or SONDE_STAGING_AGENT_CHAT_TOKEN is configured"
-            exit 0
-          fi
-          export CHAT_PREWARM_TOKEN="$CHAT_SMOKE_TOKEN"
-          node scripts/prewarm-chat-session.mjs
-          node scripts/chat-smoke.mjs
+          MANAGED_AUTH_AUDIT_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
+          MANAGED_AUTH_AUDIT_PROMPT: ${{ steps.contract.outputs.managed_auth_audit_prompt }}
+          MANAGED_AUTH_AUDIT_STALE_SESSION: ${{ steps.contract.outputs.managed_auth_audit_stale_session }}
+          MANAGED_AUTH_AUDIT_REQUIRE_TOOL_USE: ${{ steps.contract.outputs.managed_auth_audit_require_tool_use }}
+          MANAGED_AUTH_AUDIT_EXPECT_SUBSTRING: ${{ steps.contract.outputs.managed_auth_audit_expect_substring }}
+          MANAGED_AUTH_AUDIT_TIMEOUT_MS: ${{ steps.contract.outputs.managed_auth_audit_timeout_ms }}
+          MANAGED_AUTH_AUDIT_PREWARM_TIMEOUT_MS: ${{ steps.contract.outputs.managed_auth_audit_prewarm_timeout_ms }}
+          MANAGED_AUTH_AUDIT_RETRY_INTERVAL_MS: ${{ steps.contract.outputs.managed_auth_audit_retry_interval_ms }}
+          MANAGED_AUTH_AUDIT_SESSION_FILE: ${{ env.STAGING_SMOKE_SESSION_FILE }}
+        run: node scripts/run-managed-auth-audit.mjs
 
       - name: Run staging smoke tests
         env:
           E2E_BASE_URL: ${{ steps.targets.outputs.ui_url }}
-          E2E_DEPLOY_ENVIRONMENT: staging
+          E2E_DEPLOY_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
           E2E_AGENT_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
-          E2E_AGENT_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN }}
-          E2E_SUPABASE_URL: https://${{ vars.SUPABASE_STAGING_PROJECT_REF }}.supabase.co
-          E2E_EXPECT_PROGRAM_ID: shared
-          E2E_EXPECT_EXPERIMENT_ID: EXP-9001
-          E2E_EXPECT_TIMELINE_AUTH_MODE: server token
-          E2E_CHAT_PROMPT: "Use Sonde tools to list one accessible program id, then reply with SONDE_SMOKE_OK."
+          E2E_AGENT_RUNTIME_AUDIT_TOKEN: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          E2E_SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          E2E_EXPECT_PROGRAM_ID: ${{ steps.contract.outputs.smoke_expected_program_id }}
+          E2E_EXPECT_EXPERIMENT_ID: ${{ steps.contract.outputs.smoke_expected_experiment_id }}
+          E2E_EXPECT_TIMELINE_AUTH_MODE: ${{ steps.contract.outputs.smoke_expected_timeline_auth_mode }}
+          E2E_CHAT_PROMPT: ${{ steps.contract.outputs.managed_auth_audit_prompt }}
           STAGING_SMOKE_SESSION_FILE: ${{ env.STAGING_SMOKE_SESSION_FILE }}
         run: |
           if [ -f "$STAGING_SMOKE_SESSION_FILE" ]; then

--- a/.github/workflows/soak-staging.yml
+++ b/.github/workflows/soak-staging.yml
@@ -22,6 +22,11 @@ permissions:
 jobs:
   soak:
     runs-on: ubuntu-latest
+    environment: staging
+    env:
+      HOSTED_AGENT_URL: ${{ vars.SONDE_AGENT_HTTP_BASE || vars.SONDE_STAGING_AGENT_HTTP_BASE || '' }}
+      HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF || vars.SUPABASE_STAGING_PROJECT_REF || '' }}
+      HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY || vars.SUPABASE_STAGING_ANON_KEY || '' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -57,9 +62,9 @@ jobs:
 
       - name: Wait for staging agent
         run: |
-          AGENT="${{ vars.SONDE_STAGING_AGENT_HTTP_BASE }}"
+          AGENT="${{ env.HOSTED_AGENT_URL }}"
           if [ -z "$AGENT" ]; then
-            echo "::error::SONDE_STAGING_AGENT_HTTP_BASE is not configured"
+            echo "::error::No staging agent URL is configured"
             exit 1
           fi
           for attempt in $(seq 1 60); do
@@ -76,8 +81,8 @@ jobs:
       - name: Provision staging soak sessions
         working-directory: server
         env:
-          SUPABASE_URL: https://${{ vars.SUPABASE_STAGING_PROJECT_REF }}.supabase.co
-          SUPABASE_ANON_KEY: ${{ vars.SUPABASE_STAGING_ANON_KEY }}
+          SUPABASE_URL: https://${{ env.HOSTED_SUPABASE_PROJECT_REF }}.supabase.co
+          SUPABASE_ANON_KEY: ${{ env.HOSTED_SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_STAGING_SERVICE_ROLE_KEY }}
           SMOKE_USER_COUNT: ${{ steps.soak.outputs.concurrency }}
           SMOKE_USER_PREFIX: sonde-staging-soak
@@ -94,7 +99,7 @@ jobs:
 
       - name: Timeline concurrency smoke
         env:
-          AGENT_BASE: ${{ vars.SONDE_STAGING_AGENT_HTTP_BASE }}
+          AGENT_BASE: ${{ env.HOSTED_AGENT_URL }}
           SOAK_SESSION_FILE: ${{ env.SOAK_SESSION_FILE }}
         run: |
           ACCESS_TOKEN="$(node -e 'const fs=require(\"node:fs\"); const file=process.env.SOAK_SESSION_FILE; const data=JSON.parse(fs.readFileSync(file,\"utf8\")); process.stdout.write((data.access_tokens?.[0] ?? \"\").trim());')"
@@ -112,7 +117,7 @@ jobs:
       - name: Run staging chat soak
         working-directory: server
         env:
-          SOAK_CHAT_HTTP_BASE: ${{ vars.SONDE_STAGING_AGENT_HTTP_BASE }}
+          SOAK_CHAT_HTTP_BASE: ${{ env.HOSTED_AGENT_URL }}
           SOAK_SESSION_FILE: ${{ env.SOAK_SESSION_FILE }}
           SOAK_CHAT_CONCURRENCY: ${{ steps.soak.outputs.concurrency }}
           SOAK_CHAT_ROUNDS: ${{ steps.soak.outputs.rounds }}
@@ -131,7 +136,7 @@ jobs:
         if: always()
         working-directory: server
         env:
-          SUPABASE_URL: https://${{ vars.SUPABASE_STAGING_PROJECT_REF }}.supabase.co
+          SUPABASE_URL: https://${{ env.HOSTED_SUPABASE_PROJECT_REF }}.supabase.co
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_STAGING_SERVICE_ROLE_KEY }}
           SMOKE_USERS_FILE: ${{ env.SOAK_USERS_FILE }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev test lint clean ci-local ci-browser ci-data ci-all install-hooks
+.PHONY: setup dev test lint clean ci-local ci-browser ci-data ci-auth ci-all install-hooks
 
 # ── One-command setup for new contributors ──────────────────────────
 
@@ -61,10 +61,14 @@ ci-browser:
 ci-data:
 	@bash scripts/ci/data.sh
 
+ci-auth:
+	@bash scripts/ci/auth.sh
+
 ci-all:
 	@bash scripts/ci/core.sh all
 	@bash scripts/ci/browser.sh all
 	@bash scripts/ci/data.sh
+	@bash scripts/ci/auth.sh
 
 install-hooks:
 	@git config core.hooksPath .githooks

--- a/config/hosted-environments.json
+++ b/config/hosted-environments.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": 1,
+  "parity": {
+    "agentBackend": "managed",
+    "agentUrlRequired": true,
+    "supabaseProjectRefRequired": true,
+    "supabaseAnonKeyRequired": true,
+    "smokeUserRequired": true,
+    "cliAuditTokenRequired": true,
+    "runtimeAuditTokenRequired": true,
+    "googleOAuthRequired": true,
+    "requireManagedAuth": true,
+    "requireSharedRateLimit": false,
+    "storageFileSizeLimit": "50MiB",
+    "expectedProgramId": "shared",
+    "expectedTimelineAuthMode": "server token",
+    "audit": {
+      "requireAnthropic": true,
+      "requireAgentCommitMatch": false,
+      "requireFirstPartyAgent": false,
+      "waitTimeoutMs": 600000,
+      "waitIntervalMs": 10000
+    },
+    "managedAuthAudit": {
+      "prompt": "Use Sonde tools to list one accessible program id, then reply with SONDE_SMOKE_OK.",
+      "expectSubstring": "SONDE_SMOKE_OK",
+      "staleSession": true,
+      "requireToolUse": true,
+      "timeoutMs": 180000,
+      "prewarmTimeoutMs": 300000,
+      "retryIntervalMs": 10000
+    }
+  },
+  "environments": {
+    "staging": {
+      "githubEnvironment": "staging",
+      "runtimeEnvironment": "staging",
+      "uiDefaultUrl": "https://sonde-staging.vercel.app",
+      "supabaseRedirectUrls": [
+        "https://sonde-staging.vercel.app/auth/callback",
+        "http://localhost:5173/auth/callback",
+        "http://127.0.0.1:5173/auth/callback",
+        "http://localhost:*/callback",
+        "http://127.0.0.1:*/callback"
+      ],
+      "expectedExperimentId": "EXP-9001"
+    },
+    "production": {
+      "githubEnvironment": "production",
+      "runtimeEnvironment": "production",
+      "uiDefaultUrl": "https://sonde-neon.vercel.app",
+      "supabaseRedirectUrls": [
+        "https://sonde-neon.vercel.app/auth/callback",
+        "https://*.vercel.app/**",
+        "http://localhost:5173/auth/callback",
+        "http://127.0.0.1:5173/auth/callback",
+        "http://localhost:*/callback",
+        "http://127.0.0.1:*/callback"
+      ],
+      "expectedExperimentId": "EXP-0128"
+    }
+  }
+}

--- a/scripts/ci/auth.sh
+++ b/scripts/ci/auth.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+printf '\n==> Managed auth parity\n'
+
+wait_for_status_json() {
+  local attempt
+
+  for attempt in $(seq 1 20); do
+    if status_json="$(supabase status --output json 2>/tmp/sonde-supabase-auth-status.err)"; then
+      printf '%s\n' "$status_json"
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "::error::supabase status did not become ready for auth parity checks"
+  cat /tmp/sonde-supabase-auth-status.err || true
+  exit 1
+}
+
+wait_for_server() {
+  local url="$1"
+  local log_file="$2"
+  local attempt
+
+  for attempt in $(seq 1 30); do
+    if curl -fsS "$url/health" >/dev/null 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "::error::Managed auth parity server did not become reachable in time"
+  cat "$log_file" || true
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "${server_pid:-}" ]]; then
+    kill "$server_pid" >/dev/null 2>&1 || true
+  fi
+  rm -f "${session_file:-}" "${server_log:-}"
+  supabase stop >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+supabase start
+supabase db reset --local --yes
+
+status_json="$(wait_for_status_json)"
+SB_URL="$(node -e 'const body = JSON.parse(process.argv[1]); process.stdout.write(body.API_URL);' "$status_json")"
+SB_ANON_KEY="$(node -e 'const body = JSON.parse(process.argv[1]); process.stdout.write(body.ANON_KEY);' "$status_json")"
+SB_SERVICE_ROLE_KEY="$(node -e 'const body = JSON.parse(process.argv[1]); process.stdout.write(body.SERVICE_ROLE_KEY);' "$status_json")"
+
+(
+  cd cli
+  uv sync
+)
+
+session_file="$(mktemp "${TMPDIR:-/tmp}/sonde-managed-auth-session.XXXXXX.json")"
+server_log="$(mktemp "${TMPDIR:-/tmp}/sonde-managed-auth-server.XXXXXX.log")"
+server_pid=""
+
+SMOKE_EMAIL="${SMOKE_USER_EMAIL:-smoke-auth@aeolus.earth}"
+SMOKE_PASSWORD="${SMOKE_USER_PASSWORD:-smoke-auth-password}"
+
+(
+  cd server
+  SUPABASE_URL="$SB_URL" \
+  SUPABASE_SERVICE_ROLE_KEY="$SB_SERVICE_ROLE_KEY" \
+  SMOKE_USER_EMAIL="$SMOKE_EMAIL" \
+  SMOKE_USER_PASSWORD="$SMOKE_PASSWORD" \
+  SMOKE_USER_PROGRAMS="${SMOKE_USER_PROGRAMS:-shared}" \
+  node scripts/provision-smoke-user.mjs >/dev/null
+
+  SUPABASE_URL="$SB_URL" \
+  SUPABASE_ANON_KEY="$SB_ANON_KEY" \
+  SMOKE_USER_EMAIL="$SMOKE_EMAIL" \
+  SMOKE_USER_PASSWORD="$SMOKE_PASSWORD" \
+  SMOKE_SESSION_FILE="$session_file" \
+  node scripts/mint-smoke-session.mjs >/dev/null
+)
+
+smoke_token="$(node -e 'const fs = require("node:fs"); const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write((data.access_token ?? "").trim());' "$session_file")"
+if [[ -z "$smoke_token" ]]; then
+  echo "::error::Managed auth parity could not extract an access token from $session_file"
+  exit 1
+fi
+
+pushd server >/dev/null
+NODE_ENV=test \
+SONDE_AGENT_BACKEND=managed \
+SONDE_SERVER_PORT="${SONDE_AUTH_TEST_PORT:-3005}" \
+SONDE_SKIP_CLI_PROBE="1" \
+SONDE_TEST_AGENT_MOCK="1" \
+SONDE_TEST_AUTH_BYPASS_TOKEN="$smoke_token" \
+SONDE_TEST_AUTH_DELAY_MS="25" \
+SONDE_TEST_MANAGED_MOCK_TOOL="${SONDE_TEST_MANAGED_MOCK_TOOL:-sonde_status}" \
+SONDE_TEST_MANAGED_MOCK_FINAL_TEXT="${SONDE_TEST_MANAGED_MOCK_FINAL_TEXT:-SONDE_SMOKE_OK}" \
+ANTHROPIC_API_KEY=test-key \
+SONDE_MANAGED_ENVIRONMENT_ID=env_ci_auth_parity \
+SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT="1" \
+SUPABASE_URL="$SB_URL" \
+SUPABASE_ANON_KEY="$SB_ANON_KEY" \
+SUPABASE_SERVICE_ROLE_KEY="$SB_SERVICE_ROLE_KEY" \
+npx tsx src/index.ts >"$server_log" 2>&1 &
+server_pid=$!
+popd >/dev/null
+
+wait_for_server "http://127.0.0.1:${SONDE_AUTH_TEST_PORT:-3005}" "$server_log"
+
+(
+  cd server
+  MANAGED_AUTH_AUDIT_HTTP_BASE="http://127.0.0.1:${SONDE_AUTH_TEST_PORT:-3005}" \
+  MANAGED_AUTH_AUDIT_SESSION_FILE="$session_file" \
+  MANAGED_AUTH_AUDIT_PROMPT="Use Sonde tools to inspect status and then reply with SONDE_SMOKE_OK." \
+  MANAGED_AUTH_AUDIT_EXPECT_SUBSTRING="SONDE_SMOKE_OK" \
+  MANAGED_AUTH_AUDIT_REQUIRE_TOOL_USE="1" \
+  node scripts/run-managed-auth-audit.mjs
+)

--- a/scripts/ci/hosted-preflight.sh
+++ b/scripts/ci/hosted-preflight.sh
@@ -30,7 +30,9 @@ resolve_agent_http_base() {
   fi
 
   if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-    gh variable get SONDE_STAGING_AGENT_HTTP_BASE 2>/dev/null || true
+    gh variable get SONDE_AGENT_HTTP_BASE 2>/dev/null ||
+      gh variable get SONDE_STAGING_AGENT_HTTP_BASE 2>/dev/null ||
+      true
     return 0
   fi
 
@@ -44,11 +46,14 @@ resolve_app_origin() {
   fi
 
   if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-    gh variable get SONDE_STAGING_UI_URL 2>/dev/null || true
+    gh variable get SONDE_UI_URL 2>/dev/null ||
+      gh variable get SONDE_STAGING_UI_URL 2>/dev/null ||
+      true
     return 0
   fi
 
-  printf 'https://sonde-staging.vercel.app\n'
+  node server/scripts/hosted-env-contract.mjs print-json staging 2>/dev/null |
+    node -e 'const fs = require("node:fs"); const body = JSON.parse(fs.readFileSync(0, "utf8")); console.log(body.uiUrl);'
 }
 
 agent_http_base="$(resolve_agent_http_base | tr -d '\r')"
@@ -56,7 +61,7 @@ app_origin="$(resolve_app_origin | tr -d '\r')"
 
 if [[ -z "$agent_http_base" ]]; then
   if [[ "${SONDE_HOSTED_PREFLIGHT_REQUIRED:-0}" == "1" || -n "${CI:-}" ]]; then
-    echo "::error::Unable to resolve an agent base for hosted preflight. Set SONDE_HOSTED_PREFLIGHT_AGENT_HTTP_BASE or authenticate gh so the script can read SONDE_STAGING_AGENT_HTTP_BASE."
+    echo "::error::Unable to resolve an agent base for hosted preflight. Set SONDE_HOSTED_PREFLIGHT_AGENT_HTTP_BASE or authenticate gh so the script can read SONDE_AGENT_HTTP_BASE/SONDE_STAGING_AGENT_HTTP_BASE."
     exit 1
   fi
   echo "Skipping hosted preflight locally because no hosted agent base could be resolved. Set SONDE_HOSTED_PREFLIGHT_AGENT_HTTP_BASE to enable it."

--- a/security_best_practices_report.md
+++ b/security_best_practices_report.md
@@ -1,0 +1,118 @@
+# Security Best Practices Audit
+
+Branch audited: `codex/fix-ipv6-local-agent-detection`  
+Audit date: `2026-04-13`  
+Scope: first-party code and current worktree state in `cli/`, `ui/`, `server/src`, `supabase/`, `.github/`, `server/scripts`, `scripts/`, `Dockerfile`, and `Makefile`
+
+This review used the `security-best-practices` guidance where it applied cleanly:
+- React / TypeScript frontend security guidance for `ui/`
+- General browser/frontend security guidance for client-side sinks and redirects
+
+Unsupported repo areas such as the Click CLI, Hono server, Supabase SQL/RLS, and deployment workflows were reviewed manually using secure-by-default standards.
+
+## Findings
+
+### SBP-001 — Critical — Workspace-local plaintext secrets in `server/.env`
+- Severity: Critical
+- Location:
+  - [server/.env](/Users/mlee27/code/sonde/server/.env:5)
+  - [server/.env](/Users/mlee27/code/sonde/server/.env:6)
+  - [server/.env](/Users/mlee27/code/sonde/server/.env:9)
+  - [server/.env](/Users/mlee27/code/sonde/server/.env:14)
+  - [server/example.env](/Users/mlee27/code/sonde/server/example.env:1)
+  - [server/example.env](/Users/mlee27/code/sonde/server/example.env:9)
+- Evidence:
+  - The current workspace contains non-empty live-looking credentials in `server/.env`, including a Daytona API key and GitHub token, plus Supabase project values.
+  - The checked-in example explicitly says `Copy to .env in this directory (never commit .env).`
+- Impact:
+  - Anyone with local workspace access, shell history access, backup access, or accidental file sharing can recover active credentials.
+  - If any of these values are already reused elsewhere, compromise can extend beyond this repo.
+- Recommended fix:
+  - Rotate every non-empty secret currently present in `server/.env`.
+  - Replace the file with a freshly generated local-only `.env` using new credentials.
+  - Keep secrets in a secret manager or per-user env injection flow instead of leaving live keys in long-lived plaintext files.
+  - Add a local secret scan to pre-push or CI for defense in depth, even though `.env` is gitignored.
+- False-positive note:
+  - `server/.env` is currently gitignored and not tracked, so this is a workspace-state issue rather than a committed-source leak. It is still a real exposure because the audit scope included the current repo state.
+
+### SBP-002 — High — Program-scoped principals can hard-delete core records and attached artifacts
+- Severity: High
+- Location:
+  - [supabase/migrations/20260329000012_security_hardening.sql](/Users/mlee27/code/sonde/supabase/migrations/20260329000012_security_hardening.sql:13)
+  - [supabase/migrations/20260329000012_security_hardening.sql](/Users/mlee27/code/sonde/supabase/migrations/20260329000012_security_hardening.sql:17)
+  - [supabase/migrations/20260329000012_security_hardening.sql](/Users/mlee27/code/sonde/supabase/migrations/20260329000012_security_hardening.sql:21)
+  - [supabase/migrations/20260329000012_security_hardening.sql](/Users/mlee27/code/sonde/supabase/migrations/20260329000012_security_hardening.sql:25)
+  - [supabase/migrations/20260329000012_security_hardening.sql](/Users/mlee27/code/sonde/supabase/migrations/20260329000012_security_hardening.sql:45)
+  - [supabase/migrations/20260401000006_projects_rls.sql](/Users/mlee27/code/sonde/supabase/migrations/20260401000006_projects_rls.sql:18)
+  - [cli/src/sonde/db/experiments/maintenance.py](/Users/mlee27/code/sonde/cli/src/sonde/db/experiments/maintenance.py:13)
+  - [cli/src/sonde/db/findings.py](/Users/mlee27/code/sonde/cli/src/sonde/db/findings.py:127)
+  - [cli/src/sonde/db/directions.py](/Users/mlee27/code/sonde/cli/src/sonde/db/directions.py:86)
+  - [cli/src/sonde/db/questions.py](/Users/mlee27/code/sonde/cli/src/sonde/db/questions.py:91)
+  - [cli/src/sonde/db/projects.py](/Users/mlee27/code/sonde/cli/src/sonde/db/projects.py:71)
+- Evidence:
+  - Core tables grant `FOR DELETE USING (program = ANY(user_programs()))`, which means any authenticated principal with that program scope can delete rows directly.
+  - The CLI exposes real destructive flows that immediately delete experiments, findings, directions, questions, projects, and linked artifacts.
+- Impact:
+  - A compromised agent token or a mistaken same-program human/agent action can irreversibly remove research records and evidence, not just mutate them.
+  - This is broader than admin-only maintenance; it is ordinary program-scope authorization.
+- Recommended fix:
+  - Restrict hard delete to admins only, or move destructive actions behind privileged RPCs with explicit authorization checks.
+  - Prefer soft delete / tombstones plus an admin restore path for experiments, findings, directions, questions, projects, and artifacts.
+  - Preserve full pre-delete snapshots or immutable delete logs so recovery does not depend on database restore alone.
+- False-positive note:
+  - This may be intentional product policy for now, but it is still a meaningful authorization risk because destructive power is granted to every scoped principal, not just elevated operators.
+
+### SBP-003 — Low — Hosted server always trusts localhost browser origins for CORS
+- Severity: Low
+- Location:
+  - [server/src/app.ts](/Users/mlee27/code/sonde/server/src/app.ts:22)
+  - [server/src/app.ts](/Users/mlee27/code/sonde/server/src/app.ts:135)
+  - [server/src/app.ts](/Users/mlee27/code/sonde/server/src/app.ts:150)
+  - [server/src/app.ts](/Users/mlee27/code/sonde/server/src/app.ts:159)
+- Evidence:
+  - `LOCAL_UI_ORIGINS` hardcodes multiple `localhost` and `127.0.0.1` origins.
+  - `getAllowedOrigins()` always unions those with configured origins, and the result is used for hosted `/chat`, `/mcp/*`, and `/github/*` CORS with `credentials: true`.
+- Impact:
+  - This expands the trusted browser-origin surface on every deployment, including hosted environments that do not need local browser access.
+  - Today this is partially mitigated because the server relies on bearer tokens rather than ambient cookie auth, but it is still unnecessary attack surface and makes future auth changes easier to get wrong.
+- Recommended fix:
+  - Gate localhost origins to development/test only.
+  - In staging/production, require all allowed origins to come from explicit configuration.
+- False-positive note:
+  - I did not find a direct bearer-token theft path from this alone. This is a hardening finding, not a confirmed auth bypass.
+
+### SBP-004 — Low — Predictable fallback secrets are used outside strict environments
+- Severity: Low
+- Location:
+  - [server/src/security-config.ts](/Users/mlee27/code/sonde/server/src/security-config.ts:26)
+  - [server/src/security-config.ts](/Users/mlee27/code/sonde/server/src/security-config.ts:35)
+  - [server/src/security-config.ts](/Users/mlee27/code/sonde/server/src/security-config.ts:105)
+  - [server/src/ws-session-token.ts](/Users/mlee27/code/sonde/server/src/ws-session-token.ts:41)
+- Evidence:
+  - `getWsTokenSecret()` falls back to the static string `sonde-dev-ws-token-secret` outside staging/production.
+  - `getRuntimeAuditToken()` falls back to `sonde-dev-runtime-audit-token` outside staging/production.
+- Impact:
+  - Any internet-exposed dev or preview deployment that forgets to set explicit secrets inherits guessable defaults for protected flows.
+  - For the WebSocket path, a party that knows the fallback secret can forge pre-upgrade session tokens for that environment.
+- Recommended fix:
+  - Remove default secrets entirely, or only allow them when the server is bound to loopback during local development.
+  - Fail closed whenever the server is reachable beyond local-only development.
+- False-positive note:
+  - Staging and production are already guarded by `assertSecurityConfig()`, so this is a preview/dev hardening issue rather than a production bug when environment classification is correct.
+
+## Verified Strengths
+
+These controls looked solid in the current branch and lowered risk materially:
+
+- Safe auth redirect handling rejects off-site redirects and protocol-relative paths in [ui/src/lib/auth-redirect.ts](/Users/mlee27/code/sonde/ui/src/lib/auth-redirect.ts:1).
+- The hosted UI config sets strong response headers, including CSP, HSTS, `X-Frame-Options`, and `Referrer-Policy`, in [ui/vercel.ts](/Users/mlee27/code/sonde/ui/vercel.ts:29).
+- The server verifies access tokens with `supabase.auth.getUser(accessToken)` before trusting user identity, instead of relying on locally decoded claims alone, in [server/src/auth.ts](/Users/mlee27/code/sonde/server/src/auth.ts:60).
+- Test-only auth bypass is guarded so it cannot be enabled outside `NODE_ENV=test` in [server/src/security-config.ts](/Users/mlee27/code/sonde/server/src/security-config.ts:95).
+
+## Recommended Next Steps
+
+1. Rotate and remove all live secrets currently present in `server/.env`.
+2. Narrow hard-delete permissions and add soft-delete or restore-safe tombstones for core research records and artifacts.
+3. Restrict localhost CORS origins to local development only.
+4. Remove predictable fallback secrets for non-strict environments, or make them loopback-only.
+

--- a/server/scripts/audit-deployed-stack.mjs
+++ b/server/scripts/audit-deployed-stack.mjs
@@ -191,12 +191,32 @@ async function main() {
         "Agent runtime metadata is missing managedConfigured"
       );
       ensure(
+        Object.prototype.hasOwnProperty.call(agentRuntime ?? {}, "managedConfigError"),
+        "Agent runtime metadata is missing managedConfigError"
+      );
+      ensure(
         Object.prototype.hasOwnProperty.call(agentRuntime ?? {}, "sondeMcpConfigured"),
         "Agent runtime metadata is missing sondeMcpConfigured"
       );
       ensure(
         Object.prototype.hasOwnProperty.call(agentRuntime ?? {}, "githubConfigured"),
         "Agent runtime metadata is missing githubConfigured"
+      );
+      ensure(
+        Object.prototype.hasOwnProperty.call(agentRuntime ?? {}, "anthropicConfigured"),
+        "Agent runtime metadata is missing anthropicConfigured"
+      );
+      ensure(
+        Object.prototype.hasOwnProperty.call(agentRuntime ?? {}, "anthropicConfigError"),
+        "Agent runtime metadata is missing anthropicConfigError"
+      );
+      ensure(
+        Object.prototype.hasOwnProperty.call(agentRuntime ?? {}, "anthropicAdminConfigured"),
+        "Agent runtime metadata is missing anthropicAdminConfigured"
+      );
+      ensure(
+        Object.prototype.hasOwnProperty.call(agentRuntime ?? {}, "anthropicAdminConfigError"),
+        "Agent runtime metadata is missing anthropicAdminConfigError"
       );
       ensure(
         Object.prototype.hasOwnProperty.call(agentRuntime ?? {}, "cliGitRef"),
@@ -286,6 +306,18 @@ async function main() {
 
       if (requireAnthropic) {
         ensure(agentRuntime.anthropicConfigured, "Agent is missing Anthropic configuration");
+        ensure(
+          !agentRuntime.anthropicConfigError,
+          `Agent Anthropic config is invalid: ${agentRuntime.anthropicConfigError}`,
+        );
+        ensure(
+          agentRuntime.managedConfigured,
+          "Agent managed runtime configuration is invalid",
+        );
+        ensure(
+          !agentRuntime.managedConfigError,
+          `Agent managed runtime config is invalid: ${agentRuntime.managedConfigError}`,
+        );
       }
 
       if (requireSharedRateLimit) {

--- a/server/scripts/chat-smoke-lib.mjs
+++ b/server/scripts/chat-smoke-lib.mjs
@@ -106,6 +106,8 @@ export async function runChatConversation({
     let finalText = "";
     let lastEventType = null;
     let disallowedFailureMarker = null;
+    let failurePhase = null;
+    let failurePreview = null;
 
     const timer = setTimeout(() => {
       ws.close();
@@ -131,8 +133,24 @@ export async function runChatConversation({
         sawVisibleOutput,
         receivedDone,
         finalText,
+        failurePhase,
+        failurePreview,
         durationMs: Date.now() - startedAt,
       });
+    }
+
+    function rememberFailure(text, phase) {
+      if (!text) {
+        return;
+      }
+      const marker =
+        DISALLOWED_CHAT_FAILURE_MARKERS.find((candidate) => text.includes(candidate)) ?? null;
+      if (!marker) {
+        return;
+      }
+      disallowedFailureMarker = disallowedFailureMarker ?? marker;
+      failurePhase = failurePhase ?? phase;
+      failurePreview = failurePreview ?? summarizeText(text);
     }
 
     ws.on("open", () => {});
@@ -160,10 +178,7 @@ export async function runChatConversation({
 
       if (message.type === "text_done") {
         finalText = message.content ?? streamedText;
-        disallowedFailureMarker =
-          disallowedFailureMarker ??
-          DISALLOWED_CHAT_FAILURE_MARKERS.find((marker) => finalText.includes(marker)) ??
-          null;
+        rememberFailure(finalText, "text_done");
       }
 
       if (message.type === "ping") {
@@ -192,8 +207,17 @@ export async function runChatConversation({
       }
 
       if (message.type === "error") {
+        rememberFailure(message.message ?? "", "server_error");
         finish(new Error(`Server returned error: ${message.message}`));
         return;
+      }
+
+      if (message.type === "tool_use_end") {
+        rememberFailure(message.output ?? "", "tool_use_end");
+      }
+
+      if (message.type === "tool_use_error") {
+        rememberFailure(message.error ?? "", "tool_use_error");
       }
 
       if (message.type === "done") {
@@ -220,7 +244,7 @@ export async function runChatConversation({
         if (requireToolUse && disallowedFailureMarker) {
           finish(
             new Error(
-              `Chat completed after surfacing an auth/config failure (${disallowedFailureMarker}). Final text: ${summarizeText(finalText)}`
+              `Chat completed after surfacing an auth/config failure (${disallowedFailureMarker}) during ${failurePhase ?? "chat"}: ${failurePreview ?? summarizeText(finalText)}`
             )
           );
           return;

--- a/server/scripts/hosted-env-contract.mjs
+++ b/server/scripts/hosted-env-contract.mjs
@@ -1,4 +1,5 @@
 import {
+  formatHostedEnvironmentForLogs,
   formatHostedEnvironmentForGithubOutputs,
   loadHostedEnvironmentContract,
   resolveHostedEnvironment,
@@ -61,16 +62,7 @@ function runValidate(environmentName) {
   const summary = {
     status: errors.length === 0 ? "ok" : "error",
     environment: environmentName,
-    uiUrl: resolved.uiUrl,
-    agentUrlConfigured: Boolean(resolved.agentUrl),
-    supabaseProjectRefConfigured: Boolean(resolved.supabaseProjectRef),
-    supabaseAnonKeyConfigured: Boolean(resolved.supabaseAnonKey),
-    smokeUserConfigured:
-      resolved.smokeUserEmailConfigured && resolved.smokeUserPasswordConfigured,
-    cliAuditTokenConfigured: resolved.cliAuditTokenConfigured,
-    runtimeAuditTokenConfigured: resolved.runtimeAuditTokenConfigured,
-    requireSharedRateLimit: resolved.requireSharedRateLimit,
-    redisConfigured: resolved.redisUrlConfigured && resolved.redisTokenConfigured,
+    resolved: formatHostedEnvironmentForLogs(resolved),
     errors,
   };
 
@@ -99,7 +91,7 @@ function runResolveGithubOutputs(environmentName) {
 
 function runPrintJson(environmentName) {
   const resolved = resolveHostedEnvironment(environmentName);
-  console.log(JSON.stringify(resolved, null, 2));
+  console.log(JSON.stringify(formatHostedEnvironmentForLogs(resolved), null, 2));
 }
 
 const command = process.argv[2];

--- a/server/scripts/hosted-env-contract.mjs
+++ b/server/scripts/hosted-env-contract.mjs
@@ -1,0 +1,130 @@
+import {
+  formatHostedEnvironmentForGithubOutputs,
+  loadHostedEnvironmentContract,
+  resolveHostedEnvironment,
+  validateHostedEnvironmentContract,
+  validateResolvedHostedEnvironment,
+} from "./lib/hosted-env-contract.mjs";
+
+function printGithubOutput(name, value) {
+  const normalized = value == null ? "" : String(value);
+  if (!/[\n\r]/.test(normalized)) {
+    console.log(`${name}=${normalized}`);
+    return;
+  }
+
+  const delimiter = `EOF_${name.toUpperCase()}`;
+  console.log(`${name}<<${delimiter}`);
+  console.log(normalized);
+  console.log(delimiter);
+}
+
+function usage() {
+  console.error(
+    "Usage: node server/scripts/hosted-env-contract.mjs <check-parity|validate|resolve-github-outputs|print-json> [environment]",
+  );
+  process.exit(1);
+}
+
+function runCheckParity() {
+  const contract = loadHostedEnvironmentContract();
+  const errors = validateHostedEnvironmentContract(contract);
+  if (errors.length > 0) {
+    for (const error of errors) {
+      console.error(`[hosted-env-contract] ${error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        status: "ok",
+        schemaVersion: contract.schemaVersion,
+        environments: Object.keys(contract.environments ?? {}),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function runValidate(environmentName) {
+  const contract = loadHostedEnvironmentContract();
+  const contractErrors = validateHostedEnvironmentContract(contract);
+  const resolved = resolveHostedEnvironment(environmentName, process.env, contract);
+  const errors = [
+    ...contractErrors,
+    ...validateResolvedHostedEnvironment(resolved),
+  ];
+
+  const summary = {
+    status: errors.length === 0 ? "ok" : "error",
+    environment: environmentName,
+    uiUrl: resolved.uiUrl,
+    agentUrlConfigured: Boolean(resolved.agentUrl),
+    supabaseProjectRefConfigured: Boolean(resolved.supabaseProjectRef),
+    supabaseAnonKeyConfigured: Boolean(resolved.supabaseAnonKey),
+    smokeUserConfigured:
+      resolved.smokeUserEmailConfigured && resolved.smokeUserPasswordConfigured,
+    cliAuditTokenConfigured: resolved.cliAuditTokenConfigured,
+    runtimeAuditTokenConfigured: resolved.runtimeAuditTokenConfigured,
+    requireSharedRateLimit: resolved.requireSharedRateLimit,
+    redisConfigured: resolved.redisUrlConfigured && resolved.redisTokenConfigured,
+    errors,
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+  if (errors.length > 0) {
+    process.exit(1);
+  }
+}
+
+function runResolveGithubOutputs(environmentName) {
+  const contract = loadHostedEnvironmentContract();
+  const contractErrors = validateHostedEnvironmentContract(contract);
+  if (contractErrors.length > 0) {
+    for (const error of contractErrors) {
+      console.error(`[hosted-env-contract] ${error}`);
+    }
+    process.exit(1);
+  }
+
+  const resolved = resolveHostedEnvironment(environmentName, process.env, contract);
+  const outputs = formatHostedEnvironmentForGithubOutputs(resolved);
+  for (const [name, value] of Object.entries(outputs)) {
+    printGithubOutput(name, value);
+  }
+}
+
+function runPrintJson(environmentName) {
+  const resolved = resolveHostedEnvironment(environmentName);
+  console.log(JSON.stringify(resolved, null, 2));
+}
+
+const command = process.argv[2];
+const environmentName = process.argv[3];
+
+if (!command) {
+  usage();
+}
+
+switch (command) {
+  case "check-parity":
+    runCheckParity();
+    break;
+  case "validate":
+    if (!environmentName) usage();
+    runValidate(environmentName);
+    break;
+  case "resolve-github-outputs":
+    if (!environmentName) usage();
+    runResolveGithubOutputs(environmentName);
+    break;
+  case "print-json":
+    if (!environmentName) usage();
+    runPrintJson(environmentName);
+    break;
+  default:
+    usage();
+}

--- a/server/scripts/lib/hosted-env-contract.d.mts
+++ b/server/scripts/lib/hosted-env-contract.d.mts
@@ -1,0 +1,79 @@
+export interface HostedEnvironmentContract {
+  schemaVersion: number;
+  parity: Record<string, unknown>;
+  environments: Record<string, Record<string, unknown>>;
+}
+
+export interface ResolvedHostedEnvironment {
+  schemaVersion: number;
+  name: string;
+  githubEnvironment: string;
+  runtimeEnvironment: string;
+  agentBackend: string;
+  uiUrl: string;
+  agentUrl: string;
+  supabaseProjectRef: string;
+  supabaseAnonKey: string;
+  smokeUserEmailConfigured: boolean;
+  smokeUserPasswordConfigured: boolean;
+  cliAuditTokenConfigured: boolean;
+  runtimeAuditTokenConfigured: boolean;
+  redisUrlConfigured: boolean;
+  redisTokenConfigured: boolean;
+  googleClientIdConfigured: boolean;
+  googleClientSecretConfigured: boolean;
+  requireSharedRateLimit: boolean;
+  requirements: {
+    agentUrlRequired: boolean;
+    supabaseProjectRefRequired: boolean;
+    supabaseAnonKeyRequired: boolean;
+    smokeUserRequired: boolean;
+    cliAuditTokenRequired: boolean;
+    runtimeAuditTokenRequired: boolean;
+    googleOAuthRequired: boolean;
+    requireManagedAuth: boolean;
+  };
+  storageFileSizeLimit: string;
+  supabaseRedirectUrls: string[];
+  expectedProgramId: string;
+  expectedExperimentId: string;
+  expectedTimelineAuthMode: string;
+  audit: {
+    requireAnthropic: boolean;
+    requireAgentCommitMatch: boolean;
+    requireFirstPartyAgent: boolean;
+    waitTimeoutMs: number;
+    waitIntervalMs: number;
+  };
+  managedAuthAudit: {
+    prompt: string;
+    expectSubstring: string;
+    staleSession: boolean;
+    requireToolUse: boolean;
+    timeoutMs: number;
+    prewarmTimeoutMs: number;
+    retryIntervalMs: number;
+  };
+}
+
+export function loadHostedEnvironmentContract(
+  contractPath?: string,
+): HostedEnvironmentContract;
+
+export function validateHostedEnvironmentContract(
+  contract: HostedEnvironmentContract,
+): string[];
+
+export function resolveHostedEnvironment(
+  name: string,
+  env?: NodeJS.ProcessEnv,
+  contract?: HostedEnvironmentContract,
+): ResolvedHostedEnvironment;
+
+export function validateResolvedHostedEnvironment(
+  resolved: ResolvedHostedEnvironment,
+): string[];
+
+export function formatHostedEnvironmentForGithubOutputs(
+  resolved: ResolvedHostedEnvironment,
+): Record<string, string>;

--- a/server/scripts/lib/hosted-env-contract.mjs
+++ b/server/scripts/lib/hosted-env-contract.mjs
@@ -1,0 +1,369 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CONTRACT_PATH = path.resolve(
+  __dirname,
+  "../../../config/hosted-environments.json",
+);
+
+const ALLOWED_ENVIRONMENT_KEYS = new Set([
+  "githubEnvironment",
+  "runtimeEnvironment",
+  "uiDefaultUrl",
+  "agentDefaultUrl",
+  "supabaseRedirectUrls",
+  "expectedExperimentId",
+]);
+
+function trim(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function parseBooleanFlag(value, fallback = false) {
+  const normalized = trim(value).toLowerCase();
+  if (!normalized) return fallback;
+  return normalized === "1" || normalized === "true";
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(trim(value), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isValidUrl(value) {
+  try {
+    const url = new URL(value);
+    return Boolean(url.protocol === "http:" || url.protocol === "https:");
+  } catch {
+    return false;
+  }
+}
+
+function normalizeCsv(values) {
+  return values.map((value) => value.trim()).filter(Boolean).join(",");
+}
+
+export function loadHostedEnvironmentContract(
+  contractPath = DEFAULT_CONTRACT_PATH,
+) {
+  return JSON.parse(fs.readFileSync(contractPath, "utf8"));
+}
+
+export function validateHostedEnvironmentContract(contract) {
+  const errors = [];
+
+  if (contract?.schemaVersion !== 1) {
+    errors.push("Hosted environment contract must declare schemaVersion 1.");
+  }
+
+  const parity = contract?.parity;
+  if (!parity || typeof parity !== "object") {
+    errors.push("Hosted environment contract is missing the parity section.");
+  }
+
+  const environments = contract?.environments;
+  if (!environments || typeof environments !== "object") {
+    errors.push("Hosted environment contract is missing environments.");
+    return errors;
+  }
+
+  for (const name of ["staging", "production"]) {
+    if (!environments[name]) {
+      errors.push(`Hosted environment contract is missing '${name}'.`);
+      continue;
+    }
+    for (const key of Object.keys(environments[name])) {
+      if (!ALLOWED_ENVIRONMENT_KEYS.has(key)) {
+        errors.push(
+          `Hosted environment contract '${name}' contains unsupported key '${key}'.`,
+        );
+      }
+    }
+    if (!trim(environments[name].runtimeEnvironment)) {
+      errors.push(`Hosted environment contract '${name}' is missing runtimeEnvironment.`);
+    }
+    if (!trim(environments[name].uiDefaultUrl)) {
+      errors.push(`Hosted environment contract '${name}' is missing uiDefaultUrl.`);
+    } else if (!isValidUrl(environments[name].uiDefaultUrl)) {
+      errors.push(
+        `Hosted environment contract '${name}' has an invalid uiDefaultUrl.`,
+      );
+    }
+    if (!Array.isArray(environments[name].supabaseRedirectUrls)) {
+      errors.push(
+        `Hosted environment contract '${name}' is missing supabaseRedirectUrls.`,
+      );
+    } else if (environments[name].supabaseRedirectUrls.length === 0) {
+      errors.push(
+        `Hosted environment contract '${name}' must declare at least one Supabase redirect URL.`,
+      );
+    }
+    if (!trim(environments[name].expectedExperimentId)) {
+      errors.push(
+        `Hosted environment contract '${name}' is missing expectedExperimentId.`,
+      );
+    }
+  }
+
+  if (parity) {
+    const requiredParityKeys = [
+      "agentBackend",
+      "agentUrlRequired",
+      "supabaseProjectRefRequired",
+      "supabaseAnonKeyRequired",
+      "smokeUserRequired",
+      "cliAuditTokenRequired",
+      "runtimeAuditTokenRequired",
+      "googleOAuthRequired",
+      "requireManagedAuth",
+      "requireSharedRateLimit",
+      "storageFileSizeLimit",
+      "expectedProgramId",
+      "expectedTimelineAuthMode",
+      "audit",
+      "managedAuthAudit",
+    ];
+    for (const key of requiredParityKeys) {
+      if (!(key in parity)) {
+        errors.push(`Hosted environment parity is missing '${key}'.`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+export function resolveHostedEnvironment(
+  name,
+  env = process.env,
+  contract = loadHostedEnvironmentContract(),
+) {
+  const parity = contract.parity ?? {};
+  const environment = contract.environments?.[name];
+  if (!environment) {
+    throw new Error(`Unknown hosted environment '${name}'.`);
+  }
+
+  return {
+    schemaVersion: contract.schemaVersion,
+    name,
+    githubEnvironment: trim(environment.githubEnvironment) || name,
+    runtimeEnvironment: trim(environment.runtimeEnvironment) || name,
+    agentBackend: trim(parity.agentBackend) || "managed",
+    uiUrl: trim(env.HOSTED_UI_URL) || trim(environment.uiDefaultUrl),
+    agentUrl: trim(env.HOSTED_AGENT_URL) || trim(environment.agentDefaultUrl),
+    supabaseProjectRef: trim(env.HOSTED_SUPABASE_PROJECT_REF),
+    supabaseAnonKey: trim(env.HOSTED_SUPABASE_ANON_KEY),
+    smokeUserEmailConfigured: Boolean(trim(env.HOSTED_SMOKE_USER_EMAIL)),
+    smokeUserPasswordConfigured: Boolean(trim(env.HOSTED_SMOKE_USER_PASSWORD)),
+    cliAuditTokenConfigured: Boolean(trim(env.HOSTED_CLI_AUDIT_TOKEN)),
+    runtimeAuditTokenConfigured: Boolean(trim(env.HOSTED_RUNTIME_AUDIT_TOKEN)),
+    redisUrlConfigured: Boolean(trim(env.HOSTED_REDIS_URL)),
+    redisTokenConfigured: Boolean(trim(env.HOSTED_REDIS_TOKEN)),
+    googleClientIdConfigured: Boolean(trim(env.HOSTED_GOOGLE_CLIENT_ID)),
+    googleClientSecretConfigured: Boolean(trim(env.HOSTED_GOOGLE_CLIENT_SECRET)),
+    requireSharedRateLimit: parseBooleanFlag(
+      env.HOSTED_REQUIRE_SHARED_RATE_LIMIT,
+      Boolean(parity.requireSharedRateLimit),
+    ),
+    requirements: {
+      agentUrlRequired: Boolean(parity.agentUrlRequired),
+      supabaseProjectRefRequired: Boolean(parity.supabaseProjectRefRequired),
+      supabaseAnonKeyRequired: Boolean(parity.supabaseAnonKeyRequired),
+      smokeUserRequired: Boolean(parity.smokeUserRequired),
+      cliAuditTokenRequired: Boolean(parity.cliAuditTokenRequired),
+      runtimeAuditTokenRequired: Boolean(parity.runtimeAuditTokenRequired),
+      googleOAuthRequired: Boolean(parity.googleOAuthRequired),
+      requireManagedAuth: Boolean(parity.requireManagedAuth),
+    },
+    storageFileSizeLimit:
+      trim(environment.storageFileSizeLimit) ||
+      trim(parity.storageFileSizeLimit) ||
+      "50MiB",
+    supabaseRedirectUrls: Array.isArray(environment.supabaseRedirectUrls)
+      ? environment.supabaseRedirectUrls.map((value) => trim(value)).filter(Boolean)
+      : [],
+    expectedProgramId: trim(environment.expectedProgramId) || trim(parity.expectedProgramId),
+    expectedExperimentId: trim(environment.expectedExperimentId),
+    expectedTimelineAuthMode:
+      trim(environment.expectedTimelineAuthMode) ||
+      trim(parity.expectedTimelineAuthMode),
+    audit: {
+      requireAnthropic: Boolean(parity.audit?.requireAnthropic ?? true),
+      requireAgentCommitMatch: Boolean(
+        parity.audit?.requireAgentCommitMatch ?? false,
+      ),
+      requireFirstPartyAgent: Boolean(
+        parity.audit?.requireFirstPartyAgent ?? false,
+      ),
+      waitTimeoutMs: parsePositiveInt(
+        String(parity.audit?.waitTimeoutMs ?? ""),
+        600000,
+      ),
+      waitIntervalMs: parsePositiveInt(
+        String(parity.audit?.waitIntervalMs ?? ""),
+        10000,
+      ),
+    },
+    managedAuthAudit: {
+      prompt: trim(parity.managedAuthAudit?.prompt),
+      expectSubstring: trim(parity.managedAuthAudit?.expectSubstring),
+      staleSession: Boolean(parity.managedAuthAudit?.staleSession),
+      requireToolUse: Boolean(parity.managedAuthAudit?.requireToolUse),
+      timeoutMs: parsePositiveInt(
+        String(parity.managedAuthAudit?.timeoutMs ?? ""),
+        180000,
+      ),
+      prewarmTimeoutMs: parsePositiveInt(
+        String(parity.managedAuthAudit?.prewarmTimeoutMs ?? ""),
+        300000,
+      ),
+      retryIntervalMs: parsePositiveInt(
+        String(parity.managedAuthAudit?.retryIntervalMs ?? ""),
+        10000,
+      ),
+    },
+  };
+}
+
+export function validateResolvedHostedEnvironment(resolved) {
+  const errors = [];
+
+  if (!resolved.uiUrl) {
+    errors.push("HOSTED_UI_URL is required.");
+  } else if (!isValidUrl(resolved.uiUrl)) {
+    errors.push("HOSTED_UI_URL must be a valid http(s) URL.");
+  }
+
+  if (resolved.requirements.agentUrlRequired) {
+    if (!resolved.agentUrl) {
+      errors.push("HOSTED_AGENT_URL is required.");
+    } else if (!isValidUrl(resolved.agentUrl)) {
+      errors.push("HOSTED_AGENT_URL must be a valid http(s) URL.");
+    }
+  } else if (resolved.agentUrl && !isValidUrl(resolved.agentUrl)) {
+    errors.push("HOSTED_AGENT_URL must be a valid http(s) URL.");
+  }
+
+  if (resolved.requirements.supabaseProjectRefRequired && !resolved.supabaseProjectRef) {
+    errors.push("HOSTED_SUPABASE_PROJECT_REF is required.");
+  }
+
+  if (resolved.requirements.supabaseAnonKeyRequired) {
+    if (!resolved.supabaseAnonKey) {
+      errors.push("HOSTED_SUPABASE_ANON_KEY is required.");
+    } else if (!resolved.supabaseAnonKey.startsWith("sb_publishable_")) {
+      errors.push("HOSTED_SUPABASE_ANON_KEY must be a publishable key.");
+    }
+  }
+
+  if (resolved.requirements.smokeUserRequired) {
+    if (!resolved.smokeUserEmailConfigured) {
+      errors.push("HOSTED_SMOKE_USER_EMAIL is required.");
+    }
+    if (!resolved.smokeUserPasswordConfigured) {
+      errors.push("HOSTED_SMOKE_USER_PASSWORD is required.");
+    }
+  }
+
+  if (resolved.requirements.cliAuditTokenRequired && !resolved.cliAuditTokenConfigured) {
+    errors.push("HOSTED_CLI_AUDIT_TOKEN is required.");
+  }
+
+  if (
+    resolved.requirements.runtimeAuditTokenRequired &&
+    !resolved.runtimeAuditTokenConfigured
+  ) {
+    errors.push("HOSTED_RUNTIME_AUDIT_TOKEN is required.");
+  }
+
+  if (resolved.requirements.googleOAuthRequired) {
+    if (!resolved.googleClientIdConfigured) {
+      errors.push("HOSTED_GOOGLE_CLIENT_ID is required.");
+    }
+    if (!resolved.googleClientSecretConfigured) {
+      errors.push("HOSTED_GOOGLE_CLIENT_SECRET is required.");
+    }
+  }
+
+  if (resolved.requireSharedRateLimit) {
+    if (!resolved.redisUrlConfigured) {
+      errors.push("HOSTED_REDIS_URL is required when shared rate limiting is enabled.");
+    }
+    if (!resolved.redisTokenConfigured) {
+      errors.push(
+        "HOSTED_REDIS_TOKEN is required when shared rate limiting is enabled.",
+      );
+    }
+  }
+
+  if (!resolved.expectedProgramId) {
+    errors.push("Hosted environment contract is missing expectedProgramId.");
+  }
+  if (!resolved.expectedExperimentId) {
+    errors.push("Hosted environment contract is missing expectedExperimentId.");
+  }
+  if (!resolved.expectedTimelineAuthMode) {
+    errors.push("Hosted environment contract is missing expectedTimelineAuthMode.");
+  }
+  if (!resolved.managedAuthAudit.prompt) {
+    errors.push("Hosted environment contract is missing managedAuthAudit.prompt.");
+  }
+  if (!resolved.managedAuthAudit.expectSubstring) {
+    errors.push(
+      "Hosted environment contract is missing managedAuthAudit.expectSubstring.",
+    );
+  }
+  if (!resolved.supabaseRedirectUrls.length) {
+    errors.push("Hosted environment contract is missing Supabase redirect URLs.");
+  }
+
+  return errors;
+}
+
+export function formatHostedEnvironmentForGithubOutputs(resolved) {
+  return {
+    schema_version: String(resolved.schemaVersion),
+    github_environment: resolved.githubEnvironment,
+    runtime_environment: resolved.runtimeEnvironment,
+    agent_backend: resolved.agentBackend,
+    ui_url: resolved.uiUrl,
+    agent_url: resolved.agentUrl,
+    supabase_project_ref: resolved.supabaseProjectRef,
+    supabase_anon_key: resolved.supabaseAnonKey,
+    require_shared_rate_limit: String(resolved.requireSharedRateLimit),
+    site_url: resolved.uiUrl,
+    redirect_urls_csv: normalizeCsv(resolved.supabaseRedirectUrls),
+    storage_file_size_limit: resolved.storageFileSizeLimit,
+    smoke_expected_program_id: resolved.expectedProgramId,
+    smoke_expected_experiment_id: resolved.expectedExperimentId,
+    smoke_expected_timeline_auth_mode: resolved.expectedTimelineAuthMode,
+    audit_require_anthropic: String(resolved.audit.requireAnthropic),
+    audit_require_agent_commit_match: String(
+      resolved.audit.requireAgentCommitMatch,
+    ),
+    audit_require_first_party_agent: String(
+      resolved.audit.requireFirstPartyAgent,
+    ),
+    audit_wait_timeout_ms: String(resolved.audit.waitTimeoutMs),
+    audit_wait_interval_ms: String(resolved.audit.waitIntervalMs),
+    managed_auth_audit_prompt: resolved.managedAuthAudit.prompt,
+    managed_auth_audit_expect_substring:
+      resolved.managedAuthAudit.expectSubstring,
+    managed_auth_audit_stale_session: String(
+      resolved.managedAuthAudit.staleSession,
+    ),
+    managed_auth_audit_require_tool_use: String(
+      resolved.managedAuthAudit.requireToolUse,
+    ),
+    managed_auth_audit_timeout_ms: String(resolved.managedAuthAudit.timeoutMs),
+    managed_auth_audit_prewarm_timeout_ms: String(
+      resolved.managedAuthAudit.prewarmTimeoutMs,
+    ),
+    managed_auth_audit_retry_interval_ms: String(
+      resolved.managedAuthAudit.retryIntervalMs,
+    ),
+  };
+}

--- a/server/scripts/lib/hosted-env-contract.mjs
+++ b/server/scripts/lib/hosted-env-contract.mjs
@@ -367,3 +367,32 @@ export function formatHostedEnvironmentForGithubOutputs(resolved) {
     ),
   };
 }
+
+export function formatHostedEnvironmentForLogs(resolved) {
+  return {
+    schemaVersion: resolved.schemaVersion,
+    name: resolved.name,
+    githubEnvironment: resolved.githubEnvironment,
+    runtimeEnvironment: resolved.runtimeEnvironment,
+    agentBackend: resolved.agentBackend,
+    uiUrl: resolved.uiUrl,
+    agentUrl: resolved.agentUrl,
+    supabaseProjectRef: resolved.supabaseProjectRef,
+    requireSharedRateLimit: resolved.requireSharedRateLimit,
+    storageFileSizeLimit: resolved.storageFileSizeLimit,
+    supabaseRedirectUrls: resolved.supabaseRedirectUrls,
+    expectedProgramId: resolved.expectedProgramId,
+    expectedExperimentId: resolved.expectedExperimentId,
+    expectedTimelineAuthMode: resolved.expectedTimelineAuthMode,
+    audit: resolved.audit,
+    managedAuthAudit: {
+      promptConfigured: Boolean(resolved.managedAuthAudit.prompt),
+      expectSubstringConfigured: Boolean(resolved.managedAuthAudit.expectSubstring),
+      staleSession: resolved.managedAuthAudit.staleSession,
+      requireToolUse: resolved.managedAuthAudit.requireToolUse,
+      timeoutMs: resolved.managedAuthAudit.timeoutMs,
+      prewarmTimeoutMs: resolved.managedAuthAudit.prewarmTimeoutMs,
+      retryIntervalMs: resolved.managedAuthAudit.retryIntervalMs,
+    },
+  };
+}

--- a/server/scripts/run-cli-hosted-audit.mjs
+++ b/server/scripts/run-cli-hosted-audit.mjs
@@ -137,6 +137,7 @@ async function main() {
   const sondeToken = process.env.CLI_AUDIT_SONDE_TOKEN?.trim() || "";
   const email = process.env.SMOKE_USER_EMAIL?.trim() || "";
   const password = process.env.SMOKE_USER_PASSWORD?.trim() || "";
+  const requestedAuthMode = (process.env.CLI_AUDIT_AUTH_MODE?.trim() || "auto").toLowerCase();
   const auditEnvironment = process.env.CLI_AUDIT_ENV?.trim() || "staging";
   const auditProgram = process.env.CLI_AUDIT_PROGRAM?.trim() || "shared";
   const expectedExperimentId = process.env.CLI_AUDIT_EXPECT_EXPERIMENT_ID?.trim() || "";
@@ -154,13 +155,23 @@ async function main() {
     AEOLUS_SUPABASE_URL: supabaseUrl,
     AEOLUS_SUPABASE_ANON_KEY: supabaseAnonKey,
   };
+  const authMode =
+    requestedAuthMode === "auto" ? (sondeToken ? "token" : "session") : requestedAuthMode;
 
-  if (sondeToken) {
+  if (!["token", "session"].includes(authMode)) {
+    throw new Error("CLI_AUDIT_AUTH_MODE must be one of: auto, token, session.");
+  }
+
+  if (authMode === "token") {
+    if (!sondeToken) {
+      throw new Error("CLI_AUDIT_AUTH_MODE=token requires CLI_AUDIT_SONDE_TOKEN.");
+    }
     cliEnv.SONDE_TOKEN = sondeToken;
   } else {
+    delete cliEnv.SONDE_TOKEN;
     if (!email || !password) {
       throw new Error(
-        "Set CLI_AUDIT_SONDE_TOKEN or provide SMOKE_USER_EMAIL and SMOKE_USER_PASSWORD."
+        "CLI_AUDIT_AUTH_MODE=session requires SMOKE_USER_EMAIL and SMOKE_USER_PASSWORD."
       );
     }
 
@@ -203,11 +214,11 @@ async function main() {
     }
   }
 
-  if (sondeToken && !whoami.is_agent) {
+  if (authMode === "token" && !whoami.is_agent) {
     throw new Error("CLI audit expected agent-token auth, but whoami reported a human session");
   }
 
-  if (!sondeToken && email && whoami.email !== email) {
+  if (authMode === "session" && email && whoami.email !== email) {
     throw new Error(`CLI authenticated as ${whoami.email}, expected ${email}`);
   }
 
@@ -218,10 +229,11 @@ async function main() {
   const summary = {
     environment: auditEnvironment,
     email: whoami.email,
+    isAgent: whoami.is_agent === true,
     programCount: programs.length,
     allowWrite,
     briefKeys: Object.keys(brief),
-    authMode: sondeToken ? "token" : "session",
+    authMode,
   };
 
   if (expectedExperimentId) {

--- a/server/scripts/run-managed-auth-audit.mjs
+++ b/server/scripts/run-managed-auth-audit.mjs
@@ -1,0 +1,181 @@
+import fs from "node:fs";
+import {
+  parseBooleanFlag,
+  parsePositiveInt,
+  requiredEnv,
+  resolveWsUrl,
+  runChatConversation,
+} from "./chat-smoke-lib.mjs";
+
+async function requestJson(url, init) {
+  const response = await fetch(url, init);
+  const bodyText = await response.text();
+  const body = bodyText ? JSON.parse(bodyText) : null;
+
+  if (!response.ok) {
+    const message =
+      body?.msg ||
+      body?.message ||
+      body?.error_description ||
+      body?.error ||
+      response.statusText;
+    throw new Error(`Supabase request failed (${response.status}): ${message}`);
+  }
+
+  return body;
+}
+
+function readSessionToken(sessionFile) {
+  if (!sessionFile) {
+    return "";
+  }
+  const raw = fs.readFileSync(sessionFile, "utf8");
+  const parsed = JSON.parse(raw);
+  return parsed?.access_token?.trim?.() ?? "";
+}
+
+async function mintSessionToken() {
+  const supabaseUrl = requiredEnv("SUPABASE_URL");
+  const supabaseAnonKey = requiredEnv("SUPABASE_ANON_KEY");
+  const email = requiredEnv("SMOKE_USER_EMAIL");
+  const password = requiredEnv("SMOKE_USER_PASSWORD");
+
+  const session = await requestJson(`${supabaseUrl}/auth/v1/token?grant_type=password`, {
+    method: "POST",
+    headers: {
+      apikey: supabaseAnonKey,
+      Authorization: `Bearer ${supabaseAnonKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ email, password }),
+  });
+
+  return session?.access_token?.trim?.() ?? "";
+}
+
+function buildMessagePayload() {
+  const prompt = (process.env.MANAGED_AUTH_AUDIT_PROMPT ?? process.env.CHAT_SMOKE_PROMPT ?? "").trim();
+  if (!prompt) {
+    throw new Error("Set MANAGED_AUTH_AUDIT_PROMPT or CHAT_SMOKE_PROMPT.");
+  }
+  const staleSession =
+    process.env.MANAGED_AUTH_AUDIT_STALE_SESSION === "1" ||
+    process.env.CHAT_SMOKE_STALE_SESSION === "1";
+  return {
+    type: "message",
+    content: prompt,
+    ...(staleSession
+      ? { sessionId: "deadbeef-dead-beef-dead-beefdeadbeef" }
+      : {}),
+  };
+}
+
+function isRetryablePrewarmFailure(status, bodyText) {
+  if ([502, 503, 504].includes(status)) {
+    return true;
+  }
+  return /chat runtime is not ready/i.test(bodyText);
+}
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function prewarmChatSession(httpBase, token, timeoutMs, retryIntervalMs) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    const response = await fetch(`${httpBase.replace(/\/$/, "")}/chat/prewarm`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const bodyText = await response.text();
+    if (response.ok) {
+      return bodyText;
+    }
+    if (Date.now() >= deadline || !isRetryablePrewarmFailure(response.status, bodyText)) {
+      throw new Error(
+        `Prewarm request failed (${response.status}): ${bodyText.slice(0, 240)}`
+      );
+    }
+    await sleep(retryIntervalMs);
+  }
+}
+
+async function resolveAuditToken() {
+  const explicitToken = process.env.MANAGED_AUTH_AUDIT_TOKEN?.trim();
+  if (explicitToken) {
+    return { authMode: "token", token: explicitToken };
+  }
+
+  const sessionToken = readSessionToken(process.env.MANAGED_AUTH_AUDIT_SESSION_FILE?.trim() || "");
+  if (sessionToken) {
+    return { authMode: "session_file", token: sessionToken };
+  }
+
+  const mintedToken = await mintSessionToken();
+  if (!mintedToken) {
+    throw new Error("Could not mint a smoke session token for managed auth audit.");
+  }
+  return { authMode: "smoke_user", token: mintedToken };
+}
+
+async function main() {
+  const httpBase = requiredEnv("MANAGED_AUTH_AUDIT_HTTP_BASE");
+  const timeoutMs = parsePositiveInt(process.env.MANAGED_AUTH_AUDIT_TIMEOUT_MS, 180_000);
+  const prewarmTimeoutMs = parsePositiveInt(
+    process.env.MANAGED_AUTH_AUDIT_PREWARM_TIMEOUT_MS,
+    300_000
+  );
+  const retryIntervalMs = parsePositiveInt(
+    process.env.MANAGED_AUTH_AUDIT_RETRY_INTERVAL_MS,
+    10_000
+  );
+  const expectedSubstring =
+    process.env.MANAGED_AUTH_AUDIT_EXPECT_SUBSTRING?.trim() ||
+    process.env.CHAT_SMOKE_EXPECT_SUBSTRING?.trim() ||
+    null;
+  const requireToolUse = parseBooleanFlag(
+    (
+      process.env.MANAGED_AUTH_AUDIT_REQUIRE_TOOL_USE ??
+      process.env.CHAT_SMOKE_REQUIRE_TOOL_USE ??
+      ""
+    )
+      .trim()
+      .toLowerCase()
+  );
+
+  const { authMode, token } = await resolveAuditToken();
+  const prewarmMessage = await prewarmChatSession(
+    httpBase,
+    token,
+    prewarmTimeoutMs,
+    retryIntervalMs
+  );
+  const outcome = await runChatConversation({
+    wsUrl: resolveWsUrl({ httpBase }),
+    token,
+    messagePayload: buildMessagePayload(),
+    timeoutMs,
+    expectedSubstring,
+    requireToolUse,
+  });
+
+  console.log(
+    JSON.stringify({
+      authMode,
+      httpBase,
+      prewarmMessage,
+      expectedSubstring,
+      requireToolUse,
+      ...outcome,
+    })
+  );
+}
+
+main().catch((error) => {
+  console.error("[run-managed-auth-audit] Failed:", error.message);
+  process.exit(1);
+});

--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { createApp, getAllowedOrigins } from "./app.js";
 import { resetGitHubCachesForTests } from "./github.js";
+import { resetManagedClientStateForTests } from "./managed/client.js";
+import { resetManagedSessionCacheForTests } from "./managed/session-cache.js";
 
 const originalEnv = { ...process.env };
 const originalFetch = globalThis.fetch;
@@ -14,6 +16,8 @@ beforeEach(() => {
   process.env.SONDE_RUNTIME_AUDIT_TOKEN = "test-runtime-token";
   delete process.env.SONDE_COMMIT_SHA;
   resetGitHubCachesForTests();
+  resetManagedClientStateForTests();
+  resetManagedSessionCacheForTests();
   globalThis.fetch = originalFetch;
 });
 
@@ -21,6 +25,8 @@ afterEach(() => {
   process.env = { ...originalEnv };
   globalThis.fetch = originalFetch;
   resetGitHubCachesForTests();
+  resetManagedClientStateForTests();
+  resetManagedSessionCacheForTests();
 });
 
 describe("createApp", () => {
@@ -82,12 +88,16 @@ describe("createApp", () => {
       schemaVersion: string | null;
       agentBackend: string;
       managedConfigured: boolean;
+      managedConfigError: string | null;
       sondeMcpConfigured: boolean;
       githubConfigured: boolean;
       anthropicConfigured: boolean;
+      anthropicConfigError: string | null;
       anthropicAdminConfigured: boolean;
+      anthropicAdminConfigError: string | null;
       costTelemetryConfigured: boolean;
       liveSpendEnabled: boolean;
+      telemetryRequiresServiceRole: boolean;
       cliGitRef: string | null;
       supabaseProjectRef: string | null;
       sharedRateLimitConfigured: boolean;
@@ -101,10 +111,14 @@ describe("createApp", () => {
       schemaVersion: "20260407000123",
       agentBackend: "managed",
       managedConfigured: false,
+      managedConfigError:
+        "SONDE_MANAGED_ENVIRONMENT_ID is not configured.",
       sondeMcpConfigured: true,
       githubConfigured: false,
       anthropicConfigured: true,
+      anthropicConfigError: null,
       anthropicAdminConfigured: false,
+      anthropicAdminConfigError: "ANTHROPIC_ADMIN_API_KEY is not configured.",
       costTelemetryConfigured: false,
       liveSpendEnabled: false,
       telemetryRequiresServiceRole: false,
@@ -332,6 +346,28 @@ describe("createApp", () => {
     assert.equal(body.status, "ready");
     assert.equal(body.backend, "managed");
     assert.equal(body.session_id, "sesn_test_prewarm");
+  });
+
+  it("returns a structured prewarm error when managed auth is malformed", async () => {
+    process.env.ANTHROPIC_API_KEY = "$(python - <<'PY' print('bad') PY)";
+    process.env.SONDE_MANAGED_ENVIRONMENT_ID = "env_123";
+    process.env.SONDE_MANAGED_AGENT_ID = "agent_123";
+    const app = createApp();
+
+    const response = await app.request("http://localhost/chat/prewarm", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
+    });
+
+    assert.equal(response.status, 503);
+    const body = (await response.json()) as {
+      error: { type: string; message: string };
+    };
+    assert.equal(body.error.type, "chat_runtime_unavailable");
+    assert.match(body.error.message, /unevaluated shell or template syntax/);
+    assert.doesNotMatch(body.error.message, /python - <<'PY'/);
   });
 
   it("rejects unauthenticated GitHub proxy requests", async () => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -17,6 +17,7 @@ import {
   fetchManagedSessions,
 } from "./admin-managed-costs.js";
 import { constantTimeSecretEquals, getInternalAdminToken } from "./security-config.js";
+import { isManagedConfigError } from "./managed/config.js";
 
 const LOCAL_UI_ORIGINS = [
   "http://localhost:5173",
@@ -407,19 +408,28 @@ export function createApp(): Hono {
       return user;
     }
 
-    const startedAt = Date.now();
-    const { prewarmManagedSession } = await import("./managed/session-cache.js");
-    const result = await prewarmManagedSession({
-      user,
-      sondeToken: accessToken,
-    });
-    return c.json({
-      status: "ready",
-      backend: getAgentBackend(),
-      reused: result.reused,
-      duration_ms: Date.now() - startedAt,
-      session_id: result.sessionId,
-    });
+    try {
+      const startedAt = Date.now();
+      const { prewarmManagedSession } = await import("./managed/session-cache.js");
+      const result = await prewarmManagedSession({
+        user,
+        sondeToken: accessToken,
+      });
+      return c.json({
+        status: "ready",
+        backend: getAgentBackend(),
+        reused: result.reused,
+        duration_ms: Date.now() - startedAt,
+        session_id: result.sessionId,
+      });
+    } catch (error) {
+      return errorResponse(
+        c,
+        isManagedConfigError(error) ? 503 : 500,
+        isManagedConfigError(error) ? "chat_runtime_unavailable" : "chat_prewarm_failed",
+        error instanceof Error ? error.message : "Failed to prepare chat runtime.",
+      );
+    }
   });
 
   registerGitHubRoutes(app);

--- a/server/src/chat-session-recovery.test.ts
+++ b/server/src/chat-session-recovery.test.ts
@@ -5,6 +5,8 @@ import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import WebSocket from "ws";
 import { createApp, handleWebSocket } from "./app.js";
+import { resetManagedClientStateForTests } from "./managed/client.js";
+import { resetManagedSessionCacheForTests } from "./managed/session-cache.js";
 import { issueWsSessionToken } from "./ws-session-token.js";
 
 const originalEnv = { ...process.env };
@@ -21,10 +23,14 @@ beforeEach(() => {
     SONDE_MANAGED_ENVIRONMENT_ID: "env_test_managed",
     SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT: "1",
   };
+  resetManagedClientStateForTests();
+  resetManagedSessionCacheForTests();
 });
 
 afterEach(() => {
   process.env = { ...originalEnv };
+  resetManagedClientStateForTests();
+  resetManagedSessionCacheForTests();
 });
 
 describe("chat websocket session recovery", () => {

--- a/server/src/hosted-env-contract.test.ts
+++ b/server/src/hosted-env-contract.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatHostedEnvironmentForGithubOutputs,
+  loadHostedEnvironmentContract,
+  resolveHostedEnvironment,
+  validateHostedEnvironmentContract,
+  validateResolvedHostedEnvironment,
+} from "../scripts/lib/hosted-env-contract.mjs";
+
+describe("hosted environment contract", () => {
+  it("validates the checked-in contract", () => {
+    const contract = loadHostedEnvironmentContract();
+    assert.deepEqual(validateHostedEnvironmentContract(contract), []);
+  });
+
+  it("resolves staging defaults and shared audit expectations", () => {
+    const resolved = resolveHostedEnvironment("staging", {
+      HOSTED_AGENT_URL: "https://agent-staging.example.com",
+      HOSTED_SUPABASE_PROJECT_REF: "stageproj",
+      HOSTED_SUPABASE_ANON_KEY: "sb_publishable_stage",
+      HOSTED_SMOKE_USER_EMAIL: "smoke@aeolus.earth",
+      HOSTED_SMOKE_USER_PASSWORD: "secret",
+      HOSTED_CLI_AUDIT_TOKEN: "cli-audit",
+      HOSTED_RUNTIME_AUDIT_TOKEN: "runtime-audit",
+      HOSTED_GOOGLE_CLIENT_ID: "google-id",
+      HOSTED_GOOGLE_CLIENT_SECRET: "google-secret",
+    });
+
+    assert.equal(resolved.uiUrl, "https://sonde-staging.vercel.app");
+    assert.equal(resolved.agentUrl, "https://agent-staging.example.com");
+    assert.equal(resolved.expectedProgramId, "shared");
+    assert.equal(resolved.expectedExperimentId, "EXP-9001");
+    assert.equal(
+      resolved.managedAuthAudit.expectSubstring,
+      "SONDE_SMOKE_OK",
+    );
+    assert.equal(resolved.storageFileSizeLimit, "50MiB");
+    assert.deepEqual(validateResolvedHostedEnvironment(resolved), []);
+  });
+
+  it("requires redis credentials when shared rate limiting is enabled", () => {
+    const resolved = resolveHostedEnvironment("production", {
+      HOSTED_AGENT_URL: "https://agent.example.com",
+      HOSTED_SUPABASE_PROJECT_REF: "prodproj",
+      HOSTED_SUPABASE_ANON_KEY: "sb_publishable_prod",
+      HOSTED_SMOKE_USER_EMAIL: "smoke@aeolus.earth",
+      HOSTED_SMOKE_USER_PASSWORD: "secret",
+      HOSTED_CLI_AUDIT_TOKEN: "cli-audit",
+      HOSTED_RUNTIME_AUDIT_TOKEN: "runtime-audit",
+      HOSTED_GOOGLE_CLIENT_ID: "google-id",
+      HOSTED_GOOGLE_CLIENT_SECRET: "google-secret",
+      HOSTED_REQUIRE_SHARED_RATE_LIMIT: "true",
+    });
+
+    assert.deepEqual(validateResolvedHostedEnvironment(resolved), [
+      "HOSTED_REDIS_URL is required when shared rate limiting is enabled.",
+      "HOSTED_REDIS_TOKEN is required when shared rate limiting is enabled.",
+    ]);
+  });
+
+  it("formats GitHub outputs with the contract-derived smoke expectations", () => {
+    const resolved = resolveHostedEnvironment("production", {
+      HOSTED_AGENT_URL: "https://agent.example.com",
+      HOSTED_SUPABASE_PROJECT_REF: "prodproj",
+      HOSTED_SUPABASE_ANON_KEY: "sb_publishable_prod",
+    });
+
+    const outputs = formatHostedEnvironmentForGithubOutputs(resolved);
+    assert.equal(outputs.runtime_environment, "production");
+    assert.equal(outputs.site_url, "https://sonde-neon.vercel.app");
+    assert.equal(outputs.smoke_expected_experiment_id, "EXP-0128");
+    assert.match(outputs.redirect_urls_csv, /https:\/\/sonde-neon\.vercel\.app\/auth\/callback/);
+  });
+});

--- a/server/src/managed-chat.test.ts
+++ b/server/src/managed-chat.test.ts
@@ -5,6 +5,8 @@ import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import WebSocket from "ws";
 import { createApp, handleWebSocket } from "./app.js";
+import { resetManagedClientStateForTests } from "./managed/client.js";
+import { resetManagedSessionCacheForTests } from "./managed/session-cache.js";
 import { issueWsSessionToken } from "./ws-session-token.js";
 
 const originalEnv = { ...process.env };
@@ -156,12 +158,16 @@ beforeEach(() => {
     SONDE_MANAGED_ENVIRONMENT_ID: "env_test_managed",
     SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT: "1",
   };
+  resetManagedClientStateForTests();
+  resetManagedSessionCacheForTests();
   globalThis.fetch = originalFetch;
 });
 
 afterEach(() => {
   process.env = { ...originalEnv };
   globalThis.fetch = originalFetch;
+  resetManagedClientStateForTests();
+  resetManagedSessionCacheForTests();
 });
 
 describe("managed chat websocket", () => {

--- a/server/src/managed/client.test.ts
+++ b/server/src/managed/client.test.ts
@@ -109,4 +109,32 @@ describe("normalizeManagedSessionEvent", () => {
     assert.equal(Array.isArray(sessionBodies[0]?.resources), true);
     assert.equal("resources" in sessionBodies[1]!, false);
   });
+
+  it("fails before fetch when the Anthropic API key is malformed", async () => {
+    process.env.ANTHROPIC_API_KEY = "$(python - <<'PY' print('bad') PY)";
+
+    let fetchCalls = 0;
+    globalThis.fetch = async () => {
+      fetchCalls += 1;
+      return new Response("{}");
+    };
+
+    await assert.rejects(
+      () =>
+        createManagedSession({
+          user: {
+            id: "user-1",
+            email: "ci-smoke@aeolus.earth",
+            name: "CI Smoke",
+          },
+          sondeToken: "sonde-token",
+        }),
+      (error) =>
+        error instanceof Error &&
+        error.message.includes("unevaluated shell or template syntax") &&
+        !error.message.includes("python - <<'PY'"),
+    );
+
+    assert.equal(fetchCalls, 0);
+  });
 });

--- a/server/src/managed/client.ts
+++ b/server/src/managed/client.ts
@@ -5,6 +5,10 @@ import { createSondeToolDefinitions } from "../mcp/registry.js";
 import { runSonde } from "../sonde-runner.js";
 import { resolveAgentModel, SYSTEM_PROMPT } from "../agent.js";
 import { z } from "zod";
+import {
+  getAnthropicAdminApiKey,
+  getAnthropicApiKey,
+} from "./config.js";
 
 const ANTHROPIC_API_BASE = "https://api.anthropic.com";
 const ANTHROPIC_VERSION = "2023-06-01";
@@ -82,30 +86,68 @@ export interface AnthropicCostReportResponse {
 }
 
 let ephemeralAgentIdPromise: Promise<string> | null = null;
-const mockManagedPrompts = new Map<string, string>();
+interface MockManagedSessionState {
+  finalText: string;
+  history: ManagedSessionEvent[];
+  pendingToolName: string | null;
+  pendingToolInput: Record<string, unknown>;
+  pendingToolUseId: string | null;
+  phase: "initial" | "awaiting_tool_result" | "final";
+  toolResultText: string | null;
+}
+
+const mockManagedSessions = new Map<string, MockManagedSessionState>();
+
+export function resetManagedClientStateForTests(): void {
+  ephemeralAgentIdPromise = null;
+  mockManagedSessions.clear();
+}
 
 function isMockManagedMode(env: NodeJS.ProcessEnv = process.env): boolean {
   return env.SONDE_TEST_AGENT_MOCK === "1";
 }
 
+function summarizeMockPrompt(text: string): string {
+  const summary = text.replace(/\s+/g, " ").trim().slice(0, 80);
+  return summary || "ok";
+}
+
+function parseMockToolInput(env: NodeJS.ProcessEnv = process.env): Record<string, unknown> {
+  const raw = env.SONDE_TEST_MANAGED_MOCK_TOOL_INPUT?.trim();
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {}
+
+  return {};
+}
+
+function extractMockToolResultText(event: Record<string, unknown>): string | null {
+  const content = event.content;
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const text = content
+    .map((block) =>
+      block && typeof block === "object" && typeof block.text === "string"
+        ? block.text
+        : ""
+    )
+    .filter((value) => value.length > 0)
+    .join("\n")
+    .trim();
+  return text || null;
+}
+
 function getAnthropicBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
   return (env.ANTHROPIC_BASE_URL?.trim() || ANTHROPIC_API_BASE).replace(/\/+$/, "");
-}
-
-function getAnthropicApiKey(env: NodeJS.ProcessEnv = process.env): string {
-  const apiKey = env.ANTHROPIC_API_KEY?.trim();
-  if (!apiKey) {
-    throw new Error("Managed mode requires ANTHROPIC_API_KEY.");
-  }
-  return apiKey;
-}
-
-function getAnthropicAdminApiKey(env: NodeJS.ProcessEnv = process.env): string {
-  const apiKey = env.ANTHROPIC_ADMIN_API_KEY?.trim();
-  if (!apiKey) {
-    throw new Error("Managed cost reconciliation requires ANTHROPIC_ADMIN_API_KEY.");
-  }
-  return apiKey;
 }
 
 function managedHeaders(beta: string = MANAGED_AGENTS_BETA): Record<string, string> {
@@ -351,10 +393,16 @@ export async function createManagedSession(
 ): Promise<string> {
   if (isMockManagedMode()) {
     const sessionId = `sesn_mock_${crypto.randomUUID()}`;
-    mockManagedPrompts.set(
-      sessionId,
-      `Mock response: ${options.user.name ?? options.user.email ?? options.user.id}`,
-    );
+    const pendingToolName = process.env.SONDE_TEST_MANAGED_MOCK_TOOL?.trim() || null;
+    mockManagedSessions.set(sessionId, {
+      finalText: `Mock response: ${options.user.name ?? options.user.email ?? options.user.id}`,
+      history: [],
+      pendingToolName,
+      pendingToolInput: parseMockToolInput(),
+      pendingToolUseId: pendingToolName ? `tool-${crypto.randomUUID()}` : null,
+      phase: pendingToolName ? "initial" : "final",
+      toolResultText: null,
+    });
     return sessionId;
   }
 
@@ -409,19 +457,30 @@ export async function sendManagedEvents(
   events: Record<string, unknown>[]
 ): Promise<void> {
   if (isMockManagedMode()) {
+    const state = mockManagedSessions.get(sessionId);
     for (const event of events) {
-      if (event.type !== "user.message") continue;
-      const content = Array.isArray(event.content) ? event.content : [];
-      const text = content
-        .map((block) =>
-          block && typeof block === "object" && typeof block.text === "string"
-            ? block.text
-            : ""
-        )
-        .join(" ")
-        .trim();
-      const summary = text.replace(/\s+/g, " ").slice(0, 80);
-      mockManagedPrompts.set(sessionId, `Mock response: ${summary || "ok"}`);
+      if (event.type === "user.message" && state) {
+        const content = Array.isArray(event.content) ? event.content : [];
+        const text = content
+          .map((block) =>
+            block && typeof block === "object" && typeof block.text === "string"
+              ? block.text
+              : ""
+          )
+          .join(" ")
+          .trim();
+        state.finalText = `Mock response: ${summarizeMockPrompt(text)}`;
+      }
+
+      if (
+        state &&
+        state.pendingToolName &&
+        event.type === "user.custom_tool_result" &&
+        event.custom_tool_use_id === state.pendingToolUseId
+      ) {
+        state.toolResultText = extractMockToolResultText(event);
+        state.phase = "final";
+      }
     }
     return;
   }
@@ -485,7 +544,10 @@ export async function listManagedSessionEvents(
   sessionId: string
 ): Promise<ManagedSessionEvent[]> {
   if (isMockManagedMode()) {
-    return [];
+    if (!mockManagedSessions.has(sessionId)) {
+      throw new Error(`Invalid session ID: ${sessionId}`);
+    }
+    return mockManagedSessions.get(sessionId)?.history ?? [];
   }
   const response = await fetchManagedJson<ManagedEventListResponse>(
     `/v1/sessions/${sessionId}/events`
@@ -600,16 +662,51 @@ export async function* streamManagedSessionEvents(
 ): AsyncIterable<ManagedSessionEvent> {
   if (isMockManagedMode()) {
     if (signal.aborted) return;
-    yield {
+    const state = mockManagedSessions.get(sessionId);
+    if (!state) {
+      return;
+    }
+
+    if (state.pendingToolName && state.phase === "initial") {
+      state.phase = "awaiting_tool_result";
+      const toolEvent: ManagedSessionEvent = {
+        id: state.pendingToolUseId ?? `tool-${sessionId}`,
+        type: "agent.custom_tool_use",
+        name: state.pendingToolName,
+        input: state.pendingToolInput,
+      };
+      const idleEvent: ManagedSessionEvent = {
+        id: `mock-idle-awaiting-${sessionId}`,
+        type: "session.status_idle",
+        stop_reason: {
+          type: "requires_action",
+          event_ids: [state.pendingToolUseId ?? `tool-${sessionId}`],
+        },
+      };
+      state.history = [...state.history.filter((event) => event.id !== toolEvent.id), toolEvent];
+      state.history = [...state.history.filter((event) => event.id !== idleEvent.id), idleEvent];
+      yield toolEvent;
+      yield idleEvent;
+      return;
+    }
+
+    const finalText = state.toolResultText
+      ? process.env.SONDE_TEST_MANAGED_MOCK_FINAL_TEXT?.trim() || state.toolResultText
+      : state.finalText;
+    const messageEvent: ManagedSessionEvent = {
       id: `mock-msg-${sessionId}`,
       type: "agent.message",
-      content: [{ type: "text", text: mockManagedPrompts.get(sessionId) ?? "Mock response: ok" }],
+      content: [{ type: "text", text: finalText || "Mock response: ok" }],
     };
-    yield {
-      id: `mock-idle-${sessionId}`,
+    const idleEvent: ManagedSessionEvent = {
+      id: `mock-idle-final-${sessionId}`,
       type: "session.status_idle",
       stop_reason: { type: "end_turn" },
     };
+    state.history = [...state.history.filter((event) => event.id !== messageEvent.id), messageEvent];
+    state.history = [...state.history.filter((event) => event.id !== idleEvent.id), idleEvent];
+    yield messageEvent;
+    yield idleEvent;
     return;
   }
   const response = await fetch(`${getAnthropicBaseUrl()}/v1/sessions/${sessionId}/stream?beta=true`, {

--- a/server/src/managed/config.test.ts
+++ b/server/src/managed/config.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  ManagedConfigError,
+  assertManagedRuntimeConfig,
+  getAnthropicAdminApiKey,
+  getAnthropicAdminApiKeyStatus,
+  getAnthropicApiKey,
+  getAnthropicApiKeyStatus,
+  getManagedRuntimeConfigStatus,
+  isManagedConfigError,
+} from "./config.js";
+
+describe("managed config", () => {
+  it("accepts a valid Anthropic API key", () => {
+    const status = getAnthropicApiKeyStatus({
+      ANTHROPIC_API_KEY: "sk-ant-api03-valid-key",
+    });
+
+    assert.equal(status.configured, true);
+    assert.equal(status.valid, true);
+    assert.equal(status.value, "sk-ant-api03-valid-key");
+    assert.equal(status.error, null);
+  });
+
+  it("rejects command-substitution syntax", () => {
+    const status = getAnthropicApiKeyStatus({
+      ANTHROPIC_API_KEY: "$(python - <<'PY' print('bad') PY)",
+    });
+
+    assert.equal(status.configured, true);
+    assert.equal(status.valid, false);
+    assert.match(status.error ?? "", /unevaluated shell or template syntax/);
+  });
+
+  it("rejects multiline header values", () => {
+    const status = getAnthropicApiKeyStatus({
+      ANTHROPIC_API_KEY: "line-one\nline-two",
+    });
+
+    assert.equal(status.configured, true);
+    assert.equal(status.valid, false);
+    assert.match(status.error ?? "", /single-line header-safe secret/);
+  });
+
+  it("builds managed runtime status from validated secrets and ids", () => {
+    const status = getManagedRuntimeConfigStatus({
+      ANTHROPIC_API_KEY: "sk-ant-api03-valid-key",
+      SONDE_MANAGED_ENVIRONMENT_ID: "env_prod",
+      SONDE_MANAGED_AGENT_ID: "agent_prod",
+    });
+
+    assert.equal(status.managedConfigured, true);
+    assert.equal(status.managedConfigError, null);
+    assert.equal(status.anthropic.valid, true);
+  });
+
+  it("reports the first blocking managed config issue", () => {
+    const status = getManagedRuntimeConfigStatus({
+      ANTHROPIC_API_KEY: "sk-ant-api03-valid-key",
+      SONDE_MANAGED_ENVIRONMENT_ID: "",
+    });
+
+    assert.equal(status.managedConfigured, false);
+    assert.match(status.managedConfigError ?? "", /SONDE_MANAGED_ENVIRONMENT_ID/);
+  });
+
+  it("throws sanitized managed config errors", () => {
+    assert.throws(
+      () =>
+        getAnthropicApiKey({
+          ANTHROPIC_API_KEY: "$(python - <<'PY' print('bad') PY)",
+        }),
+      (error) =>
+        error instanceof ManagedConfigError &&
+        error.message.includes("unevaluated shell or template syntax") &&
+        !error.message.includes("python - <<'PY'"),
+    );
+  });
+
+  it("treats managed config errors as typed errors", () => {
+    try {
+      assertManagedRuntimeConfig({
+        ANTHROPIC_API_KEY: "sk-ant-api03-valid-key",
+        SONDE_MANAGED_ENVIRONMENT_ID: "env_prod",
+      });
+      assert.fail("Expected assertManagedRuntimeConfig to throw");
+    } catch (error) {
+      assert.equal(isManagedConfigError(error), true);
+    }
+  });
+
+  it("validates the optional admin key with the same header-safe rules", () => {
+    const invalidStatus = getAnthropicAdminApiKeyStatus({
+      ANTHROPIC_ADMIN_API_KEY: "bad value",
+    });
+    assert.equal(invalidStatus.valid, false);
+
+    assert.equal(
+      getAnthropicAdminApiKey({
+        ANTHROPIC_ADMIN_API_KEY: "sk-ant-admin-valid-key",
+      }),
+      "sk-ant-admin-valid-key",
+    );
+  });
+});

--- a/server/src/managed/config.ts
+++ b/server/src/managed/config.ts
@@ -1,0 +1,173 @@
+export class ManagedConfigError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "ManagedConfigError";
+    this.code = code;
+  }
+}
+
+export interface ManagedSecretStatus {
+  configured: boolean;
+  valid: boolean;
+  value: string | null;
+  error: string | null;
+}
+
+export interface ManagedRuntimeConfigStatus {
+  anthropic: ManagedSecretStatus;
+  anthropicAdmin: ManagedSecretStatus;
+  managedConfigured: boolean;
+  managedConfigError: string | null;
+}
+
+function secretSyntaxError(name: string): string {
+  return `${name} appears to contain unevaluated shell or template syntax.`;
+}
+
+function secretFormatError(name: string): string {
+  return `${name} must be a single-line header-safe secret.`;
+}
+
+function missingSecretError(name: string): string {
+  return `${name} is not configured.`;
+}
+
+function validateHeaderSafeSecret(
+  name: string,
+  rawValue: string | undefined,
+): ManagedSecretStatus {
+  const value = rawValue?.trim() ?? "";
+  if (!value) {
+    return {
+      configured: false,
+      valid: false,
+      value: null,
+      error: missingSecretError(name),
+    };
+  }
+
+  if (
+    value.startsWith("$(") ||
+    value.includes("${") ||
+    value.includes("`") ||
+    value.includes("<<")
+  ) {
+    return {
+      configured: true,
+      valid: false,
+      value: null,
+      error: secretSyntaxError(name),
+    };
+  }
+
+  if (/[\s\u0000-\u001f\u007f]/.test(value)) {
+    return {
+      configured: true,
+      valid: false,
+      value: null,
+      error: secretFormatError(name),
+    };
+  }
+
+  return {
+    configured: true,
+    valid: true,
+    value,
+    error: null,
+  };
+}
+
+function missingManagedEnvironmentError(): string {
+  return "SONDE_MANAGED_ENVIRONMENT_ID is not configured.";
+}
+
+function missingManagedAgentError(): string {
+  return "SONDE_MANAGED_AGENT_ID is not configured and SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT=1 is not enabled.";
+}
+
+export function getAnthropicApiKeyStatus(
+  env: NodeJS.ProcessEnv = process.env,
+): ManagedSecretStatus {
+  return validateHeaderSafeSecret("ANTHROPIC_API_KEY", env.ANTHROPIC_API_KEY);
+}
+
+export function getAnthropicAdminApiKeyStatus(
+  env: NodeJS.ProcessEnv = process.env,
+): ManagedSecretStatus {
+  return validateHeaderSafeSecret(
+    "ANTHROPIC_ADMIN_API_KEY",
+    env.ANTHROPIC_ADMIN_API_KEY,
+  );
+}
+
+export function getManagedRuntimeConfigStatus(
+  env: NodeJS.ProcessEnv = process.env,
+): ManagedRuntimeConfigStatus {
+  const anthropic = getAnthropicApiKeyStatus(env);
+  const anthropicAdmin = getAnthropicAdminApiKeyStatus(env);
+  const environmentId = env.SONDE_MANAGED_ENVIRONMENT_ID?.trim() ?? "";
+  const agentId = env.SONDE_MANAGED_AGENT_ID?.trim() ?? "";
+  const allowEphemeralAgent = env.SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT === "1";
+
+  let managedConfigError: string | null = null;
+  if (!anthropic.valid) {
+    managedConfigError = anthropic.error;
+  } else if (!environmentId) {
+    managedConfigError = missingManagedEnvironmentError();
+  } else if (!agentId && !allowEphemeralAgent) {
+    managedConfigError = missingManagedAgentError();
+  }
+
+  return {
+    anthropic,
+    anthropicAdmin,
+    managedConfigured: managedConfigError === null,
+    managedConfigError,
+  };
+}
+
+export function getAnthropicApiKey(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const status = getAnthropicApiKeyStatus(env);
+  if (!status.valid || !status.value) {
+    throw new ManagedConfigError(
+      "anthropic_api_key_invalid",
+      status.error ?? missingSecretError("ANTHROPIC_API_KEY"),
+    );
+  }
+  return status.value;
+}
+
+export function getAnthropicAdminApiKey(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const status = getAnthropicAdminApiKeyStatus(env);
+  if (!status.valid || !status.value) {
+    throw new ManagedConfigError(
+      "anthropic_admin_api_key_invalid",
+      status.error ?? missingSecretError("ANTHROPIC_ADMIN_API_KEY"),
+    );
+  }
+  return status.value;
+}
+
+export function assertManagedRuntimeConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  const status = getManagedRuntimeConfigStatus(env);
+  if (!status.managedConfigured) {
+    throw new ManagedConfigError(
+      "managed_runtime_config_invalid",
+      status.managedConfigError ?? "Claude Managed Agents are not configured.",
+    );
+  }
+}
+
+export function isManagedConfigError(
+  error: unknown,
+): error is ManagedConfigError {
+  return error instanceof ManagedConfigError;
+}

--- a/server/src/managed/session-cache.ts
+++ b/server/src/managed/session-cache.ts
@@ -154,3 +154,13 @@ export function takePrewarmedManagedSession(userId: string): string | null {
 export function rememberManagedSession(sessionId: string): void {
   getReplayState(sessionId);
 }
+
+export function resetManagedSessionCacheForTests(): void {
+  for (const timer of prewarmTimers.values()) {
+    clearTimeout(timer);
+  }
+  prewarmedSessions.clear();
+  knownSessions.clear();
+  prewarmInFlight.clear();
+  prewarmTimers.clear();
+}

--- a/server/src/runtime-metadata.ts
+++ b/server/src/runtime-metadata.ts
@@ -6,6 +6,7 @@ import {
 import { hasGitHubAccess } from "./github.js";
 import { hasSupabaseTelemetryConfig, telemetryRequiresServiceRole } from "./supabase.js";
 import { getManagedSessionCostThresholds } from "./managed/pricing.js";
+import { getManagedRuntimeConfigStatus } from "./managed/config.js";
 
 export interface RuntimeMetadata {
   status: "ok";
@@ -17,7 +18,10 @@ export interface RuntimeMetadata {
   sondeMcpConfigured: boolean;
   githubConfigured: boolean;
   anthropicConfigured: boolean;
+  anthropicConfigError: string | null;
   anthropicAdminConfigured: boolean;
+  anthropicAdminConfigError: string | null;
+  managedConfigError: string | null;
   costTelemetryConfigured: boolean;
   liveSpendEnabled: boolean;
   telemetryRequiresServiceRole: boolean;
@@ -57,11 +61,7 @@ export function getSupabaseProjectRef(
 export function getRuntimeMetadata(
   env: NodeJS.ProcessEnv = process.env
 ): RuntimeMetadata {
-  const managedConfigured =
-    Boolean(env.ANTHROPIC_API_KEY?.trim()) &&
-    Boolean(env.SONDE_MANAGED_ENVIRONMENT_ID?.trim()) &&
-    (Boolean(env.SONDE_MANAGED_AGENT_ID?.trim()) ||
-      env.SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT === "1");
+  const managedStatus = getManagedRuntimeConfigStatus(env);
   const thresholds = getManagedSessionCostThresholds(env);
   return {
     status: "ok",
@@ -69,16 +69,16 @@ export function getRuntimeMetadata(
     commitSha: env.SONDE_COMMIT_SHA?.trim() || null,
     schemaVersion: env.SONDE_SCHEMA_VERSION?.trim() || null,
     agentBackend: getAgentBackend(env),
-    managedConfigured,
-    sondeMcpConfigured:
-      Boolean(env.SONDE_PUBLIC_AGENT_BASE_URL?.trim()) ||
-      Boolean(env.SONDE_MANAGED_SONDE_MCP_URL?.trim()) ||
-      true,
+    managedConfigured: managedStatus.managedConfigured,
+    sondeMcpConfigured: true,
     githubConfigured: hasGitHubAccess(env),
-    anthropicConfigured: Boolean(env.ANTHROPIC_API_KEY?.trim()),
-    anthropicAdminConfigured: Boolean(env.ANTHROPIC_ADMIN_API_KEY?.trim()),
+    anthropicConfigured: managedStatus.anthropic.valid,
+    anthropicConfigError: managedStatus.anthropic.error,
+    anthropicAdminConfigured: managedStatus.anthropicAdmin.valid,
+    anthropicAdminConfigError: managedStatus.anthropicAdmin.error,
+    managedConfigError: managedStatus.managedConfigError,
     costTelemetryConfigured: hasSupabaseTelemetryConfig(env),
-    liveSpendEnabled: Boolean(env.ANTHROPIC_API_KEY?.trim()) && managedConfigured,
+    liveSpendEnabled: managedStatus.managedConfigured,
     telemetryRequiresServiceRole: telemetryRequiresServiceRole(env),
     managedSessionWarnUsd: thresholds.warnUsd,
     managedSessionCriticalUsd: thresholds.criticalUsd,

--- a/server/src/security-config.test.ts
+++ b/server/src/security-config.test.ts
@@ -48,4 +48,31 @@ describe("assertSecurityConfig", () => {
       /Shared Redis rate limiting is required/,
     );
   });
+
+  it("requires managed Anthropic runtime config in strict environments", () => {
+    assert.throws(
+      () =>
+        assertSecurityConfig({
+          NODE_ENV: "production",
+          SONDE_WS_TOKEN_SECRET: "ws",
+          SONDE_RUNTIME_AUDIT_TOKEN: "audit",
+        }),
+      /ANTHROPIC_API_KEY is not configured/,
+    );
+  });
+
+  it("rejects malformed managed Anthropic auth in strict environments", () => {
+    assert.throws(
+      () =>
+        assertSecurityConfig({
+          NODE_ENV: "production",
+          SONDE_WS_TOKEN_SECRET: "ws",
+          SONDE_RUNTIME_AUDIT_TOKEN: "audit",
+          ANTHROPIC_API_KEY: "$(python - <<'PY' print('bad') PY)",
+          SONDE_MANAGED_ENVIRONMENT_ID: "env_prod",
+          SONDE_MANAGED_AGENT_ID: "agent_prod",
+        }),
+      /unevaluated shell or template syntax/,
+    );
+  });
 });

--- a/server/src/security-config.ts
+++ b/server/src/security-config.ts
@@ -1,4 +1,5 @@
 import { timingSafeEqual, createHash } from "node:crypto";
+import { assertManagedRuntimeConfig } from "./managed/config.js";
 
 function getEnvironment(env: NodeJS.ProcessEnv = process.env): string {
   return (
@@ -129,6 +130,8 @@ export function assertSecurityConfig(
       "SONDE_GITHUB_ALLOWED_REPOS must be set when a server GitHub token is configured",
     );
   }
+
+  assertManagedRuntimeConfig(env);
 }
 
 export function constantTimeSecretEquals(

--- a/server/src/sonde-runner.test.ts
+++ b/server/src/sonde-runner.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildSondeEnv } from "./sonde-runner.js";
+
+describe("buildSondeEnv", () => {
+  it("maps server Supabase env into the CLI AEOLUS env names", () => {
+    const env = buildSondeEnv(
+      {
+        SUPABASE_URL: "https://staging.example.supabase.co",
+        SUPABASE_ANON_KEY: "staging-anon-key",
+        SUPABASE_SERVICE_ROLE_KEY: "staging-service-role",
+      },
+      "human-access-token"
+    );
+
+    assert.equal(env.SONDE_TOKEN, "human-access-token");
+    assert.equal(env.AEOLUS_SUPABASE_URL, "https://staging.example.supabase.co");
+    assert.equal(env.AEOLUS_SUPABASE_ANON_KEY, "staging-anon-key");
+    assert.equal(env.AEOLUS_SUPABASE_SERVICE_ROLE_KEY, "staging-service-role");
+  });
+
+  it("preserves explicit CLI env overrides ahead of server defaults", () => {
+    const env = buildSondeEnv(
+      {
+        AEOLUS_SUPABASE_URL: "https://cli.example.supabase.co",
+        AEOLUS_SUPABASE_ANON_KEY: "cli-anon-key",
+        AEOLUS_SUPABASE_SERVICE_ROLE_KEY: "cli-service-role",
+        SUPABASE_URL: "https://server.example.supabase.co",
+        SUPABASE_ANON_KEY: "server-anon-key",
+        SUPABASE_SERVICE_ROLE_KEY: "server-service-role",
+      },
+      "bot-access-token"
+    );
+
+    assert.equal(env.AEOLUS_SUPABASE_URL, "https://cli.example.supabase.co");
+    assert.equal(env.AEOLUS_SUPABASE_ANON_KEY, "cli-anon-key");
+    assert.equal(env.AEOLUS_SUPABASE_SERVICE_ROLE_KEY, "cli-service-role");
+  });
+});

--- a/server/src/sonde-runner.ts
+++ b/server/src/sonde-runner.ts
@@ -13,6 +13,57 @@ export function getResolvedSondeCliDir(): string | null {
   return memoizedCliDir;
 }
 
+function firstNonEmpty(...values: Array<string | undefined | null>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+export function buildSondeEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  sondeToken: string
+): Record<string, string> {
+  const env: Record<string, string> = {
+    ...(baseEnv as Record<string, string>),
+    SONDE_TOKEN: sondeToken,
+  };
+
+  const supabaseUrl = firstNonEmpty(
+    baseEnv.AEOLUS_SUPABASE_URL,
+    baseEnv.SUPABASE_URL,
+    baseEnv.VITE_SUPABASE_URL
+  );
+  if (supabaseUrl) {
+    env.AEOLUS_SUPABASE_URL = supabaseUrl;
+  }
+
+  const supabaseAnonKey = firstNonEmpty(
+    baseEnv.AEOLUS_SUPABASE_ANON_KEY,
+    baseEnv.AEOLUS_SUPABASE_KEY,
+    baseEnv.SUPABASE_ANON_KEY,
+    baseEnv.VITE_SUPABASE_ANON_KEY,
+    baseEnv.SUPABASE_KEY,
+    baseEnv.VITE_SUPABASE_KEY
+  );
+  if (supabaseAnonKey) {
+    env.AEOLUS_SUPABASE_ANON_KEY = supabaseAnonKey;
+  }
+
+  const serviceRoleKey = firstNonEmpty(
+    baseEnv.AEOLUS_SUPABASE_SERVICE_ROLE_KEY,
+    baseEnv.SUPABASE_SERVICE_ROLE_KEY
+  );
+  if (serviceRoleKey) {
+    env.AEOLUS_SUPABASE_SERVICE_ROLE_KEY = serviceRoleKey;
+  }
+
+  return env;
+}
+
 /**
  * Run a sonde CLI command and return the result as an MCP CallToolResult.
  * Pass the session Supabase access token as `sondeToken` (same as SONDE_TOKEN for the CLI).
@@ -36,10 +87,7 @@ export async function runSonde(
     };
   }
 
-  const env: Record<string, string> = {
-    ...(process.env as Record<string, string>),
-    SONDE_TOKEN: sondeToken,
-  };
+  const env = buildSondeEnv(process.env, sondeToken);
 
   try {
     const { stdout, stderr, exitCode } = await execFileWithExitCode("uv", ["run", "sonde", ...args], {

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -25,4 +25,10 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    files: ['src/routes/**/*.{ts,tsx}'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 )

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
     "test:e2e:smoke": "playwright test e2e/ci-smoke.spec.ts --project=chromium --project=firefox",
     "test:e2e:hosted": "playwright test e2e/hosted-smoke.spec.ts --project=chromium --project=firefox --reporter=github",
     "test:e2e:headed": "playwright test --headed",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/ui/src/components/artifacts/embedded-document-preview.tsx
+++ b/ui/src/components/artifacts/embedded-document-preview.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { Download, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
 

--- a/ui/src/components/chat/canvas-bubble.tsx
+++ b/ui/src/components/chat/canvas-bubble.tsx
@@ -5,7 +5,6 @@ import { cn } from "@/lib/utils";
 import { toCanvasRect } from "@/lib/assistant-canvas-layout";
 import { useSetCanvasBubbleRect } from "@/stores/assistant-canvas-layout";
 import { ChatInput } from "./chat-input";
-import { ChatInstallCta } from "./chat-install-cta";
 
 const SUGGESTIONS = [
   {
@@ -153,11 +152,6 @@ export const CanvasBubble = memo(function CanvasBubble({
               {label}
             </button>
           ))}
-        </div>
-      </div>
-      <div className="pointer-events-auto absolute bottom-3 right-3 z-10 w-[min(100%,42rem)] sm:bottom-4 sm:right-4">
-        <div className="ml-auto max-w-[42rem]">
-          <ChatInstallCta />
         </div>
       </div>
     </div>

--- a/ui/src/components/chat/chat-artifact-preview.tsx
+++ b/ui/src/components/chat/chat-artifact-preview.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { memo } from "react";
 import { useArtifacts } from "@/hooks/use-artifacts";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/ui/src/components/chat/chat-empty-state.tsx
+++ b/ui/src/components/chat/chat-empty-state.tsx
@@ -2,7 +2,6 @@ import { memo } from "react";
 import { getWelcomeGreeting } from "@/lib/welcome-name";
 import { useAuthStore } from "@/stores/auth";
 import { cn } from "@/lib/utils";
-import { ChatInstallCta } from "./chat-install-cta";
 
 interface ChatEmptyStateProps {
   /** Embedded column: tighter vertical rhythm (experiment page, etc.). */
@@ -39,11 +38,6 @@ export const ChatEmptyState = memo(function ChatEmptyState({
             Use <kbd className="rounded-[2px] border border-border px-1">@</kbd>{" "}
             to reference projects, directions, experiments, findings, or programs
           </p>
-        </div>
-      </div>
-      <div className="pointer-events-auto absolute bottom-3 right-3 z-10 w-[min(100%,34rem)] sm:bottom-4 sm:right-4">
-        <div className="ml-auto max-w-[34rem]">
-          <ChatInstallCta compact />
         </div>
       </div>
     </div>

--- a/ui/src/components/chat/chat-tool-activity.tsx
+++ b/ui/src/components/chat/chat-tool-activity.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { memo, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import {

--- a/ui/src/components/chat/mention-chip.tsx
+++ b/ui/src/components/chat/mention-chip.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import type { ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
 import { cn } from "@/lib/utils";

--- a/ui/src/components/experiments/git-provenance.tsx
+++ b/ui/src/components/experiments/git-provenance.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { memo } from "react";
 import { GitCommit, GitBranch, AlertTriangle, ExternalLink } from "lucide-react";
 import type { ExperimentSummary } from "@/types/sonde";

--- a/ui/src/contexts/chat-page-context.tsx
+++ b/ui/src/contexts/chat-page-context.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, type ReactNode } from "react";
 import type { PageContext } from "@/types/chat";
 

--- a/ui/src/hooks/use-admin.ts
+++ b/ui/src/hooks/use-admin.ts
@@ -414,8 +414,11 @@ export interface AdminRuntimeMetadata {
   environment: string;
   agentBackend: "managed";
   managedConfigured: boolean;
+  managedConfigError: string | null;
   anthropicConfigured: boolean;
+  anthropicConfigError: string | null;
   anthropicAdminConfigured: boolean;
+  anthropicAdminConfigError: string | null;
   costTelemetryConfigured: boolean;
   liveSpendEnabled: boolean;
   telemetryRequiresServiceRole: boolean;

--- a/ui/src/lib/linkify-sonde-ids.test.ts
+++ b/ui/src/lib/linkify-sonde-ids.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { linkifySondeRecordIds, recordIdToHref } from "./linkify-sonde-ids";
+
+describe("recordIdToHref", () => {
+  it("maps supported record ids to routes", () => {
+    expect(recordIdToHref("EXP-0001")).toBe("/experiments/EXP-0001");
+    expect(recordIdToHref("proj-0002")).toBe("/projects/PROJ-0002");
+    expect(recordIdToHref("DIR-0042")).toBe("/directions/DIR-0042");
+  });
+});
+
+describe("linkifySondeRecordIds", () => {
+  it("linkifies bare experiment and project ids", () => {
+    expect(linkifySondeRecordIds("Compare EXP-0001 with PROJ-0002.")).toBe(
+      "Compare [EXP-0001](/experiments/EXP-0001) with [PROJ-0002](/projects/PROJ-0002).",
+    );
+  });
+
+  it("linkifies ids wrapped in markdown emphasis", () => {
+    expect(linkifySondeRecordIds("See **EXP-0001** and _proj-0002_.")).toBe(
+      "See **[EXP-0001](/experiments/EXP-0001)** and _[proj-0002](/projects/PROJ-0002)_.",
+    );
+  });
+
+  it("linkifies bracketed record refs, including bolded ids", () => {
+    expect(linkifySondeRecordIds("See [EXP-0001] and [**PROJ-0002**].")).toBe(
+      "See [EXP-0001](/experiments/EXP-0001) and [**PROJ-0002**](/projects/PROJ-0002).",
+    );
+  });
+
+  it("does not rewrite existing markdown links", () => {
+    expect(
+      linkifySondeRecordIds("Existing [EXP-0001](/experiments/EXP-0001) link."),
+    ).toBe("Existing [EXP-0001](/experiments/EXP-0001) link.");
+  });
+
+  it("does not touch fenced code or inline code", () => {
+    expect(linkifySondeRecordIds("`EXP-0001` and ```PROJ-0002```")).toBe(
+      "`EXP-0001` and ```PROJ-0002```",
+    );
+  });
+});

--- a/ui/src/lib/linkify-sonde-ids.ts
+++ b/ui/src/lib/linkify-sonde-ids.ts
@@ -5,7 +5,7 @@
 
 /** Matches EXP-0123, find-0001, proj-001, q-42, etc. */
 export const SONDE_RECORD_ID_REGEX =
-  /\b(EXP|FIND|DIR|Q|PROJ|ART)-[A-Za-z0-9]+\b/g;
+  /(?<![A-Za-z0-9])(EXP|FIND|DIR|Q|PROJ|ART)-[A-Za-z0-9]+(?![A-Za-z0-9])/g;
 
 export type SondeRecordLinkTarget =
   | { to: "/experiments/$id"; params: { id: string } }
@@ -68,12 +68,35 @@ function mask(text: string, pattern: RegExp, chunks: string[]): string {
   });
 }
 
+function linkifyBracketedRecordRefs(text: string): string {
+  return text.replace(/\[([^[\]\n]+)\](?!\()/g, (full, label: string) => {
+    const ids = [...label.matchAll(new RegExp(SONDE_RECORD_ID_REGEX.source, "gi"))];
+    if (ids.length !== 1) return full;
+
+    const id = ids[0]?.[0];
+    if (!id) return full;
+
+    const href = recordIdToHref(id);
+    if (!href) return full;
+
+    const stripped = label.replace(
+      new RegExp(SONDE_RECORD_ID_REGEX.source, "gi"),
+      "",
+    );
+    if (!/^[\s*_~`]*$/.test(stripped)) return full;
+
+    return `[${label}](${href})`;
+  });
+}
+
 export function linkifySondeRecordIds(text: string): string {
   const chunks: string[] = [];
 
   let masked = text;
   masked = mask(masked, /```[\s\S]*?```/g, chunks);
   masked = mask(masked, /`[^`]+`/g, chunks);
+  masked = mask(masked, /\[([^\]]*)\]\(([^)]*)\)/g, chunks);
+  masked = linkifyBracketedRecordRefs(masked);
   masked = mask(masked, /\[([^\]]*)\]\(([^)]*)\)/g, chunks);
 
   const idRe = new RegExp(SONDE_RECORD_ID_REGEX.source, "gi");

--- a/ui/src/routes/pages/admin-dashboard.tsx
+++ b/ui/src/routes/pages/admin-dashboard.tsx
@@ -163,6 +163,23 @@ export default function AdminDashboard() {
   const selectedSessionSamples = selectedSessionDetail?.samples ?? [];
   const selectedSessionEvents = selectedSessionDetail?.events ?? [];
   const latestSyncRun = managedSummary?.latestSuccessfulSync ?? managedSummary?.latestAttemptedSync ?? null;
+  const runtimeConfigIssues = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          [
+            runtimeMetadata?.managedConfigError,
+            runtimeMetadata?.anthropicConfigError,
+            runtimeMetadata?.anthropicAdminConfigError,
+          ].filter((issue): issue is string => Boolean(issue))
+        )
+      ),
+    [
+      runtimeMetadata?.anthropicAdminConfigError,
+      runtimeMetadata?.anthropicConfigError,
+      runtimeMetadata?.managedConfigError,
+    ],
+  );
 
   useEffect(() => {
     if (runtimeMetadata?.environment && managedEnvironment === "") {
@@ -339,12 +356,22 @@ export default function AdminDashboard() {
                 <p className="mt-1 font-medium text-text">
                   {runtimeMetadata?.managedConfigured ? "Configured" : "Missing managed config"}
                 </p>
+                {runtimeMetadata?.managedConfigError && (
+                  <p className="mt-1 text-[11px] leading-relaxed text-status-failed">
+                    {runtimeMetadata.managedConfigError}
+                  </p>
+                )}
               </div>
               <div className="rounded-[8px] border border-border-subtle bg-surface-raised px-3 py-2 text-[12px]">
                 <p className="text-text-tertiary">Admin reconciliation</p>
                 <p className="mt-1 font-medium text-text">
                   {runtimeMetadata?.anthropicAdminConfigured ? "Provider-backed" : "Estimated only"}
                 </p>
+                {runtimeMetadata?.anthropicAdminConfigError && (
+                  <p className="mt-1 text-[11px] leading-relaxed text-status-failed">
+                    {runtimeMetadata.anthropicAdminConfigError}
+                  </p>
+                )}
               </div>
               <div className="rounded-[8px] border border-border-subtle bg-surface-raised px-3 py-2 text-[12px]">
                 <p className="text-text-tertiary">Telemetry writes</p>
@@ -379,6 +406,18 @@ export default function AdminDashboard() {
                 </p>
               </div>
             </div>
+            {runtimeConfigIssues.length > 0 && (
+              <div className="mt-3 rounded-[8px] border border-status-failed/20 bg-status-failed/5 px-3 py-3">
+                <p className="text-[11px] font-medium text-status-failed">
+                  Managed runtime issues
+                </p>
+                <div className="mt-1 space-y-1 text-[11px] leading-relaxed text-status-failed">
+                  {runtimeConfigIssues.map((issue) => (
+                    <p key={issue}>{issue}</p>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
 
           <div className={cardClass}>

--- a/ui/src/routes/pages/brief.tsx
+++ b/ui/src/routes/pages/brief.tsx
@@ -232,13 +232,13 @@ export default function BriefPage() {
   const { data: projectTakeawayRows, isLoading: loadingProjectTakeaways } =
     useProjectTakeawaysInProgram(program);
 
-  const exps = experiments ?? [];
+  const exps = useMemo(() => experiments ?? [], [experiments]);
   const finds = useMemo(
     () => sortFindingsByImportanceAndRecency(findings ?? []),
     [findings]
   );
-  const dirs = directions ?? [];
-  const projs = projects ?? [];
+  const dirs = useMemo(() => directions ?? [], [directions]);
+  const projs = useMemo(() => projects ?? [], [projects]);
 
   const projectById = useMemo(() => new Map(projs.map((p) => [p.id, p])), [projs]);
   const directionById = useMemo(() => new Map(dirs.map((d) => [d.id, d])), [dirs]);


### PR DESCRIPTION
## Summary
- harden the managed-agent auth path so human-session tool auth failures fail early
- add shared local/PR CI entrypoints including managed auth parity
- move hosted config and smoke validation earlier so staging catches less late surprise drift

## What changed
- add managed auth audit and strengthen chat smoke failure classification
- run hosted CLI audit in both bot-token and human-session modes
- add local and PR `ci-auth` coverage for the human-session managed-tool path
- improve Sonde CLI env propagation from the server into managed tool execution
- tighten hosted smoke/config audit workflow behavior so staging failures are clearer and earlier

## Validation
- `make ci-local`
- `make ci-browser`
- `make ci-data`
- `make ci-auth`
