### PR TITLE
fix(data): repair question graph production rollout

### DIFF
--- a/scripts/ci/data.sh
+++ b/scripts/ci/data.sh
@@ -57,6 +57,7 @@ wait_for_status_json() {
 }
 
 supabase start
+bash scripts/ci/question-graph-migration.sh
 supabase db reset --local --yes
 
 status_json="$(wait_for_status_json)"

--- a/scripts/ci/question-graph-migration.sh
+++ b/scripts/ci/question-graph-migration.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+NORMALIZATION_MIGRATION="20260414000002_repair_question_graph_primary_links.sql"
+
+psql_sql() {
+  local db="$1"
+  local sql="$2"
+
+  if command -v psql >/dev/null 2>&1; then
+    PGPASSWORD=postgres psql \
+      -h 127.0.0.1 \
+      -p 54322 \
+      -U postgres \
+      -d "$db" \
+      -v ON_ERROR_STOP=1 \
+      -c "$sql"
+    return 0
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    local container
+    container="$(
+      docker ps --format '{{.Names}}' | awk '/^supabase_db_/ { print; exit }'
+    )"
+    if [[ -n "$container" ]]; then
+      docker exec "$container" psql \
+        -U postgres \
+        -d "$db" \
+        -v ON_ERROR_STOP=1 \
+        -c "$sql"
+      return 0
+    fi
+  fi
+
+  echo "::error::Unable to execute SQL against the local Supabase Postgres instance."
+  exit 1
+}
+
+psql_file() {
+  local db="$1"
+  local file="$2"
+
+  if command -v psql >/dev/null 2>&1; then
+    PGPASSWORD=postgres psql \
+      -h 127.0.0.1 \
+      -p 54322 \
+      -U postgres \
+      -d "$db" \
+      -v ON_ERROR_STOP=1 \
+      -f "$file"
+    return 0
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    local container
+    container="$(
+      docker ps --format '{{.Names}}' | awk '/^supabase_db_/ { print; exit }'
+    )"
+    if [[ -n "$container" ]]; then
+      docker exec -i "$container" psql \
+        -U postgres \
+        -d "$db" \
+        -v ON_ERROR_STOP=1 < "$file"
+      return 0
+    fi
+  fi
+
+  echo "::error::Unable to execute SQL files against the local Supabase Postgres instance."
+  exit 1
+}
+
+psql_query_value() {
+  local db="$1"
+  local sql="$2"
+
+  if command -v psql >/dev/null 2>&1; then
+    PGPASSWORD=postgres psql \
+      -h 127.0.0.1 \
+      -p 54322 \
+      -U postgres \
+      -d "$db" \
+      -v ON_ERROR_STOP=1 \
+      -tAc "$sql"
+    return 0
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    local container
+    container="$(
+      docker ps --format '{{.Names}}' | awk '/^supabase_db_/ { print; exit }'
+    )"
+    if [[ -n "$container" ]]; then
+      docker exec "$container" psql \
+        -U postgres \
+        -d "$db" \
+        -v ON_ERROR_STOP=1 \
+        -tAc "$sql"
+      return 0
+    fi
+  fi
+
+  echo "::error::Unable to query the local Supabase Postgres instance."
+  exit 1
+}
+
+create_temp_db() {
+  local db="$1"
+  psql_sql postgres "DROP DATABASE IF EXISTS ${db} WITH (FORCE);"
+  psql_sql postgres "CREATE DATABASE ${db};"
+  psql_sql "$db" "
+    CREATE SCHEMA IF NOT EXISTS auth;
+    CREATE TABLE IF NOT EXISTS auth.users (
+      id UUID PRIMARY KEY
+    );
+    CREATE OR REPLACE FUNCTION auth.uid()
+    RETURNS UUID
+    LANGUAGE sql
+    STABLE
+    AS \$\$
+      SELECT NULL::uuid;
+    \$\$;
+    CREATE OR REPLACE FUNCTION auth.jwt()
+    RETURNS jsonb
+    LANGUAGE sql
+    STABLE
+    AS \$\$
+      SELECT '{}'::jsonb;
+    \$\$;
+
+    CREATE SCHEMA IF NOT EXISTS storage;
+    CREATE TABLE IF NOT EXISTS storage.buckets (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      public BOOLEAN NOT NULL DEFAULT false,
+      file_size_limit BIGINT
+    );
+    CREATE TABLE IF NOT EXISTS storage.objects (
+      id UUID PRIMARY KEY,
+      bucket_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      owner UUID,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      last_accessed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+    );
+    ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+
+    CREATE SCHEMA IF NOT EXISTS extensions;
+    CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
+    CREATE OR REPLACE FUNCTION extensions.sign(payload jsonb, secret text)
+    RETURNS text
+    LANGUAGE sql
+    IMMUTABLE
+    AS \$\$
+      SELECT 'stub.jwt'::text;
+    \$\$;
+  "
+}
+
+drop_temp_db() {
+  local db="$1"
+  psql_sql postgres "DROP DATABASE IF EXISTS ${db} WITH (FORCE);"
+}
+
+apply_migrations_through() {
+  local db="$1"
+  local stop_file="$2"
+  local file
+
+  while IFS= read -r file; do
+    psql_file "$db" "$file"
+    if [[ "$(basename "$file")" == "$stop_file" ]]; then
+      break
+    fi
+  done < <(find supabase/migrations -maxdepth 1 -type f -name '*.sql' | sort)
+}
+
+assert_equals() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+
+  if [[ "$actual" != "$expected" ]]; then
+    echo "::error::${message}: expected '${expected}', got '${actual}'"
+    exit 1
+  fi
+}
+
+run_question_graph_backfill_regression() {
+  local db="sonde_question_graph_backfill"
+  create_temp_db "$db"
+  trap 'drop_temp_db "$db"' RETURN
+
+  apply_migrations_through "$db" "20260411000001_managed_session_costs.sql"
+
+  psql_sql "$db" "
+    INSERT INTO directions (id, program, title, question, status, source, created_at, updated_at)
+    VALUES (
+      'DIR-001',
+      'weather-intervention',
+      'Cloud-seeding direction',
+      'Which question should anchor this direction?',
+      'active',
+      'human/test',
+      '2026-04-01T00:00:00Z',
+      '2026-04-01T00:00:00Z'
+    );
+
+    INSERT INTO experiments (id, program, status, source, direction_id, created_at, updated_at)
+    VALUES (
+      'EXP-0179',
+      'weather-intervention',
+      'open',
+      'human/test',
+      'DIR-001',
+      '2026-04-02T00:00:00Z',
+      '2026-04-02T00:00:00Z'
+    );
+
+    INSERT INTO questions (
+      id,
+      program,
+      question,
+      status,
+      source,
+      promoted_to_type,
+      promoted_to_id,
+      created_at,
+      updated_at
+    )
+    VALUES
+      (
+        'Q-0001',
+        'weather-intervention',
+        'Older promoted question',
+        'promoted',
+        'human/test',
+        'experiment',
+        'EXP-0179',
+        '2026-04-03T00:00:00Z',
+        '2026-04-03T00:00:00Z'
+      ),
+      (
+        'Q-0002',
+        'weather-intervention',
+        'Newer promoted question',
+        'promoted',
+        'human/test',
+        'experiment',
+        'EXP-0179',
+        '2026-04-04T00:00:00Z',
+        '2026-04-04T00:00:00Z'
+      );
+  "
+
+  psql_file "$db" "supabase/migrations/20260412000001_question_graph.sql"
+
+  assert_equals \
+    "$(psql_query_value "$db" "SELECT count(*) FROM question_experiments WHERE experiment_id = 'EXP-0179';")" \
+    "2" \
+    "question_graph should preserve every promoted question link"
+  assert_equals \
+    "$(psql_query_value "$db" "SELECT count(*) FROM question_experiments WHERE experiment_id = 'EXP-0179' AND is_primary;")" \
+    "1" \
+    "question_graph should assign exactly one primary question per experiment"
+  assert_equals \
+    "$(psql_query_value "$db" "SELECT question_id FROM question_experiments WHERE experiment_id = 'EXP-0179' AND is_primary;")" \
+    "Q-0001" \
+    "question_graph should choose the oldest promoted question when no explicit primary exists"
+
+  trap - RETURN
+  drop_temp_db "$db"
+}
+
+run_question_graph_normalization_regression() {
+  local db="sonde_question_graph_repair"
+  create_temp_db "$db"
+  trap 'drop_temp_db "$db"' RETURN
+
+  apply_migrations_through "$db" "20260414000001_create_device_auth_requests.sql"
+
+  psql_sql "$db" "
+    INSERT INTO directions (
+      id,
+      program,
+      title,
+      question,
+      status,
+      source,
+      created_at,
+      updated_at
+    )
+    VALUES (
+      'DIR-002',
+      'weather-intervention',
+      'Repair direction',
+      'Which linked question should be primary?',
+      'active',
+      'human/test',
+      '2026-04-05T00:00:00Z',
+      '2026-04-05T00:00:00Z'
+    );
+
+    INSERT INTO experiments (id, program, status, source, direction_id, created_at, updated_at)
+    VALUES (
+      'EXP-0180',
+      'weather-intervention',
+      'open',
+      'human/test',
+      'DIR-002',
+      '2026-04-06T00:00:00Z',
+      '2026-04-06T00:00:00Z'
+    );
+
+    INSERT INTO questions (
+      id,
+      program,
+      question,
+      status,
+      source,
+      promoted_to_type,
+      promoted_to_id,
+      direction_id,
+      created_at,
+      updated_at
+    )
+    VALUES
+      (
+        'Q-0010',
+        'weather-intervention',
+        'Existing linked question',
+        'investigating',
+        'human/test',
+        'experiment',
+        'EXP-0180',
+        'DIR-002',
+        '2026-04-07T00:00:00Z',
+        '2026-04-07T00:00:00Z'
+      ),
+      (
+        'Q-0011',
+        'weather-intervention',
+        'Direction primary question',
+        'investigating',
+        'human/test',
+        'experiment',
+        'EXP-0180',
+        'DIR-002',
+        '2026-04-08T00:00:00Z',
+        '2026-04-08T00:00:00Z'
+      );
+
+    UPDATE directions
+    SET primary_question_id = 'Q-0011'
+    WHERE id = 'DIR-002';
+
+    INSERT INTO question_experiments (question_id, experiment_id, is_primary)
+    VALUES ('Q-0010', 'EXP-0180', false);
+  "
+
+  psql_file "$db" "supabase/migrations/${NORMALIZATION_MIGRATION}"
+
+  assert_equals \
+    "$(psql_query_value "$db" "SELECT count(*) FROM question_experiments WHERE experiment_id = 'EXP-0180';")" \
+    "2" \
+    "repair migration should backfill missing promoted question links"
+  assert_equals \
+    "$(psql_query_value "$db" "SELECT count(*) FROM question_experiments WHERE experiment_id = 'EXP-0180' AND is_primary;")" \
+    "1" \
+    "repair migration should assign exactly one primary question when one is missing"
+  assert_equals \
+    "$(psql_query_value "$db" "SELECT question_id FROM question_experiments WHERE experiment_id = 'EXP-0180' AND is_primary;")" \
+    "Q-0011" \
+    "repair migration should prefer the direction primary question when repairing missing primaries"
+
+  trap - RETURN
+  drop_temp_db "$db"
+}
+
+printf '\n==> Question graph migration regressions\n'
+run_question_graph_backfill_regression
+run_question_graph_normalization_regression

--- a/supabase/migrations/20260412000001_question_graph.sql
+++ b/supabase/migrations/20260412000001_question_graph.sql
@@ -181,35 +181,99 @@ WHERE q.promoted_to_type = 'experiment'
   AND q.promoted_to_id = e.id
   AND q.direction_id IS NULL;
 
+WITH ranked_direction_questions AS (
+    SELECT
+        q.direction_id,
+        q.id AS question_id,
+        row_number() OVER (
+            PARTITION BY q.direction_id
+            ORDER BY q.created_at ASC, q.id ASC
+        ) AS direction_rank
+    FROM questions q
+    WHERE q.direction_id IS NOT NULL
+)
 UPDATE directions d
-SET primary_question_id = q.id
-FROM questions q
-WHERE q.direction_id = d.id
-  AND d.primary_question_id IS NULL;
+SET primary_question_id = ranked_direction_questions.question_id
+FROM ranked_direction_questions
+WHERE d.id = ranked_direction_questions.direction_id
+  AND d.primary_question_id IS NULL
+  AND ranked_direction_questions.direction_rank = 1;
 
+WITH promoted_question_links AS (
+    SELECT
+        q.id AS question_id,
+        q.promoted_to_id AS experiment_id
+    FROM questions q
+    JOIN experiments e ON e.id = q.promoted_to_id
+    WHERE q.promoted_to_type = 'experiment'
+)
 INSERT INTO question_experiments (question_id, experiment_id, is_primary)
-SELECT q.id, q.promoted_to_id, true
-FROM questions q
-JOIN experiments e ON e.id = q.promoted_to_id
-WHERE q.promoted_to_type = 'experiment'
-  AND NOT EXISTS (
-      SELECT 1
-      FROM question_experiments qe
-      WHERE qe.question_id = q.id
-        AND qe.experiment_id = q.promoted_to_id
+SELECT pql.question_id, pql.experiment_id, false
+FROM promoted_question_links pql
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM question_experiments qe
+    WHERE qe.question_id = pql.question_id
+      AND qe.experiment_id = pql.experiment_id
+);
+
+WITH promoted_experiments AS (
+    SELECT DISTINCT q.promoted_to_id AS experiment_id
+    FROM questions q
+    WHERE q.promoted_to_type = 'experiment'
+      AND q.promoted_to_id IS NOT NULL
+)
+UPDATE question_experiments qe
+SET is_primary = false
+WHERE qe.is_primary
+  AND qe.experiment_id IN (
+      SELECT promoted_experiments.experiment_id
+      FROM promoted_experiments
   );
 
+WITH ranked_promoted_question_links AS (
+    SELECT
+        q.id AS question_id,
+        q.promoted_to_id AS experiment_id,
+        row_number() OVER (
+            PARTITION BY q.promoted_to_id
+            ORDER BY
+                CASE
+                    WHEN d.primary_question_id = q.id THEN 0
+                    ELSE 1
+                END,
+                q.created_at ASC,
+                q.id ASC
+        ) AS primary_rank
+    FROM questions q
+    JOIN experiments e ON e.id = q.promoted_to_id
+    LEFT JOIN directions d ON d.id = e.direction_id
+    WHERE q.promoted_to_type = 'experiment'
+)
+UPDATE question_experiments qe
+SET is_primary = true
+FROM ranked_promoted_question_links ranked_promoted_question_links
+WHERE ranked_promoted_question_links.primary_rank = 1
+  AND qe.question_id = ranked_promoted_question_links.question_id
+  AND qe.experiment_id = ranked_promoted_question_links.experiment_id;
+
+WITH direction_primary_links AS (
+    SELECT d.primary_question_id AS question_id, e.id AS experiment_id
+    FROM directions d
+    JOIN experiments e ON e.direction_id = d.id
+    WHERE d.primary_question_id IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1
+          FROM question_experiments qe
+          WHERE qe.experiment_id = e.id
+            AND qe.is_primary
+      )
+)
 INSERT INTO question_experiments (question_id, experiment_id, is_primary)
-SELECT d.primary_question_id, e.id, true
-FROM directions d
-JOIN experiments e ON e.direction_id = d.id
-WHERE d.primary_question_id IS NOT NULL
-  AND NOT EXISTS (
-      SELECT 1
-      FROM question_experiments qe
-      WHERE qe.experiment_id = e.id
-        AND qe.is_primary
-  );
+SELECT question_id, experiment_id, true
+FROM direction_primary_links
+ON CONFLICT (question_id, experiment_id) DO UPDATE
+SET is_primary = EXCLUDED.is_primary;
 
 WITH finding_primary_questions AS (
     SELECT

--- a/supabase/migrations/20260414000002_repair_question_graph_primary_links.sql
+++ b/supabase/migrations/20260414000002_repair_question_graph_primary_links.sql
@@ -1,0 +1,118 @@
+-- Repair missing question graph links and ensure a primary question exists when
+-- the graph has already been created.
+
+WITH ranked_direction_questions AS (
+    SELECT
+        q.direction_id,
+        q.id AS question_id,
+        row_number() OVER (
+            PARTITION BY q.direction_id
+            ORDER BY q.created_at ASC, q.id ASC
+        ) AS direction_rank
+    FROM questions q
+    WHERE q.direction_id IS NOT NULL
+)
+UPDATE directions d
+SET primary_question_id = ranked_direction_questions.question_id
+FROM ranked_direction_questions
+WHERE d.id = ranked_direction_questions.direction_id
+  AND d.primary_question_id IS NULL
+  AND ranked_direction_questions.direction_rank = 1;
+
+INSERT INTO question_experiments (question_id, experiment_id, is_primary)
+SELECT q.id, q.promoted_to_id, false
+FROM questions q
+JOIN experiments e ON e.id = q.promoted_to_id
+WHERE q.promoted_to_type = 'experiment'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM question_experiments qe
+      WHERE qe.question_id = q.id
+        AND qe.experiment_id = q.promoted_to_id
+  );
+
+WITH direction_primary_links AS (
+    SELECT d.primary_question_id AS question_id, e.id AS experiment_id
+    FROM directions d
+    JOIN experiments e ON e.direction_id = d.id
+    WHERE d.primary_question_id IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1
+          FROM question_experiments qe
+          WHERE qe.experiment_id = e.id
+            AND qe.is_primary
+      )
+)
+INSERT INTO question_experiments (question_id, experiment_id, is_primary)
+SELECT direction_primary_links.question_id, direction_primary_links.experiment_id, false
+FROM direction_primary_links
+ON CONFLICT (question_id, experiment_id) DO NOTHING;
+
+WITH ranked_duplicate_primary_links AS (
+    SELECT
+        qe.question_id,
+        qe.experiment_id,
+        row_number() OVER (
+            PARTITION BY qe.experiment_id
+            ORDER BY
+                CASE
+                    WHEN d.primary_question_id = qe.question_id THEN 0
+                    ELSE 1
+                END,
+                q.created_at ASC,
+                q.id ASC
+        ) AS primary_rank
+    FROM question_experiments qe
+    JOIN questions q ON q.id = qe.question_id
+    JOIN experiments e ON e.id = qe.experiment_id
+    LEFT JOIN directions d ON d.id = e.direction_id
+    WHERE qe.experiment_id IN (
+        SELECT duplicate_primary_experiments.experiment_id
+        FROM (
+            SELECT question_experiments.experiment_id
+            FROM question_experiments
+            WHERE is_primary
+            GROUP BY question_experiments.experiment_id
+            HAVING count(*) > 1
+        ) AS duplicate_primary_experiments
+    )
+)
+UPDATE question_experiments qe
+SET is_primary = (ranked_duplicate_primary_links.primary_rank = 1)
+FROM ranked_duplicate_primary_links
+WHERE qe.question_id = ranked_duplicate_primary_links.question_id
+  AND qe.experiment_id = ranked_duplicate_primary_links.experiment_id;
+
+WITH ranked_missing_primary_links AS (
+    SELECT
+        qe.question_id,
+        qe.experiment_id,
+        row_number() OVER (
+            PARTITION BY qe.experiment_id
+            ORDER BY
+                CASE
+                    WHEN d.primary_question_id = qe.question_id THEN 0
+                    ELSE 1
+                END,
+                q.created_at ASC,
+                q.id ASC
+        ) AS primary_rank
+    FROM question_experiments qe
+    JOIN questions q ON q.id = qe.question_id
+    JOIN experiments e ON e.id = qe.experiment_id
+    LEFT JOIN directions d ON d.id = e.direction_id
+    WHERE qe.experiment_id IN (
+        SELECT missing_primary_experiments.experiment_id
+        FROM (
+            SELECT question_experiments.experiment_id
+            FROM question_experiments
+            GROUP BY question_experiments.experiment_id
+            HAVING NOT bool_or(question_experiments.is_primary)
+        ) AS missing_primary_experiments
+    )
+)
+UPDATE question_experiments qe
+SET is_primary = (ranked_missing_primary_links.primary_rank = 1)
+FROM ranked_missing_primary_links
+WHERE qe.question_id = ranked_missing_primary_links.question_id
+  AND qe.experiment_id = ranked_missing_primary_links.experiment_id;


### PR DESCRIPTION
## Summary
- fix the question graph backfill so multiple promoted questions on one experiment do not violate the single-primary index during deploy
- add a follow-up repair migration that backfills missing links and assigns a primary only when a post-migration environment still needs repair
- add a local Supabase regression script to replay the failing production shape and the repair path in CI data integration

## Why
Production Sync Production Infra failed on `supabase db push` because `20260412000001_question_graph.sql` tried to insert more than one `is_primary=true` row for the same experiment (`EXP-0179`).

## Validation
- `bash scripts/ci/question-graph-migration.sh`
- `bash scripts/ci/data.sh`
