### PR TITLE
fix: harden hosted deploy contract wiring

### DIFF
--- a/.github/actions/load-hosted-env/action.yml
+++ b/.github/actions/load-hosted-env/action.yml
@@ -1,0 +1,167 @@
+name: Load Hosted Environment
+description: Export and validate hosted environment inputs, then resolve hosted contract outputs.
+
+inputs:
+  environment-name:
+    description: Hosted environment name (staging or production)
+    required: true
+  ui-url:
+    required: false
+    default: ""
+  default-ui-url:
+    required: false
+    default: ""
+  agent-url:
+    required: false
+    default: ""
+  default-agent-url:
+    required: false
+    default: ""
+  supabase-project-ref:
+    required: false
+    default: ""
+  default-supabase-project-ref:
+    required: false
+    default: ""
+  supabase-anon-key:
+    required: false
+    default: ""
+  default-supabase-anon-key:
+    required: false
+    default: ""
+  smoke-user-email:
+    required: false
+    default: ""
+  default-smoke-user-email:
+    required: false
+    default: ""
+  smoke-user-password:
+    required: false
+    default: ""
+  default-smoke-user-password:
+    required: false
+    default: ""
+  cli-audit-token:
+    required: false
+    default: ""
+  default-cli-audit-token:
+    required: false
+    default: ""
+  runtime-audit-token:
+    required: false
+    default: ""
+  default-runtime-audit-token:
+    required: false
+    default: ""
+  redis-url:
+    required: false
+    default: ""
+  default-redis-url:
+    required: false
+    default: ""
+  redis-token:
+    required: false
+    default: ""
+  default-redis-token:
+    required: false
+    default: ""
+  require-shared-rate-limit:
+    required: false
+    default: ""
+  google-client-id:
+    required: false
+    default: ""
+  google-client-secret:
+    required: false
+    default: ""
+
+outputs:
+  schema_version:
+    value: ${{ steps.contract.outputs.schema_version }}
+  github_environment:
+    value: ${{ steps.contract.outputs.github_environment }}
+  runtime_environment:
+    value: ${{ steps.contract.outputs.runtime_environment }}
+  agent_backend:
+    value: ${{ steps.contract.outputs.agent_backend }}
+  ui_url:
+    value: ${{ steps.contract.outputs.ui_url }}
+  agent_url:
+    value: ${{ steps.contract.outputs.agent_url }}
+  supabase_project_ref:
+    value: ${{ steps.contract.outputs.supabase_project_ref }}
+  supabase_anon_key:
+    value: ${{ steps.contract.outputs.supabase_anon_key }}
+  require_shared_rate_limit:
+    value: ${{ steps.contract.outputs.require_shared_rate_limit }}
+  site_url:
+    value: ${{ steps.contract.outputs.site_url }}
+  redirect_urls_csv:
+    value: ${{ steps.contract.outputs.redirect_urls_csv }}
+  storage_file_size_limit:
+    value: ${{ steps.contract.outputs.storage_file_size_limit }}
+  smoke_expected_program_id:
+    value: ${{ steps.contract.outputs.smoke_expected_program_id }}
+  smoke_expected_experiment_id:
+    value: ${{ steps.contract.outputs.smoke_expected_experiment_id }}
+  smoke_expected_timeline_auth_mode:
+    value: ${{ steps.contract.outputs.smoke_expected_timeline_auth_mode }}
+  audit_require_anthropic:
+    value: ${{ steps.contract.outputs.audit_require_anthropic }}
+  audit_require_agent_commit_match:
+    value: ${{ steps.contract.outputs.audit_require_agent_commit_match }}
+  audit_require_first_party_agent:
+    value: ${{ steps.contract.outputs.audit_require_first_party_agent }}
+  audit_wait_timeout_ms:
+    value: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
+  audit_wait_interval_ms:
+    value: ${{ steps.contract.outputs.audit_wait_interval_ms }}
+  managed_auth_audit_prompt:
+    value: ${{ steps.contract.outputs.managed_auth_audit_prompt }}
+  managed_auth_audit_expect_substring:
+    value: ${{ steps.contract.outputs.managed_auth_audit_expect_substring }}
+  managed_auth_audit_stale_session:
+    value: ${{ steps.contract.outputs.managed_auth_audit_stale_session }}
+  managed_auth_audit_require_tool_use:
+    value: ${{ steps.contract.outputs.managed_auth_audit_require_tool_use }}
+  managed_auth_audit_timeout_ms:
+    value: ${{ steps.contract.outputs.managed_auth_audit_timeout_ms }}
+  managed_auth_audit_prewarm_timeout_ms:
+    value: ${{ steps.contract.outputs.managed_auth_audit_prewarm_timeout_ms }}
+  managed_auth_audit_retry_interval_ms:
+    value: ${{ steps.contract.outputs.managed_auth_audit_retry_interval_ms }}
+
+runs:
+  using: composite
+  steps:
+    - id: export
+      shell: bash
+      env:
+        SOURCE_UI_URL: ${{ inputs.ui-url }}
+        SOURCE_DEFAULT_UI_URL: ${{ inputs.default-ui-url }}
+        SOURCE_AGENT_URL: ${{ inputs.agent-url }}
+        SOURCE_DEFAULT_AGENT_URL: ${{ inputs.default-agent-url }}
+        SOURCE_SUPABASE_PROJECT_REF: ${{ inputs.supabase-project-ref }}
+        SOURCE_DEFAULT_SUPABASE_PROJECT_REF: ${{ inputs.default-supabase-project-ref }}
+        SOURCE_SUPABASE_ANON_KEY: ${{ inputs.supabase-anon-key }}
+        SOURCE_DEFAULT_SUPABASE_ANON_KEY: ${{ inputs.default-supabase-anon-key }}
+        SOURCE_SMOKE_USER_EMAIL: ${{ inputs.smoke-user-email }}
+        SOURCE_DEFAULT_SMOKE_USER_EMAIL: ${{ inputs.default-smoke-user-email }}
+        SOURCE_SMOKE_USER_PASSWORD: ${{ inputs.smoke-user-password }}
+        SOURCE_DEFAULT_SMOKE_USER_PASSWORD: ${{ inputs.default-smoke-user-password }}
+        SOURCE_CLI_AUDIT_TOKEN: ${{ inputs.cli-audit-token }}
+        SOURCE_DEFAULT_CLI_AUDIT_TOKEN: ${{ inputs.default-cli-audit-token }}
+        SOURCE_RUNTIME_AUDIT_TOKEN: ${{ inputs.runtime-audit-token }}
+        SOURCE_DEFAULT_RUNTIME_AUDIT_TOKEN: ${{ inputs.default-runtime-audit-token }}
+        SOURCE_REDIS_URL: ${{ inputs.redis-url }}
+        SOURCE_DEFAULT_REDIS_URL: ${{ inputs.default-redis-url }}
+        SOURCE_REDIS_TOKEN: ${{ inputs.redis-token }}
+        SOURCE_DEFAULT_REDIS_TOKEN: ${{ inputs.default-redis-token }}
+        SOURCE_REQUIRE_SHARED_RATE_LIMIT: ${{ inputs.require-shared-rate-limit }}
+        SOURCE_GOOGLE_CLIENT_ID: ${{ inputs.google-client-id }}
+        SOURCE_GOOGLE_CLIENT_SECRET: ${{ inputs.google-client-secret }}
+      run: node server/scripts/hosted-env-contract.mjs export-github-env "${{ inputs.environment-name }}" >> "$GITHUB_ENV"
+
+    - id: contract
+      shell: bash
+      run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs "${{ inputs.environment-name }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - if: steps.gate.outputs.run == 'true'
         name: Validate hosted environment export logic with fixtures
         run: |
-          node - <<'NODE'
+          node --input-type=module - <<'NODE'
           import {
             loadHostedEnvironmentContract,
             resolveHostedEnvironment,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,70 @@ jobs:
         name: Validate hosted environment contract
         run: node server/scripts/hosted-env-contract.mjs check-parity
 
+      - if: steps.gate.outputs.run == 'true'
+        name: Validate hosted workflow action usage
+        run: bash scripts/ci/check-hosted-workflow-action.sh
+
+      - if: steps.gate.outputs.run == 'true'
+        name: Validate hosted environment export logic with fixtures
+        run: |
+          node - <<'NODE'
+          import {
+            loadHostedEnvironmentContract,
+            resolveHostedEnvironment,
+            resolveHostedGithubEnvironmentEnv,
+            validateHostedEnvironmentContract,
+            validateResolvedHostedEnvironment,
+          } from "./server/scripts/lib/hosted-env-contract.mjs";
+
+          const contract = loadHostedEnvironmentContract();
+          const contractErrors = validateHostedEnvironmentContract(contract);
+          if (contractErrors.length > 0) {
+            throw new Error(contractErrors.join("\n"));
+          }
+
+          const fixtures = {
+            staging: {
+              SOURCE_UI_URL: "https://staging-ui.example.com",
+              SOURCE_AGENT_URL: "https://staging-agent.example.com",
+              SOURCE_SUPABASE_PROJECT_REF: "stageprojref",
+              SOURCE_SUPABASE_ANON_KEY: "sb_publishable_stage_test",
+              SOURCE_SMOKE_USER_EMAIL: "stage-smoke@example.com",
+              SOURCE_SMOKE_USER_PASSWORD: "not-a-real-password",
+              SOURCE_CLI_AUDIT_TOKEN: "stage-cli-token",
+              SOURCE_RUNTIME_AUDIT_TOKEN: "stage-runtime-token",
+              SOURCE_GOOGLE_CLIENT_ID: "google-client-id",
+              SOURCE_GOOGLE_CLIENT_SECRET: "google-client-secret",
+            },
+            production: {
+              SOURCE_UI_URL: "https://prod-ui.example.com",
+              SOURCE_AGENT_URL: "https://prod-agent.example.com",
+              SOURCE_SUPABASE_PROJECT_REF: "prodprojref",
+              SOURCE_SUPABASE_ANON_KEY: "sb_publishable_prod_test",
+              SOURCE_SMOKE_USER_EMAIL: "prod-smoke@example.com",
+              SOURCE_SMOKE_USER_PASSWORD: "not-a-real-password",
+              SOURCE_CLI_AUDIT_TOKEN: "prod-cli-token",
+              SOURCE_RUNTIME_AUDIT_TOKEN: "prod-runtime-token",
+              SOURCE_GOOGLE_CLIENT_ID: "google-client-id",
+              SOURCE_GOOGLE_CLIENT_SECRET: "google-client-secret",
+            },
+          };
+
+          for (const [name, fixture] of Object.entries(fixtures)) {
+            const hostedEnv = resolveHostedGithubEnvironmentEnv(fixture);
+            const resolved = resolveHostedEnvironment(
+              name,
+              { ...fixture, ...hostedEnv },
+              contract,
+            );
+            const errors = validateResolvedHostedEnvironment(resolved);
+            if (errors.length > 0) {
+              throw new Error(`${name} fixture failed validation:\n${errors.join("\n")}`);
+            }
+          }
+          console.log("hosted export fixtures ok");
+          NODE
+
   cli-core:
     name: cli-core
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-hosted-audit.yml
+++ b/.github/workflows/cli-hosted-audit.yml
@@ -29,11 +29,19 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     env:
+      HOSTED_UI_URL: ${{ vars.SONDE_STAGING_UI_URL || vars.SONDE_UI_URL || '' }}
+      HOSTED_AGENT_URL: ${{ vars.SONDE_STAGING_AGENT_HTTP_BASE || vars.SONDE_AGENT_HTTP_BASE || '' }}
       HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_STAGING_PROJECT_REF || vars.SUPABASE_PROJECT_REF || '' }}
       HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_STAGING_ANON_KEY || vars.SUPABASE_ANON_KEY || '' }}
       HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_STAGING_SMOKE_USER_EMAIL || secrets.SONDE_SMOKE_USER_EMAIL || '' }}
       HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_STAGING_SMOKE_USER_PASSWORD || secrets.SONDE_SMOKE_USER_PASSWORD || '' }}
       HOSTED_CLI_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_CLI_AUDIT_TOKEN || secrets.SONDE_CLI_AUDIT_TOKEN || '' }}
+      HOSTED_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || '' }}
+      HOSTED_REDIS_URL: ${{ vars.SONDE_STAGING_UPSTASH_REDIS_REST_URL || vars.SONDE_UPSTASH_REDIS_REST_URL || '' }}
+      HOSTED_REDIS_TOKEN: ${{ secrets.SONDE_STAGING_UPSTASH_REDIS_REST_TOKEN || secrets.SONDE_UPSTASH_REDIS_REST_TOKEN || '' }}
+      HOSTED_REQUIRE_SHARED_RATE_LIMIT: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT || '' }}
+      HOSTED_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID || '' }}
+      HOSTED_GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET || '' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -54,7 +62,22 @@ jobs:
 
       - name: Load hosted staging contract
         id: contract
-        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs staging >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/load-hosted-env
+        with:
+          environment-name: staging
+          ui-url: ${{ env.HOSTED_UI_URL }}
+          agent-url: ${{ env.HOSTED_AGENT_URL }}
+          supabase-project-ref: ${{ env.HOSTED_SUPABASE_PROJECT_REF }}
+          supabase-anon-key: ${{ env.HOSTED_SUPABASE_ANON_KEY }}
+          smoke-user-email: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          smoke-user-password: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
+          cli-audit-token: ${{ env.HOSTED_CLI_AUDIT_TOKEN }}
+          runtime-audit-token: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          redis-url: ${{ env.HOSTED_REDIS_URL }}
+          redis-token: ${{ env.HOSTED_REDIS_TOKEN }}
+          require-shared-rate-limit: ${{ env.HOSTED_REQUIRE_SHARED_RATE_LIMIT }}
+          google-client-id: ${{ env.HOSTED_GOOGLE_CLIENT_ID }}
+          google-client-secret: ${{ env.HOSTED_GOOGLE_CLIENT_SECRET }}
 
       - name: Install Sonde CLI
         run: |
@@ -102,11 +125,19 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     env:
+      HOSTED_UI_URL: ${{ vars.SONDE_UI_URL || '' }}
+      HOSTED_AGENT_URL: ${{ vars.SONDE_AGENT_HTTP_BASE || '' }}
       HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF || secrets.SUPABASE_PROJECT_REF || '' }}
       HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY || '' }}
       HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_SMOKE_USER_EMAIL || secrets.SONDE_PRODUCTION_SMOKE_USER_EMAIL || '' }}
       HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_SMOKE_USER_PASSWORD || secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD || '' }}
       HOSTED_CLI_AUDIT_TOKEN: ${{ secrets.SONDE_CLI_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_CLI_AUDIT_TOKEN || '' }}
+      HOSTED_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN || '' }}
+      HOSTED_REDIS_URL: ${{ vars.SONDE_UPSTASH_REDIS_REST_URL || vars.SONDE_PRODUCTION_UPSTASH_REDIS_REST_URL || '' }}
+      HOSTED_REDIS_TOKEN: ${{ secrets.SONDE_UPSTASH_REDIS_REST_TOKEN || secrets.SONDE_PRODUCTION_UPSTASH_REDIS_REST_TOKEN || '' }}
+      HOSTED_REQUIRE_SHARED_RATE_LIMIT: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT || '' }}
+      HOSTED_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID || '' }}
+      HOSTED_GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET || '' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -127,7 +158,22 @@ jobs:
 
       - name: Load hosted production contract
         id: contract
-        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs production >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/load-hosted-env
+        with:
+          environment-name: production
+          ui-url: ${{ env.HOSTED_UI_URL }}
+          agent-url: ${{ env.HOSTED_AGENT_URL }}
+          supabase-project-ref: ${{ env.HOSTED_SUPABASE_PROJECT_REF }}
+          supabase-anon-key: ${{ env.HOSTED_SUPABASE_ANON_KEY }}
+          smoke-user-email: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          smoke-user-password: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
+          cli-audit-token: ${{ env.HOSTED_CLI_AUDIT_TOKEN }}
+          runtime-audit-token: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          redis-url: ${{ env.HOSTED_REDIS_URL }}
+          redis-token: ${{ env.HOSTED_REDIS_TOKEN }}
+          require-shared-rate-limit: ${{ env.HOSTED_REQUIRE_SHARED_RATE_LIMIT }}
+          google-client-id: ${{ env.HOSTED_GOOGLE_CLIENT_ID }}
+          google-client-secret: ${{ env.HOSTED_GOOGLE_CLIENT_SECRET }}
 
       - name: Install Sonde CLI
         run: |

--- a/.github/workflows/config-audit.yml
+++ b/.github/workflows/config-audit.yml
@@ -55,7 +55,22 @@ jobs:
 
       - name: Load hosted staging contract
         id: contract
-        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs staging >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/load-hosted-env
+        with:
+          environment-name: staging
+          ui-url: ${{ env.HOSTED_UI_URL }}
+          agent-url: ${{ env.HOSTED_AGENT_URL }}
+          supabase-project-ref: ${{ env.HOSTED_SUPABASE_PROJECT_REF }}
+          supabase-anon-key: ${{ env.HOSTED_SUPABASE_ANON_KEY }}
+          smoke-user-email: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          smoke-user-password: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
+          cli-audit-token: ${{ env.HOSTED_CLI_AUDIT_TOKEN }}
+          runtime-audit-token: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          redis-url: ${{ env.HOSTED_REDIS_URL }}
+          redis-token: ${{ env.HOSTED_REDIS_TOKEN }}
+          require-shared-rate-limit: ${{ env.HOSTED_REQUIRE_SHARED_RATE_LIMIT }}
+          google-client-id: ${{ env.HOSTED_GOOGLE_CLIENT_ID }}
+          google-client-secret: ${{ env.HOSTED_GOOGLE_CLIENT_SECRET }}
 
       - name: Validate required staging config
         run: node server/scripts/hosted-env-contract.mjs validate staging
@@ -163,7 +178,22 @@ jobs:
 
       - name: Load hosted production contract
         id: contract
-        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs production >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/load-hosted-env
+        with:
+          environment-name: production
+          ui-url: ${{ env.HOSTED_UI_URL }}
+          agent-url: ${{ env.HOSTED_AGENT_URL }}
+          supabase-project-ref: ${{ env.HOSTED_SUPABASE_PROJECT_REF }}
+          supabase-anon-key: ${{ env.HOSTED_SUPABASE_ANON_KEY }}
+          smoke-user-email: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          smoke-user-password: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
+          cli-audit-token: ${{ env.HOSTED_CLI_AUDIT_TOKEN }}
+          runtime-audit-token: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          redis-url: ${{ env.HOSTED_REDIS_URL }}
+          redis-token: ${{ env.HOSTED_REDIS_TOKEN }}
+          require-shared-rate-limit: ${{ env.HOSTED_REQUIRE_SHARED_RATE_LIMIT }}
+          google-client-id: ${{ env.HOSTED_GOOGLE_CLIENT_ID }}
+          google-client-secret: ${{ env.HOSTED_GOOGLE_CLIENT_SECRET }}
 
       - name: Validate required production config
         run: node server/scripts/hosted-env-contract.mjs validate production

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -67,6 +67,16 @@ jobs:
       HOSTED_UI_URL: ${{ vars.SONDE_STAGING_UI_URL || vars.SONDE_UI_URL || '' }}
       HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_STAGING_PROJECT_REF || vars.SUPABASE_PROJECT_REF || '' }}
       HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_STAGING_ANON_KEY || vars.SUPABASE_ANON_KEY || '' }}
+      HOSTED_AGENT_URL: ${{ vars.SONDE_STAGING_AGENT_HTTP_BASE || vars.SONDE_AGENT_HTTP_BASE || '' }}
+      HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_STAGING_SMOKE_USER_EMAIL || secrets.SONDE_SMOKE_USER_EMAIL || '' }}
+      HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_STAGING_SMOKE_USER_PASSWORD || secrets.SONDE_SMOKE_USER_PASSWORD || '' }}
+      HOSTED_CLI_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_CLI_AUDIT_TOKEN || secrets.SONDE_CLI_AUDIT_TOKEN || '' }}
+      HOSTED_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || '' }}
+      HOSTED_REDIS_URL: ${{ vars.SONDE_STAGING_UPSTASH_REDIS_REST_URL || vars.SONDE_UPSTASH_REDIS_REST_URL || '' }}
+      HOSTED_REDIS_TOKEN: ${{ secrets.SONDE_STAGING_UPSTASH_REDIS_REST_TOKEN || secrets.SONDE_UPSTASH_REDIS_REST_TOKEN || '' }}
+      HOSTED_REQUIRE_SHARED_RATE_LIMIT: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT || '' }}
+      HOSTED_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID || '' }}
+      HOSTED_GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET || '' }}
     if: >-
       ${{
         (vars.SUPABASE_STAGING_PROJECT_REF || vars.SUPABASE_PROJECT_REF) != '' &&
@@ -85,7 +95,22 @@ jobs:
 
       - name: Load hosted staging contract
         id: contract
-        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs staging >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/load-hosted-env
+        with:
+          environment-name: staging
+          ui-url: ${{ env.HOSTED_UI_URL }}
+          agent-url: ${{ env.HOSTED_AGENT_URL }}
+          supabase-project-ref: ${{ env.HOSTED_SUPABASE_PROJECT_REF }}
+          supabase-anon-key: ${{ env.HOSTED_SUPABASE_ANON_KEY }}
+          smoke-user-email: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          smoke-user-password: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
+          cli-audit-token: ${{ env.HOSTED_CLI_AUDIT_TOKEN }}
+          runtime-audit-token: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          redis-url: ${{ env.HOSTED_REDIS_URL }}
+          redis-token: ${{ env.HOSTED_REDIS_TOKEN }}
+          require-shared-rate-limit: ${{ env.HOSTED_REQUIRE_SHARED_RATE_LIMIT }}
+          google-client-id: ${{ env.HOSTED_GOOGLE_CLIENT_ID }}
+          google-client-secret: ${{ env.HOSTED_GOOGLE_CLIENT_SECRET }}
 
       - uses: supabase/setup-cli@v1
         with:
@@ -150,6 +175,20 @@ jobs:
     needs:
       - changes
       - push-staging-database
+    env:
+      HOSTED_UI_URL: ${{ vars.SONDE_STAGING_UI_URL || vars.SONDE_UI_URL || '' }}
+      HOSTED_AGENT_URL: ${{ vars.SONDE_STAGING_AGENT_HTTP_BASE || vars.SONDE_AGENT_HTTP_BASE || '' }}
+      HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_STAGING_PROJECT_REF || vars.SUPABASE_PROJECT_REF || '' }}
+      HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_STAGING_ANON_KEY || vars.SUPABASE_ANON_KEY || '' }}
+      HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_STAGING_SMOKE_USER_EMAIL || secrets.SONDE_SMOKE_USER_EMAIL || '' }}
+      HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_STAGING_SMOKE_USER_PASSWORD || secrets.SONDE_SMOKE_USER_PASSWORD || '' }}
+      HOSTED_CLI_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_CLI_AUDIT_TOKEN || secrets.SONDE_CLI_AUDIT_TOKEN || '' }}
+      HOSTED_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || '' }}
+      HOSTED_REDIS_URL: ${{ vars.SONDE_STAGING_UPSTASH_REDIS_REST_URL || vars.SONDE_UPSTASH_REDIS_REST_URL || '' }}
+      HOSTED_REDIS_TOKEN: ${{ secrets.SONDE_STAGING_UPSTASH_REDIS_REST_TOKEN || secrets.SONDE_UPSTASH_REDIS_REST_TOKEN || '' }}
+      HOSTED_REQUIRE_SHARED_RATE_LIMIT: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT || '' }}
+      HOSTED_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID || '' }}
+      HOSTED_GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET || '' }}
     if: >-
       ${{
         always() &&
@@ -175,7 +214,22 @@ jobs:
 
       - name: Load hosted staging contract
         id: contract
-        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs staging >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/load-hosted-env
+        with:
+          environment-name: staging
+          ui-url: ${{ env.HOSTED_UI_URL }}
+          agent-url: ${{ env.HOSTED_AGENT_URL }}
+          supabase-project-ref: ${{ env.HOSTED_SUPABASE_PROJECT_REF }}
+          supabase-anon-key: ${{ env.HOSTED_SUPABASE_ANON_KEY }}
+          smoke-user-email: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          smoke-user-password: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
+          cli-audit-token: ${{ env.HOSTED_CLI_AUDIT_TOKEN }}
+          runtime-audit-token: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          redis-url: ${{ env.HOSTED_REDIS_URL }}
+          redis-token: ${{ env.HOSTED_REDIS_TOKEN }}
+          require-shared-rate-limit: ${{ env.HOSTED_REQUIRE_SHARED_RATE_LIMIT }}
+          google-client-id: ${{ env.HOSTED_GOOGLE_CLIENT_ID }}
+          google-client-secret: ${{ env.HOSTED_GOOGLE_CLIENT_SECRET }}
 
       - name: Resolve staging schema version
         id: schema

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,18 @@ jobs:
     needs: changes
     env:
       HOSTED_UI_URL: ${{ vars.SONDE_UI_URL || '' }}
+      HOSTED_AGENT_URL: ${{ vars.SONDE_AGENT_HTTP_BASE || '' }}
+      HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF || secrets.SUPABASE_PROJECT_REF || '' }}
+      HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY || '' }}
+      HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_SMOKE_USER_EMAIL || secrets.SONDE_PRODUCTION_SMOKE_USER_EMAIL || '' }}
+      HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_SMOKE_USER_PASSWORD || secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD || '' }}
+      HOSTED_CLI_AUDIT_TOKEN: ${{ secrets.SONDE_CLI_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_CLI_AUDIT_TOKEN || '' }}
+      HOSTED_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN || '' }}
+      HOSTED_REDIS_URL: ${{ vars.SONDE_UPSTASH_REDIS_REST_URL || vars.SONDE_PRODUCTION_UPSTASH_REDIS_REST_URL || '' }}
+      HOSTED_REDIS_TOKEN: ${{ secrets.SONDE_UPSTASH_REDIS_REST_TOKEN || secrets.SONDE_PRODUCTION_UPSTASH_REDIS_REST_TOKEN || '' }}
+      HOSTED_REQUIRE_SHARED_RATE_LIMIT: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT || '' }}
+      HOSTED_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID || '' }}
+      HOSTED_GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET || '' }}
     if: >-
       ${{
         needs.changes.outputs.database == 'true' ||
@@ -75,7 +87,22 @@ jobs:
 
       - name: Load hosted production contract
         id: contract
-        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs production >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/load-hosted-env
+        with:
+          environment-name: production
+          ui-url: ${{ env.HOSTED_UI_URL }}
+          agent-url: ${{ env.HOSTED_AGENT_URL }}
+          supabase-project-ref: ${{ env.HOSTED_SUPABASE_PROJECT_REF }}
+          supabase-anon-key: ${{ env.HOSTED_SUPABASE_ANON_KEY }}
+          smoke-user-email: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          smoke-user-password: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
+          cli-audit-token: ${{ env.HOSTED_CLI_AUDIT_TOKEN }}
+          runtime-audit-token: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          redis-url: ${{ env.HOSTED_REDIS_URL }}
+          redis-token: ${{ env.HOSTED_REDIS_TOKEN }}
+          require-shared-rate-limit: ${{ env.HOSTED_REQUIRE_SHARED_RATE_LIMIT }}
+          google-client-id: ${{ env.HOSTED_GOOGLE_CLIENT_ID }}
+          google-client-secret: ${{ env.HOSTED_GOOGLE_CLIENT_SECRET }}
 
       - uses: supabase/setup-cli@v1
         with:
@@ -131,6 +158,20 @@ jobs:
     needs:
       - changes
       - push-migrations
+    env:
+      HOSTED_UI_URL: ${{ vars.SONDE_UI_URL || '' }}
+      HOSTED_AGENT_URL: ${{ vars.SONDE_AGENT_HTTP_BASE || '' }}
+      HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF || secrets.SUPABASE_PROJECT_REF || '' }}
+      HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY || '' }}
+      HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_SMOKE_USER_EMAIL || secrets.SONDE_PRODUCTION_SMOKE_USER_EMAIL || '' }}
+      HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_SMOKE_USER_PASSWORD || secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD || '' }}
+      HOSTED_CLI_AUDIT_TOKEN: ${{ secrets.SONDE_CLI_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_CLI_AUDIT_TOKEN || '' }}
+      HOSTED_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN || '' }}
+      HOSTED_REDIS_URL: ${{ vars.SONDE_UPSTASH_REDIS_REST_URL || vars.SONDE_PRODUCTION_UPSTASH_REDIS_REST_URL || '' }}
+      HOSTED_REDIS_TOKEN: ${{ secrets.SONDE_UPSTASH_REDIS_REST_TOKEN || secrets.SONDE_PRODUCTION_UPSTASH_REDIS_REST_TOKEN || '' }}
+      HOSTED_REQUIRE_SHARED_RATE_LIMIT: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT || '' }}
+      HOSTED_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID || '' }}
+      HOSTED_GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET || '' }}
     if: >-
       ${{
         always() &&
@@ -153,7 +194,22 @@ jobs:
 
       - name: Load hosted production contract
         id: contract
-        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs production >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/load-hosted-env
+        with:
+          environment-name: production
+          ui-url: ${{ env.HOSTED_UI_URL }}
+          agent-url: ${{ env.HOSTED_AGENT_URL }}
+          supabase-project-ref: ${{ env.HOSTED_SUPABASE_PROJECT_REF }}
+          supabase-anon-key: ${{ env.HOSTED_SUPABASE_ANON_KEY }}
+          smoke-user-email: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          smoke-user-password: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
+          cli-audit-token: ${{ env.HOSTED_CLI_AUDIT_TOKEN }}
+          runtime-audit-token: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          redis-url: ${{ env.HOSTED_REDIS_URL }}
+          redis-token: ${{ env.HOSTED_REDIS_TOKEN }}
+          require-shared-rate-limit: ${{ env.HOSTED_REQUIRE_SHARED_RATE_LIMIT }}
+          google-client-id: ${{ env.HOSTED_GOOGLE_CLIENT_ID }}
+          google-client-secret: ${{ env.HOSTED_GOOGLE_CLIENT_SECRET }}
 
       - name: Resolve production schema version
         id: schema

--- a/.github/workflows/smoke-production.yml
+++ b/.github/workflows/smoke-production.yml
@@ -29,6 +29,12 @@ jobs:
       HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_SMOKE_USER_EMAIL || secrets.SONDE_PRODUCTION_SMOKE_USER_EMAIL || '' }}
       HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_SMOKE_USER_PASSWORD || secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD || '' }}
       HOSTED_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_AGENT_RUNTIME_AUDIT_TOKEN || '' }}
+      HOSTED_CLI_AUDIT_TOKEN: ${{ secrets.SONDE_CLI_AUDIT_TOKEN || secrets.SONDE_PRODUCTION_CLI_AUDIT_TOKEN || '' }}
+      HOSTED_REDIS_URL: ${{ vars.SONDE_UPSTASH_REDIS_REST_URL || vars.SONDE_PRODUCTION_UPSTASH_REDIS_REST_URL || '' }}
+      HOSTED_REDIS_TOKEN: ${{ secrets.SONDE_UPSTASH_REDIS_REST_TOKEN || secrets.SONDE_PRODUCTION_UPSTASH_REDIS_REST_TOKEN || '' }}
+      HOSTED_REQUIRE_SHARED_RATE_LIMIT: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT || '' }}
+      HOSTED_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID || '' }}
+      HOSTED_GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET || '' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -46,7 +52,22 @@ jobs:
 
       - name: Load hosted production contract
         id: contract
-        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs production >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/load-hosted-env
+        with:
+          environment-name: production
+          ui-url: ${{ env.HOSTED_UI_URL }}
+          agent-url: ${{ env.HOSTED_AGENT_URL }}
+          supabase-project-ref: ${{ env.HOSTED_SUPABASE_PROJECT_REF }}
+          supabase-anon-key: ${{ env.HOSTED_SUPABASE_ANON_KEY }}
+          smoke-user-email: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          smoke-user-password: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
+          cli-audit-token: ${{ env.HOSTED_CLI_AUDIT_TOKEN }}
+          runtime-audit-token: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          redis-url: ${{ env.HOSTED_REDIS_URL }}
+          redis-token: ${{ env.HOSTED_REDIS_TOKEN }}
+          require-shared-rate-limit: ${{ env.HOSTED_REQUIRE_SHARED_RATE_LIMIT }}
+          google-client-id: ${{ env.HOSTED_GOOGLE_CLIENT_ID }}
+          google-client-secret: ${{ env.HOSTED_GOOGLE_CLIENT_SECRET }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/smoke-staging.yml
+++ b/.github/workflows/smoke-staging.yml
@@ -29,6 +29,12 @@ jobs:
       HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_STAGING_SMOKE_USER_EMAIL || secrets.SONDE_SMOKE_USER_EMAIL || '' }}
       HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_STAGING_SMOKE_USER_PASSWORD || secrets.SONDE_SMOKE_USER_PASSWORD || '' }}
       HOSTED_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || '' }}
+      HOSTED_CLI_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_CLI_AUDIT_TOKEN || secrets.SONDE_CLI_AUDIT_TOKEN || '' }}
+      HOSTED_REDIS_URL: ${{ vars.SONDE_STAGING_UPSTASH_REDIS_REST_URL || vars.SONDE_UPSTASH_REDIS_REST_URL || '' }}
+      HOSTED_REDIS_TOKEN: ${{ secrets.SONDE_STAGING_UPSTASH_REDIS_REST_TOKEN || secrets.SONDE_UPSTASH_REDIS_REST_TOKEN || '' }}
+      HOSTED_REQUIRE_SHARED_RATE_LIMIT: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT || '' }}
+      HOSTED_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID || '' }}
+      HOSTED_GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET || '' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -46,8 +52,22 @@ jobs:
 
       - name: Load hosted staging contract
         id: contract
-        working-directory: .
-        run: node server/scripts/hosted-env-contract.mjs resolve-github-outputs staging >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/load-hosted-env
+        with:
+          environment-name: staging
+          ui-url: ${{ env.HOSTED_UI_URL }}
+          agent-url: ${{ env.HOSTED_AGENT_URL }}
+          supabase-project-ref: ${{ env.HOSTED_SUPABASE_PROJECT_REF }}
+          supabase-anon-key: ${{ env.HOSTED_SUPABASE_ANON_KEY }}
+          smoke-user-email: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          smoke-user-password: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
+          cli-audit-token: ${{ env.HOSTED_CLI_AUDIT_TOKEN }}
+          runtime-audit-token: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          redis-url: ${{ env.HOSTED_REDIS_URL }}
+          redis-token: ${{ env.HOSTED_REDIS_TOKEN }}
+          require-shared-rate-limit: ${{ env.HOSTED_REQUIRE_SHARED_RATE_LIMIT }}
+          google-client-id: ${{ env.HOSTED_GOOGLE_CLIENT_ID }}
+          google-client-secret: ${{ env.HOSTED_GOOGLE_CLIENT_SECRET }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/soak-staging.yml
+++ b/.github/workflows/soak-staging.yml
@@ -24,12 +24,41 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     env:
+      HOSTED_UI_URL: ${{ vars.SONDE_STAGING_UI_URL || vars.SONDE_UI_URL || '' }}
       HOSTED_AGENT_URL: ${{ vars.SONDE_STAGING_AGENT_HTTP_BASE || vars.SONDE_AGENT_HTTP_BASE || '' }}
       HOSTED_SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_STAGING_PROJECT_REF || vars.SUPABASE_PROJECT_REF || '' }}
       HOSTED_SUPABASE_ANON_KEY: ${{ vars.SUPABASE_STAGING_ANON_KEY || vars.SUPABASE_ANON_KEY || '' }}
+      HOSTED_SMOKE_USER_EMAIL: ${{ secrets.SONDE_STAGING_SMOKE_USER_EMAIL || secrets.SONDE_SMOKE_USER_EMAIL || '' }}
+      HOSTED_SMOKE_USER_PASSWORD: ${{ secrets.SONDE_STAGING_SMOKE_USER_PASSWORD || secrets.SONDE_SMOKE_USER_PASSWORD || '' }}
+      HOSTED_CLI_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_CLI_AUDIT_TOKEN || secrets.SONDE_CLI_AUDIT_TOKEN || '' }}
+      HOSTED_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_STAGING_AGENT_RUNTIME_AUDIT_TOKEN || secrets.SONDE_AGENT_RUNTIME_AUDIT_TOKEN || '' }}
+      HOSTED_REDIS_URL: ${{ vars.SONDE_STAGING_UPSTASH_REDIS_REST_URL || vars.SONDE_UPSTASH_REDIS_REST_URL || '' }}
+      HOSTED_REDIS_TOKEN: ${{ secrets.SONDE_STAGING_UPSTASH_REDIS_REST_TOKEN || secrets.SONDE_UPSTASH_REDIS_REST_TOKEN || '' }}
+      HOSTED_REQUIRE_SHARED_RATE_LIMIT: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT || '' }}
+      HOSTED_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID || '' }}
+      HOSTED_GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET || '' }}
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Load hosted staging contract
+        id: contract
+        uses: ./.github/actions/load-hosted-env
+        with:
+          environment-name: staging
+          ui-url: ${{ env.HOSTED_UI_URL }}
+          agent-url: ${{ env.HOSTED_AGENT_URL }}
+          supabase-project-ref: ${{ env.HOSTED_SUPABASE_PROJECT_REF }}
+          supabase-anon-key: ${{ env.HOSTED_SUPABASE_ANON_KEY }}
+          smoke-user-email: ${{ env.HOSTED_SMOKE_USER_EMAIL }}
+          smoke-user-password: ${{ env.HOSTED_SMOKE_USER_PASSWORD }}
+          cli-audit-token: ${{ env.HOSTED_CLI_AUDIT_TOKEN }}
+          runtime-audit-token: ${{ env.HOSTED_RUNTIME_AUDIT_TOKEN }}
+          redis-url: ${{ env.HOSTED_REDIS_URL }}
+          redis-token: ${{ env.HOSTED_REDIS_TOKEN }}
+          require-shared-rate-limit: ${{ env.HOSTED_REQUIRE_SHARED_RATE_LIMIT }}
+          google-client-id: ${{ env.HOSTED_GOOGLE_CLIENT_ID }}
+          google-client-secret: ${{ env.HOSTED_GOOGLE_CLIENT_SECRET }}
 
       - name: Set soak temp paths
         run: |

--- a/scripts/ci/check-hosted-workflow-action.sh
+++ b/scripts/ci/check-hosted-workflow-action.sh
@@ -16,16 +16,15 @@ workflows=(
 )
 
 for workflow in "${workflows[@]}"; do
-  if ! rg -q 'uses:\s+\./\.github/actions/load-hosted-env' "$workflow"; then
+  if ! grep -Eq 'uses:[[:space:]]+\./\.github/actions/load-hosted-env' "$workflow"; then
     echo "::error file=${workflow}::Hosted workflow must use ./.github/actions/load-hosted-env"
     exit 1
   fi
 done
 
-if rg -n 'run:\s+node server/scripts/hosted-env-contract\.mjs resolve-github-outputs' .github/workflows \
-  | grep -v '^$' >/dev/null; then
+if grep -REn 'run:[[:space:]]+node server/scripts/hosted-env-contract\.mjs resolve-github-outputs' .github/workflows >/tmp/hosted-workflow-direct-calls.txt; then
   echo "::error::Hosted workflows should load contract outputs through ./.github/actions/load-hosted-env, not direct resolve-github-outputs calls."
-  rg -n 'run:\s+node server/scripts/hosted-env-contract\.mjs resolve-github-outputs' .github/workflows
+  cat /tmp/hosted-workflow-direct-calls.txt
   exit 1
 fi
 

--- a/scripts/ci/check-hosted-workflow-action.sh
+++ b/scripts/ci/check-hosted-workflow-action.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+workflows=(
+  ".github/workflows/deploy-staging.yml"
+  ".github/workflows/deploy.yml"
+  ".github/workflows/config-audit.yml"
+  ".github/workflows/cli-hosted-audit.yml"
+  ".github/workflows/smoke-staging.yml"
+  ".github/workflows/smoke-production.yml"
+  ".github/workflows/soak-staging.yml"
+)
+
+for workflow in "${workflows[@]}"; do
+  if ! rg -q 'uses:\s+\./\.github/actions/load-hosted-env' "$workflow"; then
+    echo "::error file=${workflow}::Hosted workflow must use ./.github/actions/load-hosted-env"
+    exit 1
+  fi
+done
+
+if rg -n 'run:\s+node server/scripts/hosted-env-contract\.mjs resolve-github-outputs' .github/workflows \
+  | grep -v '^$' >/dev/null; then
+  echo "::error::Hosted workflows should load contract outputs through ./.github/actions/load-hosted-env, not direct resolve-github-outputs calls."
+  rg -n 'run:\s+node server/scripts/hosted-env-contract\.mjs resolve-github-outputs' .github/workflows
+  exit 1
+fi
+
+ruby <<'RUBY'
+require "yaml"
+
+Dir[".github/workflows/*.yml"].sort.each do |workflow|
+  data = YAML.load_file(workflow)
+  next unless data.is_a?(Hash)
+
+  jobs = data.fetch("jobs", {})
+  jobs.each do |job_name, job|
+    next unless job.is_a?(Hash)
+
+    Array(job["steps"]).each_with_index do |step, idx|
+      next unless step.is_a?(Hash)
+      next unless step["uses"]
+
+      if step.key?("working-directory")
+        warn "::error file=#{workflow}::job '#{job_name}' step #{idx + 1} uses an action and sets working-directory, which GitHub Actions does not support."
+        exit 1
+      end
+    end
+  end
+end
+RUBY
+
+echo "hosted workflow action usage ok"

--- a/scripts/ci/core.sh
+++ b/scripts/ci/core.sh
@@ -34,6 +34,9 @@ run_guard() {
     } | sort
   )
   echo "shell syntax ok"
+
+  log_section "Hosted workflow action usage"
+  bash scripts/ci/check-hosted-workflow-action.sh
 }
 
 run_cli() {

--- a/server/scripts/hosted-env-contract.mjs
+++ b/server/scripts/hosted-env-contract.mjs
@@ -3,6 +3,7 @@ import {
   formatHostedEnvironmentForGithubOutputs,
   loadHostedEnvironmentContract,
   resolveHostedEnvironment,
+  resolveHostedGithubEnvironmentEnv,
   validateHostedEnvironmentContract,
   validateResolvedHostedEnvironment,
 } from "./lib/hosted-env-contract.mjs";
@@ -22,7 +23,7 @@ function printGithubOutput(name, value) {
 
 function usage() {
   console.error(
-    "Usage: node server/scripts/hosted-env-contract.mjs <check-parity|validate|resolve-github-outputs|print-json> [environment]",
+    "Usage: node server/scripts/hosted-env-contract.mjs <check-parity|validate|resolve-github-outputs|export-github-env|print-json> [environment]",
   );
   process.exit(1);
 }
@@ -89,6 +90,32 @@ function runResolveGithubOutputs(environmentName) {
   }
 }
 
+function runExportGithubEnv(environmentName) {
+  const contract = loadHostedEnvironmentContract();
+  const contractErrors = validateHostedEnvironmentContract(contract);
+  const hostedEnv = resolveHostedGithubEnvironmentEnv(process.env);
+  const resolved = resolveHostedEnvironment(
+    environmentName,
+    { ...process.env, ...hostedEnv },
+    contract,
+  );
+  const errors = [
+    ...contractErrors,
+    ...validateResolvedHostedEnvironment(resolved),
+  ];
+
+  if (errors.length > 0) {
+    for (const error of errors) {
+      console.error(`[hosted-env-contract] ${error}`);
+    }
+    process.exit(1);
+  }
+
+  for (const [name, value] of Object.entries(hostedEnv)) {
+    printGithubOutput(name, value);
+  }
+}
+
 function runPrintJson(environmentName) {
   const resolved = resolveHostedEnvironment(environmentName);
   console.log(JSON.stringify(formatHostedEnvironmentForLogs(resolved), null, 2));
@@ -112,6 +139,10 @@ switch (command) {
   case "resolve-github-outputs":
     if (!environmentName) usage();
     runResolveGithubOutputs(environmentName);
+    break;
+  case "export-github-env":
+    if (!environmentName) usage();
+    runExportGithubEnv(environmentName);
     break;
   case "print-json":
     if (!environmentName) usage();

--- a/server/scripts/lib/hosted-env-contract.mjs
+++ b/server/scripts/lib/hosted-env-contract.mjs
@@ -45,6 +45,10 @@ function normalizeCsv(values) {
   return values.map((value) => value.trim()).filter(Boolean).join(",");
 }
 
+function chooseSource(primary, fallback = "") {
+  return trim(primary) || trim(fallback);
+}
+
 export function loadHostedEnvironmentContract(
   contractPath = DEFAULT_CONTRACT_PATH,
 ) {
@@ -225,6 +229,51 @@ export function resolveHostedEnvironment(
         10000,
       ),
     },
+  };
+}
+
+export function resolveHostedGithubEnvironmentEnv(env = process.env) {
+  return {
+    HOSTED_UI_URL: chooseSource(env.SOURCE_UI_URL, env.SOURCE_DEFAULT_UI_URL),
+    HOSTED_AGENT_URL: chooseSource(
+      env.SOURCE_AGENT_URL,
+      env.SOURCE_DEFAULT_AGENT_URL,
+    ),
+    HOSTED_SUPABASE_PROJECT_REF: chooseSource(
+      env.SOURCE_SUPABASE_PROJECT_REF,
+      env.SOURCE_DEFAULT_SUPABASE_PROJECT_REF,
+    ),
+    HOSTED_SUPABASE_ANON_KEY: chooseSource(
+      env.SOURCE_SUPABASE_ANON_KEY,
+      env.SOURCE_DEFAULT_SUPABASE_ANON_KEY,
+    ),
+    HOSTED_SMOKE_USER_EMAIL: chooseSource(
+      env.SOURCE_SMOKE_USER_EMAIL,
+      env.SOURCE_DEFAULT_SMOKE_USER_EMAIL,
+    ),
+    HOSTED_SMOKE_USER_PASSWORD: chooseSource(
+      env.SOURCE_SMOKE_USER_PASSWORD,
+      env.SOURCE_DEFAULT_SMOKE_USER_PASSWORD,
+    ),
+    HOSTED_CLI_AUDIT_TOKEN: chooseSource(
+      env.SOURCE_CLI_AUDIT_TOKEN,
+      env.SOURCE_DEFAULT_CLI_AUDIT_TOKEN,
+    ),
+    HOSTED_RUNTIME_AUDIT_TOKEN: chooseSource(
+      env.SOURCE_RUNTIME_AUDIT_TOKEN,
+      env.SOURCE_DEFAULT_RUNTIME_AUDIT_TOKEN,
+    ),
+    HOSTED_REDIS_URL: chooseSource(
+      env.SOURCE_REDIS_URL,
+      env.SOURCE_DEFAULT_REDIS_URL,
+    ),
+    HOSTED_REDIS_TOKEN: chooseSource(
+      env.SOURCE_REDIS_TOKEN,
+      env.SOURCE_DEFAULT_REDIS_TOKEN,
+    ),
+    HOSTED_REQUIRE_SHARED_RATE_LIMIT: trim(env.SOURCE_REQUIRE_SHARED_RATE_LIMIT),
+    HOSTED_GOOGLE_CLIENT_ID: trim(env.SOURCE_GOOGLE_CLIENT_ID),
+    HOSTED_GOOGLE_CLIENT_SECRET: trim(env.SOURCE_GOOGLE_CLIENT_SECRET),
   };
 }
 


### PR DESCRIPTION
## Summary
- route all hosted workflows through a shared hosted-env loader action
- validate and export hosted env before deploy, audit, and smoke work begins
- add CI guards so hosted workflows cannot drift back to ad-hoc contract resolution

## Testing
- bash scripts/ci/core.sh guard
- SOURCE_UI_URL=https://staging-ui.example.com SOURCE_AGENT_URL=https://staging-agent.example.com SOURCE_SUPABASE_PROJECT_REF=stageprojref SOURCE_SUPABASE_ANON_KEY=sb_publishable_stage_test SOURCE_SMOKE_USER_EMAIL=stage-smoke@example.com SOURCE_SMOKE_USER_PASSWORD=stage-password SOURCE_CLI_AUDIT_TOKEN=stage-cli-token SOURCE_RUNTIME_AUDIT_TOKEN=stage-runtime-token SOURCE_GOOGLE_CLIENT_ID=google-client-id SOURCE_GOOGLE_CLIENT_SECRET=google-client-secret node server/scripts/hosted-env-contract.mjs export-github-env staging
