### PR TITLE
fix(ui): stabilize hosted auth smoke recovery

### DIFF
--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -64,11 +64,26 @@ function parseSessionJson(sessionJson: string) {
   const parsed = JSON.parse(sessionJson) as {
     access_token: string;
     refresh_token: string;
+    expires_in?: number;
+    expires_at?: number;
+    token_type?: string;
     user: Record<string, unknown>;
   };
 
   if (!parsed.access_token || !parsed.refresh_token || !parsed.user) {
     throw new Error("E2E auth session JSON is missing required session fields.");
+  }
+
+  if (
+    typeof parsed.expires_at !== "number" &&
+    typeof parsed.expires_in === "number" &&
+    Number.isFinite(parsed.expires_in)
+  ) {
+    parsed.expires_at = Math.floor(Date.now() / 1000) + parsed.expires_in;
+  }
+
+  if (!parsed.token_type) {
+    parsed.token_type = "bearer";
   }
 
   return parsed;

--- a/ui/e2e/hosted-smoke.spec.ts
+++ b/ui/e2e/hosted-smoke.spec.ts
@@ -82,6 +82,42 @@ async function readVisibleText(page: Page, selector: string): Promise<string | n
   return text?.trim() || null;
 }
 
+async function waitForTimelineLandingState(
+  page: Page,
+  diagnosticsAuthMode: Locator,
+  loadButton: Locator,
+): Promise<"diagnostics" | "load" | "empty"> {
+  const emptyState = page.getByText("No git-linked experiments found");
+  await expect
+    .poll(
+      async () => {
+        if (await diagnosticsAuthMode.isVisible().catch(() => false)) {
+          return "diagnostics";
+        }
+        if (await loadButton.isVisible().catch(() => false)) {
+          return "load";
+        }
+        if (await emptyState.isVisible().catch(() => false)) {
+          return "empty";
+        }
+        return "pending";
+      },
+      {
+        timeout: 20_000,
+        message: "Expected timeline to resolve to diagnostics, a repo swimlane, or the empty state.",
+      },
+    )
+    .not.toBe("pending");
+
+  if (await diagnosticsAuthMode.isVisible().catch(() => false)) {
+    return "diagnostics";
+  }
+  if (await loadButton.isVisible().catch(() => false)) {
+    return "load";
+  }
+  return "empty";
+}
+
 async function assertTimelineProxyAvailable(request: APIRequestContext): Promise<void> {
   if (!AGENT_HTTP_BASE) {
     throw new Error("Timeline proxy smoke requires E2E_AGENT_HTTP_BASE.");
@@ -510,15 +546,21 @@ test.describe(`${SUITE_LABEL} authenticated flows`, () => {
     await page.goto("/timeline");
 
     const diagnosticsAuthMode = page.getByText(new RegExp(EXPECT_TIMELINE_AUTH_MODE, "i")).first();
-    if (await diagnosticsAuthMode.isVisible().catch(() => false)) {
+    const loadButton = page.getByRole("button", { name: "Load commit history" }).first();
+    const landingState = await waitForTimelineLandingState(
+      page,
+      diagnosticsAuthMode,
+      loadButton,
+    );
+
+    if (landingState === "diagnostics") {
       await expect(page.getByText(/upstream GitHub request/i)).toBeVisible({
         timeout: 60_000,
       });
       return;
     }
 
-    const loadButton = page.getByRole("button", { name: "Load commit history" }).first();
-    if (await loadButton.isVisible().catch(() => false)) {
+    if (landingState === "load") {
       await loadButton.click();
 
       const timelineError = page.getByText(/Failed to load commit history|Sign in again|Repository not accessible|Server GitHub token is invalid|Hosted Sonde UI is missing VITE_AGENT_WS_URL/i);

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist', 'node_modules', '.vite'] },
+  { ignores: ['dist', 'node_modules', '.vite', 'playwright-report', 'test-results'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/ui/src/lib/session-auth.test.ts
+++ b/ui/src/lib/session-auth.test.ts
@@ -94,6 +94,23 @@ describe("getFreshAccessToken", () => {
     expect(authClient.refreshSession).toHaveBeenCalledOnce();
   });
 
+  it("keeps the current token when expiry metadata is missing", async () => {
+    const authClient = createAuthClient({
+      session: {
+        ...baseSession,
+        expires_at: undefined,
+      } as Session,
+    });
+
+    const token = await getFreshAccessToken({
+      authClient,
+      now: 1_900_000_000_000,
+    });
+
+    expect(token).toBe("access-token");
+    expect(authClient.refreshSession).not.toHaveBeenCalled();
+  });
+
   it("throws a reauth error when refresh fails", async () => {
     const authClient = createAuthClient({
       session: {

--- a/ui/src/lib/session-auth.ts
+++ b/ui/src/lib/session-auth.ts
@@ -23,11 +23,18 @@ function trimAccessToken(session: Session | null): string {
   return session?.access_token?.trim() ?? "";
 }
 
+function hasExpiryTimestamp(session: Session | null): session is Session & { expires_at: number } {
+  return typeof session?.expires_at === "number" && Number.isFinite(session.expires_at);
+}
+
 function isExpiringSoon(
   session: Session | null,
   now: number,
   refreshWindowMs: number,
 ): boolean {
+  if (!hasExpiryTimestamp(session)) {
+    return false;
+  }
   const expiresAtMs = (session?.expires_at ?? 0) * 1000;
   return expiresAtMs <= now + refreshWindowMs;
 }


### PR DESCRIPTION
## Summary
- keep seeded smoke sessions usable when expiry metadata is missing
- derive missing expiry/token metadata for hosted smoke session seeding
- wait for the timeline page to resolve before branching between diagnostics, repo swimlane, and empty state
- ignore Playwright artifact folders in UI lint runs

## Why
The staging rollout after #149/#150 exposed two real CI gaps:
- hosted timeline smoke could branch into the empty-state assertion before the repo swimlane finished rendering
- hosted chat smoke could fall into the new inline reauth path even with a freshly minted smoke session

This patch keeps the product auth path strict while making the shared token helper and hosted smoke harness resilient to the session shape that Supabase returns in CI.

## Validation
- npm --prefix ui run test
- npm --prefix ui run test -- src/lib/session-auth.test.ts
- npm --prefix ui run lint
- npm --prefix ui run build
- npm --prefix ui run test:e2e:smoke -- --grep "sign-in-again CTA|stale agent session|auth readiness"