### PR TITLE
fix(deploy): redeploy hosted agent on every push

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -170,8 +170,7 @@ jobs:
           needs.push-staging-database.result == 'skipped'
         ) &&
         (
-          needs.changes.outputs.agent == 'true' ||
-          needs.changes.outputs.database == 'true' ||
+          github.event_name == 'push' ||
           (
             github.event_name == 'workflow_dispatch' &&
             !inputs.seed_only

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,8 +153,7 @@ jobs:
           needs.push-migrations.result == 'skipped'
         ) &&
         (
-          needs.changes.outputs.agent == 'true' ||
-          needs.changes.outputs.database == 'true' ||
+          github.event_name == 'push' ||
           github.event_name == 'workflow_dispatch'
         )
       }}


### PR DESCRIPTION
## Summary
- redeploy the staging agent on every staging push, not only on server/database diffs
- do the same for production pushes so runtime parity stays aligned with release commits
- keep workflow-dispatch behavior unchanged

## Problem
The hosted release gates require the agent runtime commit to match the deployed UI commit. For UI-only merges, `Sync Staging Infra` and `Sync Production Infra` were skipping the agent deploy because no `cli/**` or `server/**` paths changed, which left the agent advertising the previous commit and caused staging smoke/config audit parity timeouts.

## Fix
Make the hosted agent deploy jobs run on every push to `staging` and `main`, while still respecting the existing database-success guard and the `seed_only` workflow-dispatch path on staging.

## Validation
- `ruby -e 'require "yaml"; [".github/workflows/deploy-staging.yml", ".github/workflows/deploy.yml"].each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'`
- verified the failing staging run was blocked by an old agent commit (`5ab31cd...`) while the UI had already moved to `44c20bd...`
