### PR TITLE
fix(ui): recover cleanly from idle auth expiry

### DIFF
--- a/ui/e2e/ci-smoke.spec.ts
+++ b/ui/e2e/ci-smoke.spec.ts
@@ -22,6 +22,52 @@ async function mockProgramsRoute(page: Page) {
   });
 }
 
+async function mockTimelineExperimentSummaryRoute(page: Page) {
+  await page.route("**/rest/v1/experiment_summary*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          id: "EXP-CI-0001",
+          program: "shared",
+          status: "complete",
+          source: "ci-smoke",
+          content: null,
+          hypothesis: "CI smoke timeline experiment",
+          parameters: {},
+          results: null,
+          finding: null,
+          metadata: {},
+          git_commit: "0123456789abcdef0123456789abcdef01234567",
+          git_repo: "https://github.com/aeolus-earth/sonde",
+          git_branch: "main",
+          git_close_commit: null,
+          git_close_branch: null,
+          git_dirty: false,
+          code_context: null,
+          data_sources: [],
+          tags: [],
+          direction_id: null,
+          project_id: null,
+          linear_id: null,
+          related: [],
+          parent_id: null,
+          branch_type: null,
+          claimed_by: null,
+          claimed_at: null,
+          run_at: null,
+          created_at: "2026-04-14T00:00:00.000Z",
+          updated_at: "2026-04-14T00:00:00.000Z",
+          artifact_count: 0,
+          artifact_types: null,
+          artifact_filenames: null,
+        },
+      ]),
+    });
+  });
+}
+
 test.describe("CI smoke", () => {
   test("login renders without third-party auth gate", async ({ page }) => {
     await page.goto("/login");
@@ -109,6 +155,41 @@ test.describe("CI smoke", () => {
     ).not.toBeVisible();
   });
 
+  test("chat shows an inline sign-in-again CTA when the chat session token expires", async ({
+    page,
+  }) => {
+    await seedBypassSession(page);
+    await seedActiveProgram(page, "shared");
+    await mockProgramsRoute(page);
+
+    await page.route("**/chat/session-token", async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: {
+            type: "unauthorized",
+            message: "Missing or invalid Sonde session token",
+          },
+        }),
+      });
+    });
+
+    await page.goto("/");
+
+    const authBanner = page
+      .getByRole("alert")
+      .filter({ hasText: "Session expired" })
+      .first();
+
+    await expect(authBanner).toBeVisible({ timeout: 20_000 });
+    await expect(authBanner.getByRole("button", { name: "Sign in again" })).toBeVisible();
+    await expect(
+      page.locator('textarea[aria-label="Chat message"]:visible').first()
+    ).not.toBeEditable();
+    await expect(page.getByText("Chat session token request failed (401)")).not.toBeVisible();
+  });
+
   test("chat renders a final-only assistant response", async ({ page }) => {
     await seedBypassSession(page);
     await seedActiveProgram(page, "shared");
@@ -126,5 +207,35 @@ test.describe("CI smoke", () => {
     await expect(page.getByText(/Mock response:/)).toBeVisible({
       timeout: 15_000,
     });
+  });
+
+  test("timeline shows an inline sign-in-again CTA when the proxy request is unauthorized", async ({
+    page,
+  }) => {
+    await seedBypassSession(page);
+    await seedActiveProgram(page, "shared");
+    await mockProgramsRoute(page);
+    await mockTimelineExperimentSummaryRoute(page);
+    await page.route("**/github/repos/**/commits*", async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: {
+            type: "unauthorized",
+            message: "Sign in again to load timeline commit history.",
+          },
+        }),
+      });
+    });
+
+    await page.goto("/timeline");
+    await page.getByRole("button", { name: "Load commit history" }).first().click();
+
+    const timelineError = page
+      .getByText("Sign in again to load timeline commit history.")
+      .first();
+    await expect(timelineError).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByRole("button", { name: "Sign in again" })).toBeVisible();
   });
 });

--- a/ui/e2e/hosted-smoke.spec.ts
+++ b/ui/e2e/hosted-smoke.spec.ts
@@ -17,6 +17,11 @@ import {
   seedActiveProgram,
   seedConfiguredSession,
 } from "./helpers";
+import {
+  seedActivationSession,
+  seedActiveProgram,
+  seedConfiguredSession,
+} from "./helpers";
 
 const BASE_URL = process.env.E2E_BASE_URL;
 const DEPLOY_ENVIRONMENT = process.env.E2E_DEPLOY_ENVIRONMENT?.trim() || "hosted";
@@ -50,10 +55,28 @@ interface DeviceActivationStartResponse {
   interval: number;
 }
 
+const TIMELINE_PROXY_REPO = {
+  owner: "aeolus-earth",
+  repo: "sonde",
+};
+
 function agentOrigin(value: string | null): string | null {
   if (!value) return null;
   return new URL(value).origin;
 }
+
+function normalizeAuthMode(value: string): string {
+  return value.toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function readAccessToken(sessionJson: string | null): string | null {
+  if (!sessionJson) return null;
+  const parsed = JSON.parse(sessionJson) as { access_token?: string | null };
+  const token = parsed.access_token?.trim() || "";
+  return token || null;
+}
+
+const AUTH_ACCESS_TOKEN = readAccessToken(AUTH_SESSION_JSON);
 
 async function readVisibleText(page: Page, selector: string): Promise<string | null> {
   const locator = page.locator(selector).first();
@@ -62,6 +85,46 @@ async function readVisibleText(page: Page, selector: string): Promise<string | n
   }
   const text = await locator.textContent().catch(() => "");
   return text?.trim() || null;
+}
+
+async function assertTimelineProxyAvailable(request: APIRequestContext): Promise<void> {
+  if (!AGENT_HTTP_BASE) {
+    throw new Error("Timeline proxy smoke requires E2E_AGENT_HTTP_BASE.");
+  }
+  if (!AUTH_ACCESS_TOKEN) {
+    throw new Error("Timeline proxy smoke requires E2E_AUTH_SESSION_JSON with an access token.");
+  }
+
+  const response = await request.get(
+    `${AGENT_HTTP_BASE}/github/repos/${TIMELINE_PROXY_REPO.owner}/${TIMELINE_PROXY_REPO.repo}/commits?per_page=25`,
+    {
+      headers: {
+        Authorization: `Bearer ${AUTH_ACCESS_TOKEN}`,
+      },
+    }
+  );
+  const bodyText = await response.text();
+  expect(
+    response.ok(),
+    `Timeline proxy request failed: ${response.status()} ${bodyText.slice(0, 240)}`
+  ).toBeTruthy();
+
+  const body = JSON.parse(bodyText) as {
+    commits: Array<{ sha: string }>;
+    repo: { owner: string; repo: string };
+    diagnostics: {
+      authMode: string;
+      upstreamRequests: number;
+    };
+  };
+
+  expect(body.repo.owner).toBe(TIMELINE_PROXY_REPO.owner);
+  expect(body.repo.repo).toBe(TIMELINE_PROXY_REPO.repo);
+  expect(body.commits.length).toBeGreaterThan(0);
+  expect(normalizeAuthMode(body.diagnostics.authMode)).toBe(
+    normalizeAuthMode(EXPECT_TIMELINE_AUTH_MODE)
+  );
+  expect(body.diagnostics.upstreamRequests).toBeGreaterThanOrEqual(0);
 }
 
 async function waitForHostedChatResponse(
@@ -445,25 +508,48 @@ test.describe(`${SUITE_LABEL} authenticated flows`, () => {
     });
   });
 
-  test("timeline loads commit history through the server proxy", async ({ page }) => {
+  test("timeline loads commit history through the server proxy", async ({
+    page,
+    request,
+  }) => {
     await page.goto("/timeline");
 
-    const loadButton = page.getByRole("button", { name: "Load commit history" }).first();
-    await expect(loadButton).toBeVisible({ timeout: 20_000 });
-    await loadButton.click();
+    const diagnosticsAuthMode = page.getByText(new RegExp(EXPECT_TIMELINE_AUTH_MODE, "i")).first();
+    if (await diagnosticsAuthMode.isVisible().catch(() => false)) {
+      await expect(page.getByText(/upstream GitHub request/i)).toBeVisible({
+        timeout: 60_000,
+      });
+      return;
+    }
 
-    const timelineError = page.getByText(/Failed to load commit history|Sign in again|Repository not accessible|Server GitHub token is invalid|Hosted Sonde UI is missing VITE_AGENT_WS_URL/i);
+    const loadButton = page.getByRole("button", { name: "Load commit history" }).first();
+    if (await loadButton.isVisible().catch(() => false)) {
+      await loadButton.click();
+
+      const timelineError = page.getByText(/Failed to load commit history|Sign in again|Repository not accessible|Server GitHub token is invalid|Hosted Sonde UI is missing VITE_AGENT_WS_URL/i);
+      await expect(
+        page.getByText(new RegExp(EXPECT_TIMELINE_AUTH_MODE, "i"))
+      ).toBeVisible({ timeout: 60_000 }).catch(async () => {
+        const errorText = await timelineError.first().textContent().catch(() => "");
+        throw new Error(
+          `Timeline diagnostics never loaded expected auth mode (${EXPECT_TIMELINE_AUTH_MODE}). Visible error: ${errorText || "(none)"}`
+        );
+      });
+      await expect(page.getByText(/upstream GitHub request/i)).toBeVisible({
+        timeout: 60_000,
+      });
+      return;
+    }
+
+    await expect(page.getByText("No git-linked experiments found")).toBeVisible({
+      timeout: 20_000,
+    });
     await expect(
-      page.getByText(new RegExp(EXPECT_TIMELINE_AUTH_MODE, "i"))
-    ).toBeVisible({ timeout: 60_000 }).catch(async () => {
-      const errorText = await timelineError.first().textContent().catch(() => "");
-      throw new Error(
-        `Timeline diagnostics never loaded expected auth mode (${EXPECT_TIMELINE_AUTH_MODE}). Visible error: ${errorText || "(none)"}`
-      );
-    });
-    await expect(page.getByText(/upstream GitHub request/i)).toBeVisible({
-      timeout: 60_000,
-    });
+      page.getByText(
+        "Experiments logged with sonde log from inside a git repo will appear here."
+      )
+    ).toBeVisible();
+    await assertTimelineProxyAvailable(request);
   });
 
   test("chat connects and renders a hosted agent response on the first turn", async ({

--- a/ui/e2e/hosted-smoke.spec.ts
+++ b/ui/e2e/hosted-smoke.spec.ts
@@ -17,11 +17,6 @@ import {
   seedActiveProgram,
   seedConfiguredSession,
 } from "./helpers";
-import {
-  seedActivationSession,
-  seedActiveProgram,
-  seedConfiguredSession,
-} from "./helpers";
 
 const BASE_URL = process.env.E2E_BASE_URL;
 const DEPLOY_ENVIRONMENT = process.env.E2E_DEPLOY_ENVIRONMENT?.trim() || "hosted";

--- a/ui/src/components/auth/inline-reauth-button.tsx
+++ b/ui/src/components/auth/inline-reauth-button.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { LogIn } from "lucide-react";
+import { currentAuthReturnPath } from "@/lib/auth-redirect";
+import { cn } from "@/lib/utils";
+import { useAuthStore } from "@/stores/auth";
+
+interface InlineReauthButtonProps {
+  label?: string;
+  returnPath?: string;
+  className?: string;
+}
+
+export function InlineReauthButton({
+  label = "Sign in again",
+  returnPath,
+  className,
+}: InlineReauthButtonProps) {
+  const signInWithGoogle = useAuthStore((s) => s.signInWithGoogle);
+  const [pending, setPending] = useState(false);
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        setPending(true);
+        void signInWithGoogle({
+          returnPath: returnPath ?? currentAuthReturnPath(),
+        }).finally(() => {
+          setPending(false);
+        });
+      }}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-[5.5px] bg-accent px-2.5 py-1 text-[11px] font-medium text-on-accent transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-70",
+        className,
+      )}
+      disabled={pending}
+    >
+      <LogIn className="h-3.5 w-3.5" />
+      {pending ? "Opening sign-in…" : label}
+    </button>
+  );
+}

--- a/ui/src/components/chat/chat-connection-banner.tsx
+++ b/ui/src/components/chat/chat-connection-banner.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { AlertCircle, RefreshCw, WifiOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ConnectionStatus } from "@/types/chat";
+import { InlineReauthButton } from "@/components/auth/inline-reauth-button";
 import { ChatConnectionDot } from "./chat-connection-dot";
 
 interface ChatConnectionBannerProps {
@@ -19,6 +20,12 @@ const statusMeta: Record<
     icon: typeof WifiOff;
   }
 > = {
+  auth_required: {
+    title: "Session expired",
+    detail: "Sign in again to reconnect this chat without leaving the current page.",
+    chip: "Sign in again",
+    icon: AlertCircle,
+  },
   disconnected: {
     title: "Agent not connected",
     detail: "Messages will send once the session is available again.",
@@ -55,7 +62,11 @@ export const ChatConnectionBanner = memo(function ChatConnectionBanner({
 
   return (
     <div
-      role={connectionStatus === "disconnected" ? "alert" : "status"}
+      role={
+        connectionStatus === "disconnected" || connectionStatus === "auth_required"
+          ? "alert"
+          : "status"
+      }
       className={cn(
         "mb-3 flex items-start gap-3 rounded-[18px] border px-3.5 py-3 shadow-sm backdrop-blur-xl",
         glass
@@ -110,6 +121,9 @@ export const ChatConnectionBanner = memo(function ChatConnectionBanner({
             >
               <span className="truncate">{agentModel}</span>
             </span>
+          ) : null}
+          {connectionStatus === "auth_required" ? (
+            <InlineReauthButton className="ml-auto" />
           ) : null}
         </div>
       </div>

--- a/ui/src/components/chat/chat-connection-dot.tsx
+++ b/ui/src/components/chat/chat-connection-dot.tsx
@@ -7,6 +7,7 @@ const statusClass: Record<ConnectionStatus, string> = {
   connecting: "bg-status-running animate-pulse",
   reconnecting: "bg-status-open animate-pulse",
   recovering: "bg-accent animate-pulse",
+  auth_required: "bg-status-failed",
   disconnected: "bg-status-failed",
 };
 
@@ -15,6 +16,7 @@ const statusTitle: Record<ConnectionStatus, string> = {
   connecting: "Connecting…",
   reconnecting: "Reconnecting…",
   recovering: "Recovering session…",
+  auth_required: "Session expired",
   disconnected: "Disconnected",
 };
 

--- a/ui/src/hooks/use-admin.ts
+++ b/ui/src/hooks/use-admin.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient, keepPreviousData } from "@tansta
 import { supabase } from "@/lib/supabase";
 import { useEffect } from "react";
 import { getAgentHttpBase } from "@/lib/agent-http";
+import { getFreshAccessToken, SessionReauthRequiredError } from "@/lib/session-auth";
 import { useAddToast } from "@/stores/toast";
 
 export interface AdminStats {
@@ -273,14 +274,9 @@ export function useAuthEvents(limit = 50) {
 }
 
 async function getAdminAccessToken(): Promise<string> {
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const token = session?.access_token?.trim() ?? "";
-  if (!token) {
-    throw new Error("You need to be signed in to access admin diagnostics.");
-  }
-  return token;
+  return getFreshAccessToken({
+    reauthMessage: "Session expired. Sign in again to access admin diagnostics.",
+  });
 }
 
 async function fetchAdminJson<T>(path: string, init?: RequestInit): Promise<T> {
@@ -294,6 +290,11 @@ async function fetchAdminJson<T>(path: string, init?: RequestInit): Promise<T> {
     },
   });
   if (!response.ok) {
+    if (response.status === 401) {
+      throw new SessionReauthRequiredError(
+        "Session expired. Sign in again to access admin diagnostics.",
+      );
+    }
     const text = await response.text();
     throw new Error(text || `Admin request failed (${response.status})`);
   }

--- a/ui/src/hooks/use-chat.ts
+++ b/ui/src/hooks/use-chat.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef } from "react";
-import { supabase } from "@/lib/supabase";
 import { useAuthStore } from "@/stores/auth";
 import {
   useChatStoreApi,
@@ -13,12 +12,18 @@ import {
   getAgentWsBase,
   HostedAgentConfigError,
 } from "@/lib/agent-http";
+import {
+  getFreshAccessToken,
+  SessionReauthRequiredError,
+} from "@/lib/session-auth";
 import type {
   MentionRef,
   ServerMessage,
   ClientMessage,
 } from "@/types/chat";
 import { expandDefendExistenceCommand } from "@/lib/defend-existence";
+
+const CHAT_REAUTH_MESSAGE = "Session expired. Sign in again to reconnect chat.";
 
 async function fetchChatSessionToken(accessToken: string): Promise<string> {
   const response = await fetch(`${getAgentHttpBase()}/chat/session-token`, {
@@ -28,6 +33,9 @@ async function fetchChatSessionToken(accessToken: string): Promise<string> {
     },
   });
   if (!response.ok) {
+    if (response.status === 401) {
+      throw new SessionReauthRequiredError(CHAT_REAUTH_MESSAGE);
+    }
     throw new Error(`Chat session token request failed (${response.status})`);
   }
   const payload = (await response.json()) as { token?: string };
@@ -310,7 +318,6 @@ export function useChat() {
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectDelay = useRef(RECONNECT_BASE_MS);
   const authFailureRef = useRef(false);
-  const authErrorLoggedRef = useRef(false);
   const connectionIssueRef = useRef<string | null>(null);
   const recoveringSessionIdRef = useRef<string | null>(null);
   const connectRef = useRef<() => Promise<void>>(async () => {});
@@ -321,6 +328,16 @@ export function useChat() {
       reconnectTimer.current = null;
     }
   }, []);
+
+  const setAuthRequiredState = useCallback(() => {
+    authFailureRef.current = true;
+    connectionIssueRef.current = null;
+    clearReconnectTimer();
+    const store = chatStoreApiRef.current.getState();
+    store.setConnectionStatus("auth_required");
+    store.setStreaming(false);
+    store.setStreamingTabId(null);
+  }, [clearReconnectTimer]);
 
   const scheduleReconnect = useCallback(() => {
     if (authFailureRef.current) return;
@@ -366,29 +383,23 @@ export function useChat() {
 
   const connect = useCallback(async () => {
     if (authFailureRef.current) return;
-
-    const { data: sessionData, error: sessionError } =
-      await supabase.auth.getSession();
-    if (sessionError || !sessionData.session?.access_token) {
+    let token: string;
+    try {
+      token = await getFreshAccessToken({
+        reauthMessage: CHAT_REAUTH_MESSAGE,
+      });
+    } catch (error) {
+      if (error instanceof SessionReauthRequiredError) {
+        chatDebug("connect:reauth-required");
+        setAuthRequiredState();
+        return;
+      }
       chatDebug("connect:no-session", {
-        hasError: Boolean(sessionError),
+        message: error instanceof Error ? error.message : String(error),
       });
       chatStoreApiRef.current.getState().setConnectionStatus("disconnected");
       return;
     }
-
-    let sess = sessionData.session;
-    const expiresAtMs = (sess.expires_at ?? 0) * 1000;
-    if (expiresAtMs < Date.now() + 60_000) {
-      const { data: refreshed, error: refreshErr } =
-        await supabase.auth.refreshSession();
-      if (!refreshErr && refreshed.session?.access_token) {
-        sess = refreshed.session;
-      }
-    }
-
-    const token = sess.access_token;
-    if (!token) return;
 
     const existingSocket = wsRef.current;
     if (
@@ -410,6 +421,11 @@ export function useChat() {
       wsToken = await fetchChatSessionToken(token);
       wsBase = getAgentWsBase();
     } catch (error) {
+      if (error instanceof SessionReauthRequiredError) {
+        chatDebug("connect:session-token-reauth");
+        setAuthRequiredState();
+        return;
+      }
       chatDebug("connect:session-token-error", {
         message: error instanceof Error ? error.message : String(error),
       });
@@ -437,7 +453,6 @@ export function useChat() {
         authSent: false,
       });
       authFailureRef.current = false;
-      authErrorLoggedRef.current = false;
       connectionIssueRef.current = null;
       chatStoreApiRef.current.getState().setConnectionStatus("connecting");
       reconnectDelay.current = RECONNECT_BASE_MS;
@@ -505,25 +520,9 @@ export function useChat() {
 
       if (ev.code === WS_CLOSE_UNAUTHORIZED) {
         void (async () => {
-          const { data: r } = await supabase.auth.refreshSession();
-          if (r.session?.access_token) {
-            authFailureRef.current = false;
-            reconnectDelay.current = RECONNECT_BASE_MS;
-            await connectRef.current();
-            return;
-          }
-          authFailureRef.current = true;
-          if (!authErrorLoggedRef.current) {
-            authErrorLoggedRef.current = true;
-            const s = chatStoreApiRef.current.getState();
-            s.addMessage(s.activeTabId, {
-              id: crypto.randomUUID(),
-              role: "system",
-              content:
-                "Chat could not verify your session. Sign out and sign in again, and ensure the agent server uses the same Supabase URL and anon key as this app (see server/example.env).",
-              timestamp: Date.now(),
-            });
-          }
+          authFailureRef.current = false;
+          reconnectDelay.current = RECONNECT_BASE_MS;
+          await connectRef.current();
         })();
         return;
       }
@@ -535,13 +534,12 @@ export function useChat() {
       chatDebug("ws:error-event");
       ws.close();
     };
-  }, [scheduleReconnect]);
+  }, [scheduleReconnect, setAuthRequiredState]);
 
   connectRef.current = connect;
 
   useEffect(() => {
     authFailureRef.current = false;
-    authErrorLoggedRef.current = false;
     connectionIssueRef.current = null;
 
     if (!accessToken) {
@@ -562,6 +560,40 @@ export function useChat() {
       // here would kill in-flight queries. Connection persists via wsRef.
     };
   }, [accessToken, authLoading, connect, clearReconnectTimer]);
+
+  useEffect(() => {
+    const refreshOnReturn = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+      if (!useAuthStore.getState().session) {
+        return;
+      }
+
+      void (async () => {
+        try {
+          await getFreshAccessToken({
+            reauthMessage: CHAT_REAUTH_MESSAGE,
+          });
+          if (chatStoreApiRef.current.getState().connectionStatus === "auth_required") {
+            authFailureRef.current = false;
+            await connectRef.current();
+          }
+        } catch (error) {
+          if (error instanceof SessionReauthRequiredError) {
+            setAuthRequiredState();
+          }
+        }
+      })();
+    };
+
+    window.addEventListener("focus", refreshOnReturn);
+    document.addEventListener("visibilitychange", refreshOnReturn);
+    return () => {
+      window.removeEventListener("focus", refreshOnReturn);
+      document.removeEventListener("visibilitychange", refreshOnReturn);
+    };
+  }, [setAuthRequiredState]);
 
   const send = useCallback(
     async (content: string, mentions: MentionRef[] = [], files: File[] = []) => {

--- a/ui/src/lib/auth-redirect.ts
+++ b/ui/src/lib/auth-redirect.ts
@@ -5,3 +5,13 @@ export function safeAuthRedirect(redirect: string | undefined): string {
   if (!t.startsWith("/") || t.startsWith("//")) return "/";
   return t;
 }
+
+export function currentAuthReturnPath(
+  locationLike:
+    | Pick<Location, "pathname" | "search">
+    | null
+    | undefined = typeof window !== "undefined" ? window.location : undefined,
+): string {
+  if (!locationLike) return "/";
+  return safeAuthRedirect(`${locationLike.pathname}${locationLike.search}`);
+}

--- a/ui/src/lib/github-api.ts
+++ b/ui/src/lib/github-api.ts
@@ -1,5 +1,8 @@
 import { getAgentHttpBase } from "@/lib/agent-http";
-import { supabase } from "@/lib/supabase";
+import {
+  getFreshAccessToken,
+  SessionReauthRequiredError,
+} from "@/lib/session-auth";
 import { useGitHubRateLimitStore } from "@/stores/github-rate-limit";
 import type { CommitPage } from "@/types/github";
 
@@ -52,8 +55,8 @@ export class BranchNotFoundError extends Error {
   }
 }
 
-export class GitHubProxyAuthError extends Error {
-  constructor(message = "Timeline request is unauthorized") {
+export class GitHubProxyAuthError extends SessionReauthRequiredError {
+  constructor(message = "Sign in again to load timeline commit history.") {
     super(message);
     this.name = "GitHubProxyAuthError";
   }
@@ -67,15 +70,9 @@ export class GitHubProxyConfigError extends Error {
 }
 
 async function getAccessToken(): Promise<string> {
-  const current = supabase.auth.getSession();
-  const {
-    data: { session },
-    error,
-  } = await current;
-  if (error || !session?.access_token) {
-    throw new GitHubProxyAuthError("Sign in again to load timeline commit history.");
-  }
-  return session.access_token;
+  return getFreshAccessToken({
+    reauthMessage: "Sign in again to load timeline commit history.",
+  });
 }
 
 async function parseError(response: Response): Promise<GitHubErrorPayload | null> {

--- a/ui/src/lib/session-auth.test.ts
+++ b/ui/src/lib/session-auth.test.ts
@@ -1,0 +1,134 @@
+import type { Session } from "@supabase/supabase-js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  getFreshAccessToken,
+  SessionReauthRequiredError,
+} from "./session-auth";
+
+const baseSession: Session = {
+  access_token: "access-token",
+  refresh_token: "refresh-token",
+  token_type: "bearer",
+  expires_in: 3600,
+  expires_at: 2_000_000_000,
+  user: {
+    id: "user-1",
+    aud: "authenticated",
+    role: "authenticated",
+    email: "mason@aeolus.earth",
+    email_confirmed_at: "2026-04-14T00:00:00.000Z",
+    phone: "",
+    confirmed_at: "2026-04-14T00:00:00.000Z",
+    last_sign_in_at: "2026-04-14T00:00:00.000Z",
+    app_metadata: {
+      provider: "google",
+      providers: ["google"],
+    },
+    user_metadata: {
+      full_name: "Mason",
+    },
+    identities: [],
+    created_at: "2026-04-14T00:00:00.000Z",
+    updated_at: "2026-04-14T00:00:00.000Z",
+    is_anonymous: false,
+  },
+};
+
+function createAuthClient(options: {
+  session?: Session | null;
+  refreshSession?: Session | null;
+  getSessionError?: string | null;
+  refreshError?: string | null;
+}) {
+  return {
+    getSession: vi.fn(async () => ({
+      data: {
+        session: options.session ?? null,
+      },
+      error: options.getSessionError ? { message: options.getSessionError } : null,
+    })),
+    refreshSession: vi.fn(async () => ({
+      data: {
+        session: options.refreshSession ?? null,
+      },
+      error: options.refreshError ? { message: options.refreshError } : null,
+    })),
+  };
+}
+
+describe("getFreshAccessToken", () => {
+  it("returns the current token when the session is healthy", async () => {
+    const authClient = createAuthClient({
+      session: baseSession,
+    });
+
+    const token = await getFreshAccessToken({
+      authClient,
+      now: 1_900_000_000_000,
+    });
+
+    expect(token).toBe("access-token");
+    expect(authClient.refreshSession).not.toHaveBeenCalled();
+  });
+
+  it("refreshes when the session is about to expire", async () => {
+    const authClient = createAuthClient({
+      session: {
+        ...baseSession,
+        access_token: "stale-token",
+        expires_at: 1_900_000_050,
+      },
+      refreshSession: {
+        ...baseSession,
+        access_token: "fresh-token",
+        expires_at: 1_900_003_600,
+      },
+    });
+
+    const token = await getFreshAccessToken({
+      authClient,
+      now: 1_900_000_000_000,
+    });
+
+    expect(token).toBe("fresh-token");
+    expect(authClient.refreshSession).toHaveBeenCalledOnce();
+  });
+
+  it("throws a reauth error when refresh fails", async () => {
+    const authClient = createAuthClient({
+      session: {
+        ...baseSession,
+        access_token: "stale-token",
+        expires_at: 1_900_000_050,
+      },
+      refreshError: "Refresh token invalid",
+    });
+
+    await expect(
+      getFreshAccessToken({
+        authClient,
+        now: 1_900_000_000_000,
+        reauthMessage: "Sign in again to reconnect chat.",
+      }),
+    ).rejects.toMatchObject({
+      name: SessionReauthRequiredError.name,
+      message: "Sign in again to reconnect chat.",
+    });
+  });
+
+  it("throws a reauth error when there is no session", async () => {
+    const authClient = createAuthClient({
+      session: null,
+    });
+
+    await expect(
+      getFreshAccessToken({
+        authClient,
+        reauthMessage: "Sign in again to load timeline commit history.",
+      }),
+    ).rejects.toMatchObject({
+      name: SessionReauthRequiredError.name,
+      message: "Sign in again to load timeline commit history.",
+    });
+  });
+});

--- a/ui/src/lib/session-auth.ts
+++ b/ui/src/lib/session-auth.ts
@@ -1,0 +1,85 @@
+import type { Session } from "@supabase/supabase-js";
+import { supabase } from "@/lib/supabase";
+
+const ACCESS_TOKEN_REFRESH_WINDOW_MS = 60_000;
+
+type SessionResponse = {
+  data: { session: Session | null };
+  error: { message: string } | null;
+};
+
+type AuthClient = {
+  getSession: () => Promise<SessionResponse>;
+  refreshSession: () => Promise<SessionResponse>;
+};
+
+export class SessionReauthRequiredError extends Error {
+  constructor(message = "Session expired. Sign in again to continue.") {
+    super(message);
+    this.name = "SessionReauthRequiredError";
+  }
+}
+
+function trimAccessToken(session: Session | null): string {
+  return session?.access_token?.trim() ?? "";
+}
+
+function isExpiringSoon(
+  session: Session | null,
+  now: number,
+  refreshWindowMs: number,
+): boolean {
+  const expiresAtMs = (session?.expires_at ?? 0) * 1000;
+  return expiresAtMs <= now + refreshWindowMs;
+}
+
+async function getSessionOrThrow(
+  authClient: AuthClient,
+  reauthMessage: string,
+): Promise<Session | null> {
+  const {
+    data: { session },
+    error,
+  } = (await authClient.getSession()) as SessionResponse;
+  if (error) {
+    throw new SessionReauthRequiredError(reauthMessage);
+  }
+  return session;
+}
+
+export async function getFreshAccessToken(options?: {
+  authClient?: AuthClient;
+  reauthMessage?: string;
+  refreshWindowMs?: number;
+  now?: number;
+}): Promise<string> {
+  const authClient = options?.authClient ?? supabase.auth;
+  const reauthMessage =
+    options?.reauthMessage ?? "Session expired. Sign in again to continue.";
+  const refreshWindowMs =
+    options?.refreshWindowMs ?? ACCESS_TOKEN_REFRESH_WINDOW_MS;
+  const now = options?.now ?? Date.now();
+
+  let session = await getSessionOrThrow(authClient, reauthMessage);
+  let token = trimAccessToken(session);
+
+  if (!session || !token || isExpiringSoon(session, now, refreshWindowMs)) {
+    const {
+      data: refreshed,
+      error: refreshError,
+    } = (await authClient.refreshSession()) as SessionResponse;
+
+    if (refreshError || !refreshed.session) {
+      throw new SessionReauthRequiredError(reauthMessage);
+    }
+
+    session = refreshed.session;
+    token = trimAccessToken(session);
+  }
+
+  if (!token) {
+    throw new SessionReauthRequiredError(reauthMessage);
+  }
+
+  return token;
+}

--- a/ui/src/lib/session-auth.ts
+++ b/ui/src/lib/session-auth.ts
@@ -1,5 +1,4 @@
 import type { Session } from "@supabase/supabase-js";
-import { supabase } from "@/lib/supabase";
 
 const ACCESS_TOKEN_REFRESH_WINDOW_MS = 60_000;
 
@@ -47,13 +46,18 @@ async function getSessionOrThrow(
   return session;
 }
 
+async function getDefaultAuthClient(): Promise<AuthClient> {
+  const { supabase } = await import("@/lib/supabase");
+  return supabase.auth;
+}
+
 export async function getFreshAccessToken(options?: {
   authClient?: AuthClient;
   reauthMessage?: string;
   refreshWindowMs?: number;
   now?: number;
 }): Promise<string> {
-  const authClient = options?.authClient ?? supabase.auth;
+  const authClient = options?.authClient ?? (await getDefaultAuthClient());
   const reauthMessage =
     options?.reauthMessage ?? "Session expired. Sign in again to continue.";
   const refreshWindowMs =

--- a/ui/src/routes/pages/timeline-page.tsx
+++ b/ui/src/routes/pages/timeline-page.tsx
@@ -18,6 +18,8 @@ import {
   useGitHubCommits,
 } from "@/hooks/use-github-commits";
 import { HostedAgentConfigError } from "@/lib/agent-http";
+import { InlineReauthButton } from "@/components/auth/inline-reauth-button";
+import { SessionReauthRequiredError } from "@/lib/session-auth";
 import { useTimelineRepos } from "@/hooks/use-timeline-data";
 import { queryKeys } from "@/lib/query-keys";
 import { formatRelativeTime } from "@/lib/utils";
@@ -270,6 +272,21 @@ function renderTimelineError(error: Error | null): string {
   return "Failed to load commit history";
 }
 
+function TimelineErrorNotice({ error }: { error: Error | null }) {
+  const needsReauth =
+    error instanceof SessionReauthRequiredError || error instanceof GitHubProxyAuthError;
+
+  return (
+    <div className="flex flex-col items-center gap-2 py-8 text-center">
+      <AlertTriangle className="h-5 w-5 text-status-failed" />
+      <p className="max-w-[280px] text-[12px] text-text-tertiary">
+        {renderTimelineError(error)}
+      </p>
+      {needsReauth ? <InlineReauthButton /> : null}
+    </div>
+  );
+}
+
 function RepoSwimlane({ repo }: { repo: TimelineRepo }) {
   const [branchSelection, setBranchSelection] = useState(DEFAULT_BRANCH_VALUE);
   const [fetchEnabled, setFetchEnabled] = useState(false);
@@ -396,12 +413,7 @@ function RepoSwimlane({ repo }: { repo: TimelineRepo }) {
         )}
 
         {error && (
-          <div className="flex flex-col items-center gap-2 py-8 text-center">
-            <AlertTriangle className="h-5 w-5 text-status-failed" />
-            <p className="max-w-[280px] text-[12px] text-text-tertiary">
-              {renderTimelineError(error)}
-            </p>
-          </div>
+          <TimelineErrorNotice error={error} />
         )}
 
         {commitPage && <DiagnosticsStrip diagnostics={commitPage.diagnostics} repo={commitPage.repo} />}

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -49,6 +49,7 @@ export type ConnectionStatus =
   | "connected"
   | "reconnecting"
   | "recovering"
+  | "auth_required"
   | "disconnected";
 
 export interface AgentRuntimeInfo {


### PR DESCRIPTION
## Summary
- carry the #146 timeline smoke stabilization forward on top of current staging
- centralize fresh Supabase access-token handling for agent-backed browser requests
- replace raw chat/timeline 401 UX with inline reauth recovery and focused regressions

## Problem
After the UI sat idle for a while, agent-backed requests like `/chat/session-token` and GitHub timeline proxy calls could send a stale Supabase bearer and surface raw `401` failures such as `Chat session token request failed (401)`. The server was correctly rejecting invalid Sonde sessions, but the browser had too many one-off token paths and inconsistent recovery behavior.

## What changed
- add `session-auth.ts` as the single place to fetch or refresh a browser access token
- use that helper in chat, timeline/GitHub proxy, and admin agent requests
- add an `auth_required` chat connection state with an inline `Sign in again` CTA
- preserve the current return URL when reauth starts
- proactively refresh on focus/visibility return so recovery can happen before the next action
- carry forward the #146 timeline empty-state/proxy smoke fix from current staging
- add local browser regressions for chat/timeline 401 recovery

## Validation
- `npm --prefix ui run test -- src/lib/session-auth.test.ts src/lib/device-activation-browser.test.ts src/lib/agent-http.test.ts`
- `npm --prefix ui run test:e2e:smoke -- --grep "sign-in-again CTA|stale agent session|auth readiness"`
- `npm --prefix ui run lint`
- `npm --prefix ui run build`

Supersedes #146.