### PR TITLE
fix(deploy): redeploy agent on database changes

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -171,6 +171,7 @@ jobs:
         ) &&
         (
           needs.changes.outputs.agent == 'true' ||
+          needs.changes.outputs.database == 'true' ||
           (
             github.event_name == 'workflow_dispatch' &&
             !inputs.seed_only

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,6 +154,7 @@ jobs:
         ) &&
         (
           needs.changes.outputs.agent == 'true' ||
+          needs.changes.outputs.database == 'true' ||
           github.event_name == 'workflow_dispatch'
         )
       }}


### PR DESCRIPTION
## Summary
- redeploy the staging and production agent when database changes land
- keep runtime commit and schema metadata aligned for data-only releases
- prevent smoke/config parity gates from waiting on an impossible commit update

## Testing
- ruby -e 'require "yaml"; [".github/workflows/deploy-staging.yml", ".github/workflows/deploy.yml"].each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'\n- bash scripts/ci/check-hosted-workflow-action.sh