### PR TITLE
fix(auth): prove hosted activation browser flow

### DIFF
--- a/.github/workflows/cli-hosted-audit.yml
+++ b/.github/workflows/cli-hosted-audit.yml
@@ -89,6 +89,7 @@ jobs:
       - name: Run staging CLI audit (human session)
         working-directory: server
         env:
+          CLI_AUDIT_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
           SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
           SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
           CLI_AUDIT_AUTH_MODE: session
@@ -171,6 +172,7 @@ jobs:
       - name: Run production CLI audit (human session)
         working-directory: server
         env:
+          CLI_AUDIT_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
           SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
           SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
           CLI_AUDIT_AUTH_MODE: session

--- a/.github/workflows/cli-hosted-audit.yml
+++ b/.github/workflows/cli-hosted-audit.yml
@@ -86,7 +86,7 @@ jobs:
           CLI_AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
         run: node scripts/run-cli-hosted-audit.mjs
 
-      - name: Run staging CLI audit (human session)
+      - name: Run staging CLI audit (device approval contract)
         working-directory: server
         env:
           CLI_AUDIT_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
@@ -169,7 +169,7 @@ jobs:
           CLI_AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
         run: node scripts/run-cli-hosted-audit.mjs
 
-      - name: Run production CLI audit (human session)
+      - name: Run production CLI audit (device approval contract)
         working-directory: server
         env:
           CLI_AUDIT_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -304,3 +304,23 @@ jobs:
           PARITY_WAIT_TIMEOUT_MS: 300000
           PARITY_WAIT_INTERVAL_MS: 10000
         run: node scripts/wait-for-runtime-parity.mjs
+
+      - name: Audit deployed production stack
+        if: ${{ steps.contract.outputs.agent_url != '' }}
+        working-directory: server
+        env:
+          AUDIT_UI_BASE: ${{ steps.contract.outputs.ui_url }}
+          AUDIT_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
+          AUDIT_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
+          AUDIT_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
+          AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
+          AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
+          AUDIT_REQUIRE_ANTHROPIC: ${{ steps.contract.outputs.audit_require_anthropic }}
+          AUDIT_REQUIRE_AGENT_COMMIT_MATCH: ${{ steps.contract.outputs.audit_require_agent_commit_match }}
+          AUDIT_REQUIRE_FIRST_PARTY_AGENT: ${{ steps.contract.outputs.audit_require_first_party_agent }}
+          AUDIT_REQUIRE_SHARED_RATE_LIMIT: ${{ steps.contract.outputs.audit_require_shared_rate_limit }}
+          AUDIT_REQUIRED_RUNTIME_KEYS: ${{ steps.contract.outputs.audit_required_runtime_keys_csv }}
+          AUDIT_WAIT_TIMEOUT_MS: 300000
+          AUDIT_WAIT_INTERVAL_MS: 10000
+        run: node scripts/audit-deployed-stack.mjs

--- a/cli/src/sonde/auth.py
+++ b/cli/src/sonde/auth.py
@@ -86,6 +86,22 @@ class LoginConfigurationError(Exception):
     pass
 
 
+class HostedLoginError(RuntimeError):
+    def __init__(
+        self,
+        kind: str,
+        url: str,
+        detail: str,
+        *,
+        status_code: int | None = None,
+    ) -> None:
+        super().__init__(detail)
+        self.kind = kind
+        self.url = url
+        self.detail = detail
+        self.status_code = status_code
+
+
 # ---------------------------------------------------------------------------
 # Session persistence (file-based, keyring optional)
 # ---------------------------------------------------------------------------
@@ -568,19 +584,39 @@ def _post_json(
     except HTTPError as exc:
         body = exc.read().decode("utf-8", errors="replace")
         message = _error_message_from_json(body) or f"HTTP {exc.code} from {url}"
+        if _is_device_auth_url(url):
+            kind = "http_error"
+            if exc.code == 404:
+                kind = "not_found"
+            elif exc.code == 503:
+                kind = "unavailable"
+            raise HostedLoginError(kind, url, message, status_code=exc.code) from None
         raise RuntimeError(message) from None
     except URLError as exc:
-        raise RuntimeError(f"Could not reach {url}: {exc.reason}") from None
+        message = f"Could not reach {url}: {exc.reason}"
+        if _is_device_auth_url(url):
+            raise HostedLoginError("unreachable", url, message) from None
+        raise RuntimeError(message) from None
 
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError as exc:
-        raise RuntimeError(f"Device login returned invalid JSON from {url}: {exc}") from None
+        message = f"Device login returned invalid JSON from {url}: {exc}"
+        if _is_device_auth_url(url):
+            raise HostedLoginError("invalid_response", url, message) from None
+        raise RuntimeError(message) from None
 
     if not isinstance(parsed, dict):
-        raise RuntimeError(f"Device login returned an unexpected response from {url}.")
+        message = f"Device login returned an unexpected response from {url}."
+        if _is_device_auth_url(url):
+            raise HostedLoginError("invalid_response", url, message) from None
+        raise RuntimeError(message)
 
     return parsed
+
+
+def _is_device_auth_url(url: str) -> bool:
+    return DEVICE_AUTH_PATH in url
 
 
 def _error_message_from_json(raw: str) -> str | None:

--- a/cli/src/sonde/commands/auth.py
+++ b/cli/src/sonde/commands/auth.py
@@ -9,6 +9,42 @@ from sonde.cli_options import pass_output_options
 from sonde.output import err, print_banner, print_error, print_json, print_success
 
 
+def _hosted_login_error_display(error: auth.HostedLoginError) -> tuple[str, str, str]:
+    path = error.url
+    if error.kind == "not_found":
+        return (
+            "Hosted login service is missing OAuth routes",
+            f"{path} returned 404 Not Found. This usually means the hosted Sonde UI or "
+            "agent deployment is missing the /auth/device routes.",
+            "If you manage this environment, redeploy the hosted Sonde stack and verify "
+            "/auth/device/start. Temporary fallback: sonde login --method loopback",
+        )
+    if error.kind == "unavailable":
+        return (
+            "Hosted login service is misconfigured",
+            f"{path} reported that hosted activation is unavailable. {error.detail}",
+            "Check the hosted OAuth/device-login configuration, then retry: sonde login",
+        )
+    if error.kind == "unreachable":
+        return (
+            "Hosted login service could not be reached",
+            error.detail,
+            "Check the hosted Sonde URL or network path, then retry: sonde login",
+        )
+    if error.kind == "invalid_response":
+        return (
+            "Hosted login service returned an invalid response",
+            error.detail,
+            "Check for a stale deploy or broken UI proxy on the hosted Sonde "
+            "environment, then retry: sonde login",
+        )
+    return (
+        "Hosted login failed",
+        error.detail,
+        "Retry: sonde login",
+    )
+
+
 @click.command()
 @pass_output_options
 @click.option(
@@ -56,6 +92,10 @@ def login(ctx: click.Context, remote: bool, method: str) -> None:
             str(e),
             "Set SONDE_UI_URL or SONDE_AGENT_HTTP_BASE, or run: sonde login --method loopback",
         )
+        raise SystemExit(1) from None
+    except auth.HostedLoginError as e:
+        title, detail, fix = _hosted_login_error_display(e)
+        print_error(title, detail, fix)
         raise SystemExit(1) from None
     except TimeoutError as e:
         print_error("Login timed out", str(e), "Try again: sonde login")

--- a/cli/src/sonde/diagnostics.py
+++ b/cli/src/sonde/diagnostics.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from time import perf_counter
 from typing import Any
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
 from sonde import auth
@@ -246,7 +246,7 @@ def build_local_section(*, deep: bool = False) -> DoctorSection:
 
 def build_auth_section(*, deep: bool = False) -> DoctorSection:
     """Inspect current auth state."""
-    checks = [check_auth_session(), check_device_login_base()]
+    checks = [check_auth_session(), check_device_login_base(), check_device_login_health()]
     return build_section("auth", checks, required=True)
 
 
@@ -588,6 +588,103 @@ def check_device_login_base() -> DoctorCheck:
         }
 
     return _timed_check("device-login-base", "Login transport", build, required=False)
+
+
+def check_device_login_health() -> DoctorCheck:
+    """Probe the hosted login readiness endpoint for the resolved Sonde origin."""
+
+    def build() -> dict[str, Any]:
+        resolved, source = auth._resolve_hosted_login_origin()
+        normalized = auth._normalize_hosted_login_origin(resolved)
+
+        if not normalized:
+            return {
+                "status": "skipped",
+                "summary": "Hosted login health skipped because no Sonde origin is configured.",
+            }
+
+        if source == "default-ui" and auth._uses_nondefault_supabase_target():
+            return {
+                "status": "skipped",
+                "summary": (
+                    "Hosted login health skipped until the matching Sonde origin is configured."
+                ),
+                "details": [auth._hosted_login_origin_mismatch_message()],
+            }
+
+        health_url = f"{normalized}/auth/device/health"
+        try:
+            with urlopen(health_url, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            if exc.code == 404:
+                return {
+                    "status": "warn",
+                    "summary": "Hosted login endpoint returned 404.",
+                    "details": [
+                        f"{health_url} returned 404 Not Found.",
+                        "This usually means the hosted UI proxy or agent deploy is "
+                        "missing the /auth/device routes.",
+                    ],
+                    "fix": "Redeploy the hosted Sonde UI/agent and verify /auth/device/start.",
+                }
+            return {
+                "status": "warn",
+                "summary": "Hosted login health check failed.",
+                "details": [f"{health_url} returned HTTP {exc.code}."],
+                "fix": "Check the hosted Sonde deployment and retry `sonde doctor`.",
+            }
+        except URLError as exc:
+            return {
+                "status": "warn",
+                "summary": "Hosted login endpoint is not reachable.",
+                "details": [f"Could not reach {health_url}: {exc.reason}"],
+                "fix": "Check network reachability to the hosted Sonde environment and retry.",
+            }
+        except json.JSONDecodeError:
+            return {
+                "status": "warn",
+                "summary": "Hosted login endpoint returned invalid JSON.",
+                "details": [f"{health_url} did not return a valid JSON readiness payload."],
+                "fix": (
+                    "Check for a stale deploy or broken UI proxy on the hosted Sonde environment."
+                ),
+            }
+
+        if not isinstance(payload, dict):
+            return {
+                "status": "warn",
+                "summary": "Hosted login endpoint returned an unexpected payload.",
+                "details": [f"{health_url} returned a non-object JSON response."],
+                "fix": "Check the hosted Sonde auth service deployment.",
+            }
+
+        enabled = payload.get("enabled") is True
+        config_error = payload.get("config_error")
+        verification_uri = payload.get("verification_uri")
+        if not enabled:
+            details = [f"Hosted login is disabled at {health_url}."]
+            if isinstance(config_error, str) and config_error.strip():
+                details.append(config_error.strip())
+            return {
+                "status": "warn",
+                "summary": "Hosted login is configured but unavailable.",
+                "details": details,
+                "fix": (
+                    "Fix the hosted OAuth/device-login configuration, then retry `sonde login`."
+                ),
+            }
+
+        details = [f"Ready at {health_url}."]
+        if isinstance(verification_uri, str) and verification_uri.strip():
+            details.append(f"Activation URL: {verification_uri.strip()}")
+        return {
+            "status": "ok",
+            "summary": "Hosted login endpoint is reachable and ready.",
+            "details": details,
+        }
+
+    return _timed_check("device-login-health", "Hosted login health", build, required=False)
 
 
 def check_project_root(project_root: Path | None) -> DoctorCheck:

--- a/cli/tests/test_auth_commands.py
+++ b/cli/tests/test_auth_commands.py
@@ -53,6 +53,49 @@ def test_login_reports_config_error_with_loopback_guidance(runner: CliRunner, mo
     assert "loopback" in result.output
 
 
+def test_login_reports_hosted_404_as_missing_oauth_routes(runner: CliRunner, monkeypatch) -> None:
+    monkeypatch.setattr("sonde.auth.is_authenticated", lambda: False)
+    monkeypatch.setattr(
+        "sonde.auth.login",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            auth.HostedLoginError(
+                "not_found",
+                "https://sonde-neon.vercel.app/auth/device/start",
+                "404 Not Found",
+                status_code=404,
+            )
+        ),
+    )
+
+    result = runner.invoke(cli, ["login"])
+
+    assert result.exit_code == 1
+    assert "Hosted login service is missing OAuth routes" in result.output
+    assert "/auth/device/start" in result.output
+    assert "loopback" in result.output
+
+
+def test_login_reports_hosted_503_as_configuration_issue(runner: CliRunner, monkeypatch) -> None:
+    monkeypatch.setattr("sonde.auth.is_authenticated", lambda: False)
+    monkeypatch.setattr(
+        "sonde.auth.login",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            auth.HostedLoginError(
+                "unavailable",
+                "https://sonde-neon.vercel.app/auth/device/start",
+                "Device login is not configured.",
+                status_code=503,
+            )
+        ),
+    )
+
+    result = runner.invoke(cli, ["login"])
+
+    assert result.exit_code == 1
+    assert "Hosted login service is misconfigured" in result.output
+    assert "Device login is not configured" in result.output
+
+
 def test_login_runs_hosted_activation_end_to_end(runner: CliRunner, monkeypatch, tmp_path) -> None:
     session_payload = {
         "access_token": "access-token",

--- a/cli/tests/test_doctor.py
+++ b/cli/tests/test_doctor.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import sys
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
 from sonde.cli import cli
 from sonde.diagnostics import (
     GIT_TOOL_INSTALL_COMMAND,
     check_device_login_base,
+    check_device_login_health,
     check_install_shadows,
     check_s3_settings,
     check_stac_settings,
@@ -214,6 +215,62 @@ def test_check_device_login_base_warns_on_supabase_mismatch(monkeypatch) -> None
     assert check.status == "warn"
     assert "explicit Sonde origin" in check.summary
     assert "Mismatch message" in check.details[0]
+
+
+def test_check_device_login_health_reports_ready(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sonde.diagnostics.auth._resolve_hosted_login_origin",
+        lambda: ("https://sonde-neon.vercel.app", "default-ui"),
+    )
+    monkeypatch.setattr(
+        "sonde.diagnostics.auth._normalize_hosted_login_origin", lambda value: value
+    )
+    monkeypatch.setattr("sonde.diagnostics.auth._uses_nondefault_supabase_target", lambda: False)
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return b'{"status":"ok","enabled":true,"verification_uri":"https://sonde-neon.vercel.app/activate"}'
+
+    monkeypatch.setattr("sonde.diagnostics.urlopen", lambda *_args, **_kwargs: Response())
+
+    check = check_device_login_health()
+
+    assert check.status == "ok"
+    assert "reachable and ready" in check.summary
+    assert "activate" in "\n".join(check.details)
+
+
+def test_check_device_login_health_warns_on_404(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sonde.diagnostics.auth._resolve_hosted_login_origin",
+        lambda: ("https://sonde-neon.vercel.app", "default-ui"),
+    )
+    monkeypatch.setattr(
+        "sonde.diagnostics.auth._normalize_hosted_login_origin", lambda value: value
+    )
+    monkeypatch.setattr("sonde.diagnostics.auth._uses_nondefault_supabase_target", lambda: False)
+
+    def boom(*_args, **_kwargs):
+        raise HTTPError(
+            "https://sonde-neon.vercel.app/auth/device/health",
+            404,
+            "Not Found",
+            hdrs=None,
+            fp=None,
+        )
+
+    monkeypatch.setattr("sonde.diagnostics.urlopen", boom)
+
+    check = check_device_login_health()
+
+    assert check.status == "warn"
+    assert "returned 404" in check.summary.lower()
 
 
 def test_check_install_shadows_reports_shadowed_binary(monkeypatch):

--- a/cli/tests/test_doctor.py
+++ b/cli/tests/test_doctor.py
@@ -231,7 +231,7 @@ def test_check_device_login_health_reports_ready(monkeypatch) -> None:
         def __enter__(self):
             return self
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(self, *_args):
             return False
 
         def read(self) -> bytes:

--- a/server/scripts/audit-deployed-stack.mjs
+++ b/server/scripts/audit-deployed-stack.mjs
@@ -95,19 +95,28 @@ function sleep(ms) {
 }
 
 async function collectRuntimeState({ uiBase, agentBase, runtimeAuditToken }) {
-  const [uiVersion, agentHealth, agentRuntime] = await Promise.all([
-    fetchJson(`${uiBase}/version.json`),
-    fetchJson(`${agentBase}/health`),
-    fetchJson(`${agentBase}/health/runtime`, {
-      headers: runtimeAuditToken
-        ? {
-            Authorization: `Bearer ${runtimeAuditToken}`,
-          }
-        : {},
-    }),
-  ]);
+  const [uiVersion, agentHealth, agentRuntime, directDeviceHealth, proxiedDeviceHealth] =
+    await Promise.all([
+      fetchJson(`${uiBase}/version.json`),
+      fetchJson(`${agentBase}/health`),
+      fetchJson(`${agentBase}/health/runtime`, {
+        headers: runtimeAuditToken
+          ? {
+              Authorization: `Bearer ${runtimeAuditToken}`,
+            }
+          : {},
+      }),
+      fetchJson(`${agentBase}/auth/device/health`),
+      fetchJson(`${uiBase}/auth/device/health`),
+    ]);
 
-  return { uiVersion, agentHealth, agentRuntime };
+  return {
+    uiVersion,
+    agentHealth,
+    agentRuntime,
+    directDeviceHealth,
+    proxiedDeviceHealth,
+  };
 }
 
 async function main() {
@@ -161,7 +170,7 @@ async function main() {
     }
   }
 
-  let { uiVersion, agentHealth, agentRuntime } = state;
+  let { uiVersion, agentHealth, agentRuntime, directDeviceHealth, proxiedDeviceHealth } = state;
   const agentHostname = new URL(agentBase).hostname;
   const agentHostMatchesDisallowedSuffix = matchesDisallowedHostSuffix(
     agentHostname,
@@ -294,6 +303,30 @@ async function main() {
         !agentRuntime.deviceAuthConfigError,
         `Agent device login config is invalid: ${agentRuntime.deviceAuthConfigError}`,
       );
+      ensure(
+        directDeviceHealth?.status === "ok",
+        "Agent device-auth health did not return status=ok",
+      );
+      ensure(
+        proxiedDeviceHealth?.status === "ok",
+        "UI-proxied device-auth health did not return status=ok",
+      );
+      ensure(
+        directDeviceHealth?.enabled === true,
+        `Agent device-auth health reports disabled: ${directDeviceHealth?.config_error ?? "unknown"}`,
+      );
+      ensure(
+        proxiedDeviceHealth?.enabled === true,
+        `UI-proxied device-auth health reports disabled: ${proxiedDeviceHealth?.config_error ?? "unknown"}`,
+      );
+      ensure(
+        directDeviceHealth?.verification_uri === `${uiBase}/activate`,
+        `Agent device-auth verification URI mismatch: expected ${uiBase}/activate, got ${directDeviceHealth?.verification_uri}`,
+      );
+      ensure(
+        proxiedDeviceHealth?.verification_uri === `${uiBase}/activate`,
+        `UI-proxied device-auth verification URI mismatch: expected ${uiBase}/activate, got ${proxiedDeviceHealth?.verification_uri}`,
+      );
       const deviceStart = await fetchJson(`${agentBase}/auth/device/start`, {
         method: "POST",
         headers: {
@@ -367,8 +400,8 @@ async function main() {
       }
       await sleep(waitIntervalMs);
       try {
-        state = await collectRuntimeState({ uiBase, agentBase, runtimeAuditToken });
-        ({ uiVersion, agentHealth, agentRuntime } = state);
+      state = await collectRuntimeState({ uiBase, agentBase, runtimeAuditToken });
+      ({ uiVersion, agentHealth, agentRuntime, directDeviceHealth, proxiedDeviceHealth } = state);
       } catch (refreshError) {
         lastError = refreshError;
         if (Date.now() >= deadline) {

--- a/server/scripts/audit-deployed-stack.mjs
+++ b/server/scripts/audit-deployed-stack.mjs
@@ -63,11 +63,30 @@ async function fetchJson(url, init) {
   return body;
 }
 
-async function fetchText(url) {
+async function fetchHtmlDocument(url) {
   const response = await fetch(url);
   const body = await response.text();
+  const contentType = (response.headers.get("content-type") ?? "").toLowerCase();
   if (!response.ok) {
     throw new Error(`Request failed (${response.status}) for ${url}`);
+  }
+  if (!contentType.includes("text/html")) {
+    throw new Error(`Expected HTML from ${url}, but received ${contentType || "unknown content-type"}.`);
+  }
+
+  const normalized = body.trim().toLowerCase();
+  if (!(normalized.startsWith("<!doctype html") || normalized.startsWith("<html"))) {
+    throw new Error(`Expected an HTML document from ${url}, but received a non-document response.`);
+  }
+  if (
+    normalized.includes("404: not_found") ||
+    normalized.includes("the page could not be found") ||
+    normalized.includes("this page could not be found")
+  ) {
+    throw new Error(`Hosted route ${url} rendered a 404 page instead of the Sonde app.`);
+  }
+  if (normalized.includes("\"error\":{") || normalized.includes("\"error\": {")) {
+    throw new Error(`Hosted route ${url} rendered an application error payload instead of the Sonde app.`);
   }
   return body;
 }
@@ -313,19 +332,19 @@ async function main() {
       );
       ensure(
         directDeviceHealth?.enabled === true,
-        `Agent device-auth health reports disabled: ${directDeviceHealth?.config_error ?? "unknown"}`,
+        `Agent device-auth health reports disabled: ${agentRuntime.deviceAuthConfigError ?? "unknown"}`,
       );
       ensure(
         proxiedDeviceHealth?.enabled === true,
-        `UI-proxied device-auth health reports disabled: ${proxiedDeviceHealth?.config_error ?? "unknown"}`,
+        `UI-proxied device-auth health reports disabled: ${agentRuntime.deviceAuthConfigError ?? "unknown"}`,
       );
       ensure(
-        directDeviceHealth?.verification_uri === `${uiBase}/activate`,
-        `Agent device-auth verification URI mismatch: expected ${uiBase}/activate, got ${directDeviceHealth?.verification_uri}`,
+        Object.keys(directDeviceHealth ?? {}).length === 2,
+        "Public agent device-auth health should expose only status and enabled",
       );
       ensure(
-        proxiedDeviceHealth?.verification_uri === `${uiBase}/activate`,
-        `UI-proxied device-auth verification URI mismatch: expected ${uiBase}/activate, got ${proxiedDeviceHealth?.verification_uri}`,
+        Object.keys(proxiedDeviceHealth ?? {}).length === 2,
+        "Public proxied device-auth health should expose only status and enabled",
       );
       const deviceStart = await fetchJson(`${agentBase}/auth/device/start`, {
         method: "POST",
@@ -364,7 +383,10 @@ async function main() {
         Number.isFinite(deviceStart?.interval) && deviceStart.interval > 0,
         "Device auth start returned an invalid interval",
       );
-      await fetchText(deviceStart.verification_uri);
+      await fetchHtmlDocument(deviceStart.verification_uri);
+      await fetchHtmlDocument(
+        `${uiBase}/activate/callback?user_code=${encodeURIComponent(deviceStart.user_code)}`,
+      );
 
       if (requireSharedRateLimit) {
         ensure(
@@ -383,7 +405,7 @@ async function main() {
           `Agent host matches a disallowed suffix: ${agentHostname}`
         );
 
-        const loginHtml = await fetchText(`${uiBase}/login`);
+        const loginHtml = await fetchHtmlDocument(`${uiBase}/login`);
         ensure(
           !htmlContainsDisallowedSuffix(loginHtml, disallowedHostSuffixes),
           "UI HTML still exposes a disallowed hosted-domain suffix"

--- a/server/scripts/run-cli-hosted-audit.mjs
+++ b/server/scripts/run-cli-hosted-audit.mjs
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 
 function requiredEnv(name) {
   const value = process.env[name]?.trim();
@@ -22,7 +22,7 @@ async function requestJson(url, init) {
       body?.error_description ||
       body?.error ||
       response.statusText;
-    throw new Error(`Supabase request failed (${response.status}): ${message}`);
+    throw new Error(`Request failed (${response.status}): ${message}`);
   }
 
   return body;
@@ -77,6 +77,15 @@ function runCli(command, args, env) {
   }
 }
 
+function waitForChildExit(child) {
+  return new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      resolve({ code, signal });
+    });
+  });
+}
+
 function parseJsonOutput(raw, label) {
   try {
     return JSON.parse(raw);
@@ -125,6 +134,91 @@ async function mintSession(supabaseUrl, supabaseAnonKey, email, password) {
   });
 }
 
+function extractActivationDetails(stderrBuffer) {
+  const activationUrlMatch = stderrBuffer.match(/https?:\/\/\S+\/activate\?code=[A-Z0-9-]+/i);
+  const userCodeMatch =
+    stderrBuffer.match(/enter:\s*([A-Z0-9]{4}-[A-Z0-9]{4})/i) ||
+    stderrBuffer.match(/\b([A-Z0-9]{4}-[A-Z0-9]{4})\b/);
+
+  return {
+    activationUrl: activationUrlMatch?.[0] ?? "",
+    userCode: userCodeMatch?.[1] ?? "",
+  };
+}
+
+async function completeHostedCliLogin({
+  command,
+  env,
+  agentBase,
+  approvalSession,
+}) {
+  const child = spawn(command, ["login", "--json"], {
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf-8");
+  child.stderr.setEncoding("utf-8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const userCode = await new Promise((resolve, reject) => {
+    const deadline = Date.now() + 60_000;
+
+    const poll = () => {
+      const details = extractActivationDetails(stderr);
+      if (details.userCode) {
+        resolve(details.userCode);
+        return;
+      }
+      if (Date.now() >= deadline) {
+        reject(
+          new Error(
+            `Timed out waiting for sonde login activation code.\nCLI stderr:\n${stderr.trim()}`
+          )
+        );
+        return;
+      }
+      setTimeout(poll, 100);
+    };
+
+    poll();
+  });
+
+  await requestJson(`${agentBase}/auth/device/approve`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      Authorization: `Bearer ${approvalSession.access_token}`,
+    },
+    body: JSON.stringify({
+      user_code: userCode,
+      decision: "approve",
+      session: approvalSession,
+    }),
+  });
+
+  const { code, signal } = await waitForChildExit(child);
+  if (code !== 0) {
+    const signalSuffix = signal ? ` (signal ${signal})` : "";
+    throw new Error(
+      `sonde login --json failed with exit code ${code}${signalSuffix}\nstdout:\n${stdout.trim()}\nstderr:\n${stderr.trim()}`
+    );
+  }
+
+  const loginOutput = parseJsonOutput(stdout, "login");
+  if (!loginOutput?.email) {
+    throw new Error(`Hosted CLI login did not emit a usable JSON payload: ${stdout.trim()}`);
+  }
+  return loginOutput;
+}
+
 function persistSession(configDir, session) {
   fs.writeFileSync(path.join(configDir, "session.json"), JSON.stringify(session), {
     mode: 0o600,
@@ -138,6 +232,7 @@ async function main() {
   const email = process.env.SMOKE_USER_EMAIL?.trim() || "";
   const password = process.env.SMOKE_USER_PASSWORD?.trim() || "";
   const requestedAuthMode = (process.env.CLI_AUDIT_AUTH_MODE?.trim() || "auto").toLowerCase();
+  const agentBase = process.env.CLI_AUDIT_AGENT_BASE?.trim() || "";
   const auditEnvironment = process.env.CLI_AUDIT_ENV?.trim() || "staging";
   const auditProgram = process.env.CLI_AUDIT_PROGRAM?.trim() || "shared";
   const expectedExperimentId = process.env.CLI_AUDIT_EXPECT_EXPERIMENT_ID?.trim() || "";
@@ -174,9 +269,17 @@ async function main() {
         "CLI_AUDIT_AUTH_MODE=session requires SMOKE_USER_EMAIL and SMOKE_USER_PASSWORD."
       );
     }
-
+    if (!agentBase) {
+      throw new Error("CLI_AUDIT_AGENT_BASE is required for hosted CLI login audits.");
+    }
+    cliEnv.SONDE_AGENT_HTTP_BASE = agentBase;
     const session = await mintSession(supabaseUrl, supabaseAnonKey, email, password);
-    persistSession(configDir, session);
+    await completeHostedCliLogin({
+      command: sondeExecutable,
+      env: cliEnv,
+      agentBase,
+      approvalSession: session,
+    });
   }
 
   await waitForCliReadiness({

--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -151,21 +151,11 @@ describe("createApp", () => {
     const body = (await response.json()) as {
       status: string;
       enabled: boolean;
-      config_error: string | null;
-      verification_origin: string | null;
-      verification_uri: string | null;
-      poll_interval_seconds: number;
-      ttl_seconds: number;
     };
 
     assert.deepEqual(body, {
       status: "ok",
       enabled: true,
-      config_error: null,
-      verification_origin: "https://sonde-neon.vercel.app",
-      verification_uri: "https://sonde-neon.vercel.app/activate",
-      poll_interval_seconds: 5,
-      ttl_seconds: 600,
     });
   });
 
@@ -180,19 +170,14 @@ describe("createApp", () => {
     assert.equal(response.status, 200);
 
     const body = (await response.json()) as {
+      status: string;
       enabled: boolean;
-      config_error: string | null;
-      verification_origin: string | null;
-      verification_uri: string | null;
     };
 
-    assert.equal(body.enabled, false);
-    assert.equal(
-      body.config_error,
-      "A public Sonde UI origin is required for device login.",
-    );
-    assert.equal(body.verification_origin, null);
-    assert.equal(body.verification_uri, null);
+    assert.deepEqual(body, {
+      status: "ok",
+      enabled: false,
+    });
   });
 
   it("completes a device login request without a localhost callback", async () => {

--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -141,6 +141,60 @@ describe("createApp", () => {
     });
   });
 
+  it("returns public device-auth health without secrets", async () => {
+    process.env.SONDE_PUBLIC_APP_ORIGIN = "https://sonde-neon.vercel.app";
+    const app = createApp();
+
+    const response = await app.request("http://localhost/auth/device/health");
+    assert.equal(response.status, 200);
+
+    const body = (await response.json()) as {
+      status: string;
+      enabled: boolean;
+      config_error: string | null;
+      verification_origin: string | null;
+      verification_uri: string | null;
+      poll_interval_seconds: number;
+      ttl_seconds: number;
+    };
+
+    assert.deepEqual(body, {
+      status: "ok",
+      enabled: true,
+      config_error: null,
+      verification_origin: "https://sonde-neon.vercel.app",
+      verification_uri: "https://sonde-neon.vercel.app/activate",
+      poll_interval_seconds: 5,
+      ttl_seconds: 600,
+    });
+  });
+
+  it("reports when device-auth configuration is unavailable", async () => {
+    process.env.SONDE_ENVIRONMENT = "production";
+    delete process.env.SONDE_PUBLIC_APP_ORIGIN;
+    delete process.env.SONDE_ALLOWED_ORIGINS;
+    delete process.env.SONDE_DEVICE_AUTH_ENCRYPTION_KEY;
+    const app = createApp();
+
+    const response = await app.request("http://localhost/auth/device/health");
+    assert.equal(response.status, 200);
+
+    const body = (await response.json()) as {
+      enabled: boolean;
+      config_error: string | null;
+      verification_origin: string | null;
+      verification_uri: string | null;
+    };
+
+    assert.equal(body.enabled, false);
+    assert.equal(
+      body.config_error,
+      "A public Sonde UI origin is required for device login.",
+    );
+    assert.equal(body.verification_origin, null);
+    assert.equal(body.verification_uri, null);
+  });
+
   it("completes a device login request without a localhost callback", async () => {
     const app = createApp();
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -246,11 +246,6 @@ export function createApp(): Hono {
     return c.json({
       status: "ok",
       enabled: config.enabled,
-      config_error: config.configError,
-      verification_origin: config.verificationOrigin,
-      verification_uri: config.verificationUri,
-      poll_interval_seconds: config.pollIntervalSeconds,
-      ttl_seconds: config.ttlSeconds,
     });
   });
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -241,6 +241,18 @@ export function createApp(): Hono {
 
   app.get("/health", (c) => c.json({ status: "ok" }));
   app.get("/health/runtime", (c) => c.json(getRuntimeMetadata()));
+  app.get("/auth/device/health", (c) => {
+    const config = getDeviceAuthRuntimeStatus();
+    return c.json({
+      status: "ok",
+      enabled: config.enabled,
+      config_error: config.configError,
+      verification_origin: config.verificationOrigin,
+      verification_uri: config.verificationUri,
+      poll_interval_seconds: config.pollIntervalSeconds,
+      ttl_seconds: config.ttlSeconds,
+    });
+  });
 
   app.post("/auth/device/start", async (c) => {
     const ipRateLimit = await checkUserRateLimit(

--- a/server/src/device-auth.ts
+++ b/server/src/device-auth.ts
@@ -74,6 +74,7 @@ export interface DeviceAuthConfigStatus {
   enabled: boolean;
   configError: string | null;
   verificationOrigin: string | null;
+  verificationUri: string | null;
   ttlSeconds: number;
   pollIntervalSeconds: number;
 }
@@ -643,6 +644,7 @@ export function getDeviceAuthRuntimeStatus(
     enabled: configError === null,
     configError,
     verificationOrigin,
+    verificationUri: verificationOrigin ? `${verificationOrigin}/activate` : null,
     ttlSeconds,
     pollIntervalSeconds,
   };

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 
 const defaultSupabaseUrl = "https://utvmqjssbkzpumsdpgdy.supabase.co";
 const defaultBypassToken = "playwright-smoke-token";
+const activationStorageKey = "sonde-activation-auth";
 
 function getSupabaseProjectRef(): string {
   const raw =
@@ -87,6 +88,23 @@ export async function seedSupabaseSession(
     },
     {
       key: storageKey,
+      value: session,
+    }
+  );
+}
+
+export async function seedActivationSession(
+  page: Page,
+  sessionJson: string
+): Promise<void> {
+  const session = parseSessionJson(sessionJson);
+
+  await page.addInitScript(
+    ({ key, value }) => {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    },
+    {
+      key: activationStorageKey,
       value: session,
     }
   );

--- a/ui/e2e/hosted-smoke.spec.ts
+++ b/ui/e2e/hosted-smoke.spec.ts
@@ -5,8 +5,18 @@
  * Only runs when E2E_BASE_URL is set (CI post-deploy or manual dispatch).
  * Skipped entirely during local dev (no webServer needed).
  */
-import { test, expect, type Locator, type Page } from "@playwright/test";
-import { seedActiveProgram, seedConfiguredSession } from "./helpers";
+import {
+  test,
+  expect,
+  type APIRequestContext,
+  type Locator,
+  type Page,
+} from "@playwright/test";
+import {
+  seedActivationSession,
+  seedActiveProgram,
+  seedConfiguredSession,
+} from "./helpers";
 
 const BASE_URL = process.env.E2E_BASE_URL;
 const DEPLOY_ENVIRONMENT = process.env.E2E_DEPLOY_ENVIRONMENT?.trim() || "hosted";
@@ -30,6 +40,15 @@ const SUITE_LABEL =
 
 const CHAT_AUTH_FAILURE_MARKER =
   /PGRST301|No suitable key was found to decode the JWT|JWT authentication error/i;
+
+interface DeviceActivationStartResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete: string;
+  expires_in: number;
+  interval: number;
+}
 
 function agentOrigin(value: string | null): string | null {
   if (!value) return null;
@@ -88,6 +107,88 @@ async function waitForHostedChatResponse(
 
   throw new Error(
     "Expected hosted chat to render SONDE_SMOKE_OK on the first turn."
+  );
+}
+
+async function startHostedDeviceActivation(
+  request: APIRequestContext,
+): Promise<DeviceActivationStartResponse> {
+  if (!AGENT_HTTP_BASE) {
+    throw new Error("Hosted device activation requires E2E_AGENT_HTTP_BASE.");
+  }
+
+  const response = await request.post(`${AGENT_HTTP_BASE}/auth/device/start`, {
+    data: {
+      cli_version: "hosted-smoke",
+      host_label: "ssh://hosted-smoke",
+      remote_hint: true,
+      login_method: "device",
+      request_metadata: {
+        suite: "hosted-smoke",
+      },
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+
+  return (await response.json()) as DeviceActivationStartResponse;
+}
+
+async function waitForApprovedDeviceSession(
+  request: APIRequestContext,
+  deviceCode: string,
+  pollIntervalSeconds: number,
+): Promise<{
+  status: "approved";
+  interval: number;
+  session: {
+    access_token: string;
+    refresh_token: string;
+  };
+}> {
+  if (!AGENT_HTTP_BASE) {
+    throw new Error("Hosted device activation requires E2E_AGENT_HTTP_BASE.");
+  }
+
+  const deadline = Date.now() + 30_000;
+  let lastStatus = "authorization_pending";
+
+  while (Date.now() < deadline) {
+    const response = await request.post(`${AGENT_HTTP_BASE}/auth/device/poll`, {
+      data: {
+        device_code: deviceCode,
+      },
+    });
+    expect(response.ok()).toBeTruthy();
+
+    const body = (await response.json()) as {
+      status: string;
+      interval: number;
+      session?: {
+        access_token: string;
+        refresh_token: string;
+      };
+    };
+    lastStatus = body.status;
+    if (body.status === "approved" && body.session) {
+      return body as {
+        status: "approved";
+        interval: number;
+        session: {
+          access_token: string;
+          refresh_token: string;
+        };
+      };
+    }
+    if (body.status !== "authorization_pending" && body.status !== "slow_down") {
+      throw new Error(`Hosted device activation ended in unexpected state: ${body.status}`);
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, Math.max(body.interval || pollIntervalSeconds, 1) * 1000);
+    });
+  }
+
+  throw new Error(
+    `Timed out waiting for hosted device activation approval. Last status: ${lastStatus}`,
   );
 }
 
@@ -238,6 +339,62 @@ test.describe(SUITE_LABEL, () => {
     expect(body.environment).toBeTruthy();
     expect(body.agentWsConfigured).toBeTruthy();
     expect(body.agentWsOrigin ?? null).toBe(agentOrigin(AGENT_HTTP_BASE));
+  });
+
+  test("hosted activation callback route resolves back to the activation page", async ({
+    page,
+    request,
+    browserName,
+  }) => {
+    test.skip(!AGENT_HTTP_BASE, "Skipped: no agent host configured");
+    test.skip(!AUTH_SESSION_JSON, "Skipped: no smoke auth session configured");
+    test.skip(browserName !== "chromium", "Run hosted activation smoke once to keep it lean.");
+
+    const activation = await startHostedDeviceActivation(request);
+    await seedActivationSession(page, AUTH_SESSION_JSON);
+
+    await page.goto(`/activate/callback?user_code=${encodeURIComponent(activation.user_code)}`);
+    await page.waitForURL(/\/activate(\?|$)/, { timeout: 20_000 });
+
+    const currentUrl = new URL(page.url());
+    expect(currentUrl.pathname).toBe("/activate");
+    expect(currentUrl.searchParams.get("code")).toBe(activation.user_code);
+    await expect(
+      page.getByRole("heading", { name: "Complete CLI sign-in from any browser" }),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText("ssh://hosted-smoke")).toBeVisible({ timeout: 20_000 });
+  });
+
+  test("hosted activation link can approve a headless CLI login from a browser session", async ({
+    page,
+    request,
+    browserName,
+  }) => {
+    test.skip(!AGENT_HTTP_BASE, "Skipped: no agent host configured");
+    test.skip(!AUTH_SESSION_JSON, "Skipped: no smoke auth session configured");
+    test.skip(browserName !== "chromium", "Run hosted activation smoke once to keep it lean.");
+
+    const activation = await startHostedDeviceActivation(request);
+    await seedActivationSession(page, AUTH_SESSION_JSON);
+
+    await page.goto(activation.verification_uri_complete);
+    await expect(
+      page.getByRole("heading", { name: "Complete CLI sign-in from any browser" }),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText("ssh://hosted-smoke")).toBeVisible({ timeout: 20_000 });
+
+    const approveButton = page.getByRole("button", { name: "Approve sign-in" });
+    await expect(approveButton).toBeVisible({ timeout: 20_000 });
+    await approveButton.click();
+
+    await expect(page.getByText("CLI sign-in approved")).toBeVisible({ timeout: 20_000 });
+    const approved = await waitForApprovedDeviceSession(
+      request,
+      activation.device_code,
+      activation.interval,
+    );
+    expect(approved.session.access_token).toBeTruthy();
+    expect(approved.session.refresh_token).toBeTruthy();
   });
 });
 

--- a/ui/src/lib/device-activation-browser.test.ts
+++ b/ui/src/lib/device-activation-browser.test.ts
@@ -1,0 +1,145 @@
+import type { Session } from "@supabase/supabase-js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ACTIVATION_CODE_STORAGE_KEY,
+  buildActivationCallbackHref,
+  requestActivationBrowserSignIn,
+  resolveActivationCallbackHref,
+} from "./device-activation-browser";
+
+const activationSession: Session = {
+  access_token: "access-token",
+  refresh_token: "refresh-token",
+  token_type: "bearer",
+  expires_in: 3600,
+  expires_at: 1_900_000_000,
+  user: {
+    id: "user-1",
+    aud: "authenticated",
+    role: "authenticated",
+    email: "mason@aeolus.earth",
+    email_confirmed_at: "2026-04-14T00:00:00.000Z",
+    phone: "",
+    confirmed_at: "2026-04-14T00:00:00.000Z",
+    last_sign_in_at: "2026-04-14T00:00:00.000Z",
+    app_metadata: {
+      provider: "google",
+      providers: ["google"],
+    },
+    user_metadata: {
+      full_name: "Mason",
+    },
+    identities: [],
+    created_at: "2026-04-14T00:00:00.000Z",
+    updated_at: "2026-04-14T00:00:00.000Z",
+    is_anonymous: false,
+  },
+};
+
+describe("device activation browser helpers", () => {
+  it("builds the hosted activation callback URL", () => {
+    expect(
+      buildActivationCallbackHref("https://sonde-staging.vercel.app/", "ABCD-2345"),
+    ).toBe("https://sonde-staging.vercel.app/activate/callback?user_code=ABCD-2345");
+  });
+
+  it("starts Google sign-in with the hosted callback URL and domain restriction", async () => {
+    const setItem = vi.fn();
+    const signInWithOAuth = vi.fn(async () => ({ error: null }));
+
+    const result = await requestActivationBrowserSignIn({
+      rawCode: "ab cd 23 45",
+      windowOrigin: "https://sonde-neon.vercel.app",
+      storage: { setItem },
+      authClient: { signInWithOAuth },
+    });
+
+    expect(result).toEqual({
+      normalizedCode: "ABCD-2345",
+      error: null,
+    });
+    expect(setItem).toHaveBeenCalledWith(ACTIVATION_CODE_STORAGE_KEY, "ABCD-2345");
+    expect(signInWithOAuth).toHaveBeenCalledWith({
+      provider: "google",
+      options: {
+        redirectTo: "https://sonde-neon.vercel.app/activate/callback?user_code=ABCD-2345",
+        queryParams: {
+          hd: "aeolus.earth",
+        },
+      },
+    });
+  });
+
+  it("returns a validation error when the activation code is missing", async () => {
+    const signInWithOAuth = vi.fn();
+
+    const result = await requestActivationBrowserSignIn({
+      rawCode: "bad",
+      windowOrigin: "https://sonde-neon.vercel.app",
+      authClient: { signInWithOAuth },
+    });
+
+    expect(result).toEqual({
+      normalizedCode: null,
+      error: "Enter the activation code from your terminal first.",
+    });
+    expect(signInWithOAuth).not.toHaveBeenCalled();
+  });
+
+  it("resolves the callback through the existing activation session when no OAuth code is present", async () => {
+    const href = await resolveActivationCallbackHref({
+      search: "?user_code=ABCD-2345",
+      storedCode: "",
+      authClient: {
+        exchangeCodeForSession: vi.fn(async () => ({ error: null })),
+        getSession: vi.fn(async () => ({
+          data: {
+            session: activationSession,
+          },
+          error: null,
+        })),
+      },
+    });
+
+    expect(href).toBe("/activate?code=ABCD-2345");
+  });
+
+  it("surfaces code-exchange failures back on the activation page", async () => {
+    const exchangeCodeForSession = vi.fn(async () => ({
+      error: { message: "The redirect URI is not allowed." },
+    }));
+
+    const href = await resolveActivationCallbackHref({
+      search: "?code=oauth-code&user_code=ABCD-2345",
+      storedCode: "",
+      authClient: {
+        exchangeCodeForSession,
+        getSession: vi.fn(async () => ({
+          data: { session: null },
+          error: null,
+        })),
+      },
+    });
+
+    expect(exchangeCodeForSession).toHaveBeenCalledWith("oauth-code");
+    expect(href).toBe(
+      "/activate?code=ABCD-2345&error=The+redirect+URI+is+not+allowed.",
+    );
+  });
+
+  it("surfaces OAuth provider errors back on the activation page", async () => {
+    const href = await resolveActivationCallbackHref({
+      search: "?error=access_denied&error_description=User+denied+access&user_code=ABCD-2345",
+      storedCode: "",
+      authClient: {
+        exchangeCodeForSession: vi.fn(async () => ({ error: null })),
+        getSession: vi.fn(async () => ({
+          data: { session: null },
+          error: null,
+        })),
+      },
+    });
+
+    expect(href).toBe("/activate?code=ABCD-2345&error=User+denied+access");
+  });
+});

--- a/ui/src/lib/device-activation-browser.ts
+++ b/ui/src/lib/device-activation-browser.ts
@@ -1,0 +1,123 @@
+import type { Session } from "@supabase/supabase-js";
+import { normalizeActivationCode } from "./device-activation";
+
+export const ACTIVATION_CODE_STORAGE_KEY = "sonde-activation-code";
+
+export interface ActivationOAuthClient {
+  signInWithOAuth(input: {
+    provider: "google";
+    options: {
+      redirectTo: string;
+      queryParams: {
+        hd: "aeolus.earth";
+      };
+    };
+  }): Promise<{ error: { message: string } | null }>;
+}
+
+export interface ActivationCallbackAuthClient {
+  exchangeCodeForSession(code: string): Promise<{ error: { message: string } | null }>;
+  getSession(): Promise<{
+    data: { session: Session | null };
+    error: { message: string } | null;
+  }>;
+}
+
+export function buildActivationCallbackHref(origin: string, userCode: string): string {
+  return `${origin.replace(/\/+$/, "")}/activate/callback?user_code=${encodeURIComponent(userCode)}`;
+}
+
+export function buildActivationReturnHref(userCode: string, error?: string): string {
+  const params = new URLSearchParams();
+  if (userCode) {
+    params.set("code", userCode);
+  }
+  if (error) {
+    params.set("error", error);
+  }
+  return params.size > 0 ? `/activate?${params.toString()}` : "/activate";
+}
+
+export async function requestActivationBrowserSignIn({
+  rawCode,
+  fallbackCode,
+  windowOrigin,
+  storage,
+  authClient,
+}: {
+  rawCode: string;
+  fallbackCode?: string;
+  windowOrigin: string;
+  storage?: Pick<Storage, "setItem">;
+  authClient: ActivationOAuthClient;
+}): Promise<{ normalizedCode: string | null; error: string | null }> {
+  const normalizedCode = normalizeActivationCode(rawCode || fallbackCode || "");
+  if (!normalizedCode) {
+    return {
+      normalizedCode: null,
+      error: "Enter the activation code from your terminal first.",
+    };
+  }
+
+  storage?.setItem(ACTIVATION_CODE_STORAGE_KEY, normalizedCode);
+  const { error } = await authClient.signInWithOAuth({
+    provider: "google",
+    options: {
+      redirectTo: buildActivationCallbackHref(windowOrigin, normalizedCode),
+      queryParams: {
+        hd: "aeolus.earth",
+      },
+    },
+  });
+
+  return {
+    normalizedCode,
+    error: error?.message ?? null,
+  };
+}
+
+export async function resolveActivationCallbackHref({
+  search,
+  storedCode,
+  authClient,
+}: {
+  search: string;
+  storedCode: string;
+  authClient: ActivationCallbackAuthClient;
+}): Promise<string> {
+  const params = new URLSearchParams(search);
+  const oauthError = params.get("error_description") || params.get("error") || "";
+  const oauthCode = params.get("code") || "";
+  const userCode = normalizeActivationCode(params.get("user_code") || storedCode || "");
+
+  if (oauthError) {
+    return buildActivationReturnHref(userCode, oauthError);
+  }
+
+  try {
+    if (oauthCode) {
+      const exchanged = await authClient.exchangeCodeForSession(oauthCode);
+      if (exchanged.error) {
+        return buildActivationReturnHref(userCode, exchanged.error.message);
+      }
+    } else {
+      const {
+        data: { session },
+        error,
+      } = await authClient.getSession();
+      if (error) {
+        return buildActivationReturnHref(userCode, error.message);
+      }
+      if (!session) {
+        return buildActivationReturnHref(userCode, "Activation sign-in did not complete.");
+      }
+    }
+  } catch (error) {
+    return buildActivationReturnHref(
+      userCode,
+      error instanceof Error ? error.message : "Activation sign-in did not complete.",
+    );
+  }
+
+  return buildActivationReturnHref(userCode);
+}

--- a/ui/src/routes/activate-callback.tsx
+++ b/ui/src/routes/activate-callback.tsx
@@ -2,9 +2,11 @@ import { useEffect } from "react";
 import { createRoute, useNavigate } from "@tanstack/react-router";
 import { Route as rootRoute } from "./__root";
 import { activationSupabase } from "@/lib/activation-supabase";
+import {
+  ACTIVATION_CODE_STORAGE_KEY,
+  resolveActivationCallbackHref,
+} from "@/lib/device-activation-browser";
 import { Spinner } from "@/components/ui/spinner";
-
-const ACTIVATION_CODE_STORAGE_KEY = "sonde-activation-code";
 
 function ActivationCallbackPage() {
   const navigate = useNavigate();
@@ -13,62 +15,16 @@ function ActivationCallbackPage() {
     let alive = true;
 
     void (async () => {
-      const params = new URLSearchParams(window.location.search);
-      const oauthError =
-        params.get("error_description") || params.get("error") || "";
-      const oauthCode = params.get("code") || "";
       const storedCode = sessionStorage.getItem(ACTIVATION_CODE_STORAGE_KEY) || "";
-      const userCode = params.get("user_code") || storedCode;
-
-      const redirectWithError = async (message: string) => {
-        sessionStorage.removeItem(ACTIVATION_CODE_STORAGE_KEY);
-        if (!alive) return;
-        navigate({
-          href: `/activate?${new URLSearchParams({
-            ...(userCode ? { code: userCode } : {}),
-            error: message,
-          }).toString()}`,
-          replace: true,
-        });
-      };
-
-      if (oauthError) {
-        await redirectWithError(oauthError);
-        return;
-      }
-
-      try {
-        if (oauthCode) {
-          const exchanged = await activationSupabase.auth.exchangeCodeForSession(oauthCode);
-          if (exchanged.error) {
-            await redirectWithError(exchanged.error.message);
-            return;
-          }
-        } else {
-          const {
-            data: { session },
-            error: currentError,
-          } = await activationSupabase.auth.getSession();
-          if (currentError) {
-            await redirectWithError(currentError.message);
-            return;
-          }
-          if (!session) {
-            await redirectWithError("Activation sign-in did not complete.");
-            return;
-          }
-        }
-      } catch (error) {
-        await redirectWithError(
-          error instanceof Error ? error.message : "Activation sign-in did not complete."
-        );
-        return;
-      }
-
-      if (!alive) return;
+      const href = await resolveActivationCallbackHref({
+        search: window.location.search,
+        storedCode,
+        authClient: activationSupabase.auth,
+      });
       sessionStorage.removeItem(ACTIVATION_CODE_STORAGE_KEY);
+      if (!alive) return;
       navigate({
-        href: userCode ? `/activate?code=${encodeURIComponent(userCode)}` : "/activate",
+        href,
         replace: true,
       });
     })();

--- a/ui/src/routes/activate.tsx
+++ b/ui/src/routes/activate.tsx
@@ -9,12 +9,14 @@ import {
   normalizeActivationCode,
   type DeviceActivationDetails,
 } from "@/lib/device-activation";
+import {
+  ACTIVATION_CODE_STORAGE_KEY,
+  requestActivationBrowserSignIn,
+} from "@/lib/device-activation-browser";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
-
-const ACTIVATION_CODE_STORAGE_KEY = "sonde-activation-code";
 
 function ActivationPage() {
   const searchParams =
@@ -117,30 +119,20 @@ function ActivationPage() {
   }
 
   async function signIn(): Promise<void> {
-    const normalized = normalizeActivationCode(draftCode || userCode);
-    if (!normalized) {
-      setError("Enter the activation code from your terminal first.");
+    const storage =
+      typeof window !== "undefined" ? window.sessionStorage : undefined;
+    const { normalizedCode, error: signInError } = await requestActivationBrowserSignIn({
+      rawCode: draftCode,
+      fallbackCode: userCode,
+      windowOrigin: window.location.origin,
+      storage,
+      authClient: activationSupabase.auth,
+    });
+    if (!normalizedCode) {
+      setError(signInError);
       return;
     }
-    if (typeof window !== "undefined") {
-      window.sessionStorage.setItem(ACTIVATION_CODE_STORAGE_KEY, normalized);
-    }
-    setError(null);
-    const redirectTo = `${window.location.origin}/activate/callback?user_code=${encodeURIComponent(
-      normalized
-    )}`;
-    const { error: signInError } = await activationSupabase.auth.signInWithOAuth({
-      provider: "google",
-      options: {
-        redirectTo,
-        queryParams: {
-          hd: "aeolus.earth",
-        },
-      },
-    });
-    if (signInError) {
-      setError(signInError.message);
-    }
+    setError(signInError);
   }
 
   async function handleDecision(nextDecision: "approve" | "deny"): Promise<void> {


### PR DESCRIPTION
## Summary
- make hosted OAuth deploy-gated by proving the real browser activation leg
- tighten public device-auth health so it no longer exposes detailed config internals
- add focused activation redirect/callback helper coverage and hosted smoke checks

## What changed
- reduced public `GET /auth/device/health` to a minimal `status` + `enabled` surface
- extended `audit-deployed-stack` to verify both `/activate` and `/activate/callback`
- added hosted Playwright activation smoke that approves a real device login from a browser session and polls it to completion
- extracted activation browser/callback logic into testable UI helpers
- relabeled the CLI hosted audit so it is clearly the device approval contract check, not the full browser-leg proof

## Verification
- `cd server && node --import tsx --test src/app.test.ts src/device-auth.test.ts`
- `cd ui && npm run test -- src/lib/device-activation.test.ts src/lib/device-activation-browser.test.ts`
- `cd ui && npm run lint`
- `cd server && npm run lint`
- `cd ui && npm run build`
