### PR TITLE
fix: restore hosted agent deploy parity

### DIFF
--- a/.github/workflows/config-audit.yml
+++ b/.github/workflows/config-audit.yml
@@ -100,6 +100,18 @@ jobs:
             done
           done
 
+      - name: Wait for staging agent runtime parity
+        working-directory: server
+        env:
+          PARITY_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
+          PARITY_RUNTIME_TOKEN: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
+          PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_WAIT_TIMEOUT_MS: 600000
+          PARITY_WAIT_INTERVAL_MS: 10000
+        run: node scripts/wait-for-runtime-parity.mjs
+
       - name: Audit staging deployed stack
         working-directory: server
         env:
@@ -195,6 +207,18 @@ jobs:
               sleep 10
             done
           done
+
+      - name: Wait for production agent runtime parity
+        working-directory: server
+        env:
+          PARITY_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
+          PARITY_RUNTIME_TOKEN: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
+          PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_WAIT_TIMEOUT_MS: 600000
+          PARITY_WAIT_INTERVAL_MS: 10000
+        run: node scripts/wait-for-runtime-parity.mjs
 
       - name: Audit production deployed stack
         working-directory: server

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-ref
     outputs:
+      agent: ${{ steps.filter.outputs.agent }}
       database: ${{ steps.filter.outputs.database }}
     steps:
       - uses: actions/checkout@v6
@@ -48,6 +49,13 @@ jobs:
           filters: |
             database:
               - 'supabase/**'
+              - 'config/hosted-environments.json'
+              - '.github/workflows/deploy-staging.yml'
+            agent:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - 'cli/**'
+              - 'server/**'
               - 'config/hosted-environments.json'
               - '.github/workflows/deploy-staging.yml'
 
@@ -135,3 +143,124 @@ jobs:
           else
             echo "::notice::Skipping strict schema verification because get_schema_version is not reachable with the configured staging publishable key"
           fi
+
+  deploy-staging-agent:
+    runs-on: ubuntu-latest
+    environment: staging
+    needs:
+      - changes
+      - push-staging-database
+    if: >-
+      ${{
+        always() &&
+        (
+          needs.push-staging-database.result == 'success' ||
+          needs.push-staging-database.result == 'skipped'
+        ) &&
+        (
+          needs.changes.outputs.agent == 'true' ||
+          (
+            github.event_name == 'workflow_dispatch' &&
+            !inputs.seed_only
+          )
+        )
+      }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Load hosted staging contract
+        id: contract
+        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs staging >> "$GITHUB_OUTPUT"
+
+      - name: Resolve staging schema version
+        id: schema
+        if: ${{ steps.contract.outputs.supabase_project_ref != '' && steps.contract.outputs.supabase_anon_key != '' }}
+        run: |
+          VERSION=$(curl -sf \
+            -H "apikey: ${{ steps.contract.outputs.supabase_anon_key }}" \
+            -H "Authorization: Bearer ${{ steps.contract.outputs.supabase_anon_key }}" \
+            "https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co/rest/v1/rpc/get_schema_version" | tr -d '"')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Verify Railway staging token
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_STAGING_PROJECT_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_STAGING_PROJECT_ID }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ] || [ -z "$RAILWAY_PROJECT_ID" ]; then
+            echo "::error::Missing Railway staging project token or project id"
+            exit 1
+          fi
+          railway service status \
+            -e "${{ vars.RAILWAY_STAGING_ENVIRONMENT_ID }}" \
+            -s "${{ vars.RAILWAY_STAGING_SERVICE_NAME }}" \
+            --json >/tmp/railway-staging-status.json
+
+      - name: Pin staged agent runtime metadata
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_STAGING_PROJECT_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_STAGING_PROJECT_ID }}
+          SONDE_MANAGED_ENVIRONMENT_ID: ${{ vars.SONDE_ANTHROPIC_MANAGED_ENVIRONMENT_ID }}
+          SONDE_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          SONDE_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN }}
+          SONDE_WS_TOKEN_SECRET: ${{ secrets.SONDE_STAGING_WS_TOKEN_SECRET }}
+          SONDE_GITHUB_ALLOWED_REPOS: ${{ vars.SONDE_GITHUB_ALLOWED_REPOS }}
+        run: |
+          if [ -z "$SONDE_MANAGED_ENVIRONMENT_ID" ]; then
+            echo "::error::Missing SONDE_ANTHROPIC_MANAGED_ENVIRONMENT_ID repository variable"
+            exit 1
+          fi
+          SCHEMA_VERSION="${SONDE_SCHEMA_VERSION:-unknown}"
+          railway variable delete \
+            -s "${{ vars.RAILWAY_STAGING_SERVICE_NAME }}" \
+            -e "${{ vars.RAILWAY_STAGING_ENVIRONMENT_ID }}" \
+            SONDE_MANAGED_AGENT_ID || true
+          railway variable set \
+            -s "${{ vars.RAILWAY_STAGING_SERVICE_NAME }}" \
+            -e "${{ vars.RAILWAY_STAGING_ENVIRONMENT_ID }}" \
+            --skip-deploys \
+            VITE_SUPABASE_URL="https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co" \
+            VITE_SUPABASE_ANON_KEY="${{ steps.contract.outputs.supabase_anon_key }}" \
+            SONDE_AGENT_BACKEND="managed" \
+            SONDE_MANAGED_ENVIRONMENT_ID="${SONDE_MANAGED_ENVIRONMENT_ID}" \
+            SONDE_MANAGED_AGENT_ID=" " \
+            SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT="1" \
+            SONDE_ALLOWED_ORIGINS="${{ steps.contract.outputs.site_url }}" \
+            SONDE_ENVIRONMENT="staging" \
+            SONDE_COMMIT_SHA="${GITHUB_SHA}" \
+            SONDE_CLI_GIT_REF="${GITHUB_SHA}" \
+            SONDE_SCHEMA_VERSION="${SCHEMA_VERSION}" \
+            SONDE_RUNTIME_AUDIT_TOKEN="${SONDE_RUNTIME_AUDIT_TOKEN}" \
+            SONDE_WS_TOKEN_SECRET="${SONDE_WS_TOKEN_SECRET}" \
+            SONDE_GITHUB_ALLOWED_REPOS="${SONDE_GITHUB_ALLOWED_REPOS}"
+
+      - name: Deploy staging agent
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_STAGING_PROJECT_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_STAGING_PROJECT_ID }}
+        run: |
+          railway up \
+            -e "${{ vars.RAILWAY_STAGING_ENVIRONMENT_ID }}" \
+            -s "${{ vars.RAILWAY_STAGING_SERVICE_NAME }}" \
+            --detach \
+            --ci
+
+      - name: Wait for staged agent runtime parity
+        working-directory: server
+        env:
+          PARITY_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
+          PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN }}
+          PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
+          PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_WAIT_TIMEOUT_MS: 300000
+          PARITY_WAIT_INTERVAL_MS: 10000
+        run: node scripts/wait-for-runtime-parity.mjs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-ref
     outputs:
+      agent: ${{ steps.filter.outputs.agent }}
       database: ${{ steps.filter.outputs.database }}
     steps:
       - uses: actions/checkout@v6
@@ -43,6 +44,13 @@ jobs:
           filters: |
             database:
               - 'supabase/**'
+              - 'config/hosted-environments.json'
+              - '.github/workflows/deploy.yml'
+            agent:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - 'cli/**'
+              - 'server/**'
               - 'config/hosted-environments.json'
               - '.github/workflows/deploy.yml'
 
@@ -116,3 +124,121 @@ jobs:
           else
             echo "::notice::Skipping strict schema verification because get_schema_version is not reachable with the configured production publishable key"
           fi
+
+  deploy-production-agent:
+    runs-on: ubuntu-latest
+    environment: production
+    needs:
+      - changes
+      - push-migrations
+    if: >-
+      ${{
+        always() &&
+        (
+          needs.push-migrations.result == 'success' ||
+          needs.push-migrations.result == 'skipped'
+        ) &&
+        (
+          needs.changes.outputs.agent == 'true' ||
+          github.event_name == 'workflow_dispatch'
+        )
+      }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Load hosted production contract
+        id: contract
+        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs production >> "$GITHUB_OUTPUT"
+
+      - name: Resolve production schema version
+        id: schema
+        if: ${{ steps.contract.outputs.supabase_project_ref != '' && steps.contract.outputs.supabase_anon_key != '' }}
+        run: |
+          VERSION=$(curl -sf \
+            -H "apikey: ${{ steps.contract.outputs.supabase_anon_key }}" \
+            -H "Authorization: Bearer ${{ steps.contract.outputs.supabase_anon_key }}" \
+            "https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co/rest/v1/rpc/get_schema_version" | tr -d '"')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Verify Railway production token
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_PROJECT_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PRODUCTION_PROJECT_ID }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ] || [ -z "$RAILWAY_PROJECT_ID" ]; then
+            echo "::error::Missing Railway production project token or project id"
+            exit 1
+          fi
+          railway service status \
+            -e "${{ vars.RAILWAY_PRODUCTION_ENVIRONMENT_ID }}" \
+            -s "${{ vars.RAILWAY_PRODUCTION_SERVICE_NAME }}" \
+            --json >/tmp/railway-production-status.json
+
+      - name: Pin production agent runtime metadata
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_PROJECT_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PRODUCTION_PROJECT_ID }}
+          SONDE_MANAGED_ENVIRONMENT_ID: ${{ vars.SONDE_ANTHROPIC_MANAGED_ENVIRONMENT_ID }}
+          SONDE_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          SONDE_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN }}
+          SONDE_WS_TOKEN_SECRET: ${{ secrets.SONDE_WS_TOKEN_SECRET || secrets.SONDE_PRODUCTION_WS_TOKEN_SECRET }}
+          SONDE_GITHUB_ALLOWED_REPOS: ${{ vars.SONDE_GITHUB_ALLOWED_REPOS }}
+        run: |
+          if [ -z "$SONDE_MANAGED_ENVIRONMENT_ID" ]; then
+            echo "::error::Missing SONDE_ANTHROPIC_MANAGED_ENVIRONMENT_ID repository variable"
+            exit 1
+          fi
+          SCHEMA_VERSION="${SONDE_SCHEMA_VERSION:-unknown}"
+          railway variable delete \
+            -s "${{ vars.RAILWAY_PRODUCTION_SERVICE_NAME }}" \
+            -e "${{ vars.RAILWAY_PRODUCTION_ENVIRONMENT_ID }}" \
+            SONDE_MANAGED_AGENT_ID || true
+          railway variable set \
+            -s "${{ vars.RAILWAY_PRODUCTION_SERVICE_NAME }}" \
+            -e "${{ vars.RAILWAY_PRODUCTION_ENVIRONMENT_ID }}" \
+            --skip-deploys \
+            VITE_SUPABASE_URL="https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co" \
+            VITE_SUPABASE_ANON_KEY="${{ steps.contract.outputs.supabase_anon_key }}" \
+            SONDE_AGENT_BACKEND="managed" \
+            SONDE_MANAGED_ENVIRONMENT_ID="${SONDE_MANAGED_ENVIRONMENT_ID}" \
+            SONDE_MANAGED_AGENT_ID=" " \
+            SONDE_MANAGED_ALLOW_EPHEMERAL_AGENT="1" \
+            SONDE_ALLOWED_ORIGINS="${{ steps.contract.outputs.site_url }}" \
+            SONDE_ENVIRONMENT="production" \
+            SONDE_COMMIT_SHA="${GITHUB_SHA}" \
+            SONDE_CLI_GIT_REF="${GITHUB_SHA}" \
+            SONDE_SCHEMA_VERSION="${SCHEMA_VERSION}" \
+            SONDE_RUNTIME_AUDIT_TOKEN="${SONDE_RUNTIME_AUDIT_TOKEN}" \
+            SONDE_WS_TOKEN_SECRET="${SONDE_WS_TOKEN_SECRET}" \
+            SONDE_GITHUB_ALLOWED_REPOS="${SONDE_GITHUB_ALLOWED_REPOS}"
+
+      - name: Deploy production agent
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_PROJECT_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PRODUCTION_PROJECT_ID }}
+        run: |
+          railway up \
+            -e "${{ vars.RAILWAY_PRODUCTION_ENVIRONMENT_ID }}" \
+            -s "${{ vars.RAILWAY_PRODUCTION_SERVICE_NAME }}" \
+            --detach \
+            --ci
+
+      - name: Wait for production agent runtime parity
+        working-directory: server
+        env:
+          PARITY_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
+          PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN }}
+          PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
+          PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_WAIT_TIMEOUT_MS: 300000
+          PARITY_WAIT_INTERVAL_MS: 10000
+        run: node scripts/wait-for-runtime-parity.mjs

--- a/.github/workflows/smoke-production.yml
+++ b/.github/workflows/smoke-production.yml
@@ -135,6 +135,19 @@ jobs:
           SMOKE_SESSION_FILE: ${{ env.PRODUCTION_SMOKE_SESSION_FILE }}
         run: node scripts/mint-smoke-session.mjs >/dev/null
 
+      - name: Wait for production agent runtime parity
+        if: ${{ steps.targets.outputs.agent_url != '' }}
+        working-directory: server
+        env:
+          PARITY_AGENT_BASE: ${{ steps.targets.outputs.agent_url }}
+          PARITY_RUNTIME_TOKEN: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
+          PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_WAIT_TIMEOUT_MS: 600000
+          PARITY_WAIT_INTERVAL_MS: 10000
+        run: node scripts/wait-for-runtime-parity.mjs
+
       - name: Audit deployed production stack
         if: ${{ steps.targets.outputs.agent_url != '' }}
         working-directory: server

--- a/.github/workflows/smoke-staging.yml
+++ b/.github/workflows/smoke-staging.yml
@@ -136,6 +136,19 @@ jobs:
           SMOKE_SESSION_FILE: ${{ env.STAGING_SMOKE_SESSION_FILE }}
         run: node scripts/mint-smoke-session.mjs >/dev/null
 
+      - name: Wait for staging agent runtime parity
+        if: ${{ steps.targets.outputs.agent_url != '' }}
+        working-directory: server
+        env:
+          PARITY_AGENT_BASE: ${{ steps.targets.outputs.agent_url }}
+          PARITY_RUNTIME_TOKEN: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
+          PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_WAIT_TIMEOUT_MS: 600000
+          PARITY_WAIT_INTERVAL_MS: 10000
+        run: node scripts/wait-for-runtime-parity.mjs
+
       - name: Audit deployed staging stack
         if: ${{ steps.targets.outputs.agent_url != '' }}
         working-directory: server

--- a/config/hosted-environments.json
+++ b/config/hosted-environments.json
@@ -16,7 +16,7 @@
     "expectedTimelineAuthMode": "server token",
     "audit": {
       "requireAnthropic": true,
-      "requireAgentCommitMatch": false,
+      "requireAgentCommitMatch": true,
       "requireFirstPartyAgent": false,
       "waitTimeoutMs": 600000,
       "waitIntervalMs": 10000

--- a/server/scripts/wait-for-runtime-parity.mjs
+++ b/server/scripts/wait-for-runtime-parity.mjs
@@ -1,0 +1,132 @@
+function requiredEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required env: ${name}`);
+  }
+  return value;
+}
+
+function normalizeBaseUrl(value) {
+  return value.replace(/\/+$/, "");
+}
+
+function parseNumber(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseCsv(value, fallback) {
+  const normalized = (value ?? fallback)
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  return normalized.length > 0 ? normalized : fallback.split(",");
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function fetchRuntimeMetadata(agentBase, runtimeAuditToken) {
+  const response = await fetch(`${agentBase}/health/runtime`, {
+    headers: {
+      Authorization: `Bearer ${runtimeAuditToken}`,
+    },
+  });
+  const bodyText = await response.text();
+
+  if (!response.ok) {
+    throw new Error(
+      `Runtime metadata request failed (${response.status}): ${bodyText.slice(0, 160)}`,
+    );
+  }
+
+  try {
+    return bodyText ? JSON.parse(bodyText) : {};
+  } catch {
+    throw new Error(
+      `Runtime metadata response was not valid JSON: ${bodyText.slice(0, 160)}`,
+    );
+  }
+}
+
+function missingKeys(metadata, requiredKeys) {
+  return requiredKeys.filter(
+    (key) => !Object.prototype.hasOwnProperty.call(metadata ?? {}, key),
+  );
+}
+
+async function main() {
+  const agentBase = normalizeBaseUrl(requiredEnv("PARITY_AGENT_BASE"));
+  const runtimeAuditToken = requiredEnv("PARITY_RUNTIME_TOKEN");
+  const expectedCommitSha = requiredEnv("PARITY_EXPECT_COMMIT_SHA");
+  const expectedEnvironment = process.env.PARITY_EXPECT_ENVIRONMENT?.trim() || null;
+  const expectedSchemaVersion = process.env.PARITY_EXPECT_SCHEMA_VERSION?.trim() || null;
+  const requiredKeys = parseCsv(
+    process.env.PARITY_REQUIRED_KEYS,
+    "managedConfigError,anthropicConfigError,anthropicAdminConfigError",
+  );
+  const waitTimeoutMs = parseNumber(process.env.PARITY_WAIT_TIMEOUT_MS, 300000);
+  const waitIntervalMs = parseNumber(process.env.PARITY_WAIT_INTERVAL_MS, 10000);
+  const deadline = Date.now() + waitTimeoutMs;
+
+  let lastSnapshot = null;
+  let lastError = null;
+
+  while (Date.now() <= deadline) {
+    try {
+      const metadata = await fetchRuntimeMetadata(agentBase, runtimeAuditToken);
+      const missing = missingKeys(metadata, requiredKeys);
+      const commitMatches = metadata?.commitSha === expectedCommitSha;
+      const environmentMatches =
+        !expectedEnvironment || metadata?.environment === expectedEnvironment;
+      const schemaMatches =
+        !expectedSchemaVersion || metadata?.schemaVersion === expectedSchemaVersion;
+
+      lastSnapshot = {
+        commitSha: metadata?.commitSha ?? null,
+        environment: metadata?.environment ?? null,
+        schemaVersion: metadata?.schemaVersion ?? null,
+        missingKeys: missing,
+      };
+
+      if (commitMatches && environmentMatches && schemaMatches && missing.length === 0) {
+        console.log(
+          JSON.stringify(
+            {
+              status: "ok",
+              agentBase,
+              commitSha: metadata.commitSha,
+              environment: metadata.environment,
+              schemaVersion: metadata.schemaVersion,
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await sleep(waitIntervalMs);
+  }
+
+  if (lastSnapshot) {
+    throw new Error(
+      `Timed out waiting for agent runtime parity. Expected commit=${expectedCommitSha}, environment=${expectedEnvironment ?? "<any>"}, schema=${expectedSchemaVersion ?? "<any>"}; got ${JSON.stringify(lastSnapshot)}`,
+    );
+  }
+
+  throw lastError ?? new Error("Timed out waiting for agent runtime parity.");
+}
+
+main().catch((error) => {
+  console.error(
+    `[wait-for-runtime-parity] ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- restore GitHub-owned Railway deploys for staging and production agents
- add a runtime parity gate so hosted audits wait for the live agent to pick up the current commit
- make hosted audits require agent commit parity again now that deploy ownership is back in GitHub

## Why
The staging and production Railway-hosted agents were serving older runtime metadata and older commit SHAs than the repo branches being audited. The deploy workflows were only syncing Supabase infra and no longer redeploying the external agent service, so hosted checks were comparing fresh repo state against stale Railway services.