### PR TITLE
test(ui): stabilize hosted timeline smoke

### DIFF
--- a/ui/e2e/hosted-smoke.spec.ts
+++ b/ui/e2e/hosted-smoke.spec.ts
@@ -5,7 +5,13 @@
  * Only runs when E2E_BASE_URL is set (CI post-deploy or manual dispatch).
  * Skipped entirely during local dev (no webServer needed).
  */
-import { test, expect, type Locator, type Page } from "@playwright/test";
+import {
+  test,
+  expect,
+  type APIRequestContext,
+  type Locator,
+  type Page,
+} from "@playwright/test";
 import { seedActiveProgram, seedConfiguredSession } from "./helpers";
 
 const BASE_URL = process.env.E2E_BASE_URL;
@@ -31,10 +37,28 @@ const SUITE_LABEL =
 const CHAT_AUTH_FAILURE_MARKER =
   /PGRST301|No suitable key was found to decode the JWT|JWT authentication error/i;
 
+const TIMELINE_PROXY_REPO = {
+  owner: "aeolus-earth",
+  repo: "sonde",
+};
+
 function agentOrigin(value: string | null): string | null {
   if (!value) return null;
   return new URL(value).origin;
 }
+
+function normalizeAuthMode(value: string): string {
+  return value.toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function readAccessToken(sessionJson: string | null): string | null {
+  if (!sessionJson) return null;
+  const parsed = JSON.parse(sessionJson) as { access_token?: string | null };
+  const token = parsed.access_token?.trim() || "";
+  return token || null;
+}
+
+const AUTH_ACCESS_TOKEN = readAccessToken(AUTH_SESSION_JSON);
 
 async function readVisibleText(page: Page, selector: string): Promise<string | null> {
   const locator = page.locator(selector).first();
@@ -43,6 +67,46 @@ async function readVisibleText(page: Page, selector: string): Promise<string | n
   }
   const text = await locator.textContent().catch(() => "");
   return text?.trim() || null;
+}
+
+async function assertTimelineProxyAvailable(request: APIRequestContext): Promise<void> {
+  if (!AGENT_HTTP_BASE) {
+    throw new Error("Timeline proxy smoke requires E2E_AGENT_HTTP_BASE.");
+  }
+  if (!AUTH_ACCESS_TOKEN) {
+    throw new Error("Timeline proxy smoke requires E2E_AUTH_SESSION_JSON with an access token.");
+  }
+
+  const response = await request.get(
+    `${AGENT_HTTP_BASE}/github/repos/${TIMELINE_PROXY_REPO.owner}/${TIMELINE_PROXY_REPO.repo}/commits?per_page=25`,
+    {
+      headers: {
+        Authorization: `Bearer ${AUTH_ACCESS_TOKEN}`,
+      },
+    }
+  );
+  const bodyText = await response.text();
+  expect(
+    response.ok(),
+    `Timeline proxy request failed: ${response.status()} ${bodyText.slice(0, 240)}`
+  ).toBeTruthy();
+
+  const body = JSON.parse(bodyText) as {
+    commits: Array<{ sha: string }>;
+    repo: { owner: string; repo: string };
+    diagnostics: {
+      authMode: string;
+      upstreamRequests: number;
+    };
+  };
+
+  expect(body.repo.owner).toBe(TIMELINE_PROXY_REPO.owner);
+  expect(body.repo.repo).toBe(TIMELINE_PROXY_REPO.repo);
+  expect(body.commits.length).toBeGreaterThan(0);
+  expect(normalizeAuthMode(body.diagnostics.authMode)).toBe(
+    normalizeAuthMode(EXPECT_TIMELINE_AUTH_MODE)
+  );
+  expect(body.diagnostics.upstreamRequests).toBeGreaterThanOrEqual(0);
 }
 
 async function waitForHostedChatResponse(
@@ -288,25 +352,48 @@ test.describe(`${SUITE_LABEL} authenticated flows`, () => {
     });
   });
 
-  test("timeline loads commit history through the server proxy", async ({ page }) => {
+  test("timeline loads commit history through the server proxy", async ({
+    page,
+    request,
+  }) => {
     await page.goto("/timeline");
 
-    const loadButton = page.getByRole("button", { name: "Load commit history" }).first();
-    await expect(loadButton).toBeVisible({ timeout: 20_000 });
-    await loadButton.click();
+    const diagnosticsAuthMode = page.getByText(new RegExp(EXPECT_TIMELINE_AUTH_MODE, "i")).first();
+    if (await diagnosticsAuthMode.isVisible().catch(() => false)) {
+      await expect(page.getByText(/upstream GitHub request/i)).toBeVisible({
+        timeout: 60_000,
+      });
+      return;
+    }
 
-    const timelineError = page.getByText(/Failed to load commit history|Sign in again|Repository not accessible|Server GitHub token is invalid|Hosted Sonde UI is missing VITE_AGENT_WS_URL/i);
+    const loadButton = page.getByRole("button", { name: "Load commit history" }).first();
+    if (await loadButton.isVisible().catch(() => false)) {
+      await loadButton.click();
+
+      const timelineError = page.getByText(/Failed to load commit history|Sign in again|Repository not accessible|Server GitHub token is invalid|Hosted Sonde UI is missing VITE_AGENT_WS_URL/i);
+      await expect(
+        page.getByText(new RegExp(EXPECT_TIMELINE_AUTH_MODE, "i"))
+      ).toBeVisible({ timeout: 60_000 }).catch(async () => {
+        const errorText = await timelineError.first().textContent().catch(() => "");
+        throw new Error(
+          `Timeline diagnostics never loaded expected auth mode (${EXPECT_TIMELINE_AUTH_MODE}). Visible error: ${errorText || "(none)"}`
+        );
+      });
+      await expect(page.getByText(/upstream GitHub request/i)).toBeVisible({
+        timeout: 60_000,
+      });
+      return;
+    }
+
+    await expect(page.getByText("No git-linked experiments found")).toBeVisible({
+      timeout: 20_000,
+    });
     await expect(
-      page.getByText(new RegExp(EXPECT_TIMELINE_AUTH_MODE, "i"))
-    ).toBeVisible({ timeout: 60_000 }).catch(async () => {
-      const errorText = await timelineError.first().textContent().catch(() => "");
-      throw new Error(
-        `Timeline diagnostics never loaded expected auth mode (${EXPECT_TIMELINE_AUTH_MODE}). Visible error: ${errorText || "(none)"}`
-      );
-    });
-    await expect(page.getByText(/upstream GitHub request/i)).toBeVisible({
-      timeout: 60_000,
-    });
+      page.getByText(
+        "Experiments logged with sonde log from inside a git repo will appear here."
+      )
+    ).toBeVisible();
+    await assertTimelineProxyAvailable(request);
   });
 
   test("chat connects and renders a hosted agent response on the first turn", async ({


### PR DESCRIPTION
## Summary
- stop assuming hosted environments always have a seeded git-linked experiment on /timeline
- keep GitHub proxy coverage by testing the server timeline proxy directly when the UI shows the empty state
- continue asserting the existing timeline diagnostics UI when commit history is already visible or loadable

## Testing
- npm run lint
- npm run build