### PR TITLE
fix(smoke): stop revoking the hosted app session

### DIFF
--- a/.github/workflows/smoke-production.yml
+++ b/.github/workflows/smoke-production.yml
@@ -26,7 +26,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set smoke temp paths
-        run: echo "PRODUCTION_SMOKE_SESSION_FILE=$RUNNER_TEMP/sonde-production-smoke-session.json" >> "$GITHUB_ENV"
+        run: |
+          echo "PRODUCTION_SMOKE_SESSION_FILE=$RUNNER_TEMP/sonde-production-smoke-session.json" >> "$GITHUB_ENV"
+          echo "PRODUCTION_ACTIVATION_SESSION_FILE=$RUNNER_TEMP/sonde-production-activation-session.json" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@v6
         with:
@@ -143,6 +145,19 @@ jobs:
           SMOKE_SESSION_FILE: ${{ env.PRODUCTION_SMOKE_SESSION_FILE }}
         run: node scripts/mint-smoke-session.mjs >/dev/null
 
+      - name: Mint production activation session
+        working-directory: server
+        env:
+          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
+          SMOKE_USER_EMAIL: ${{ secrets.SONDE_PRODUCTION_SMOKE_USER_EMAIL }}
+          SMOKE_USER_PASSWORD: ${{ secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD }}
+          SMOKE_SESSION_FILE: ${{ env.PRODUCTION_ACTIVATION_SESSION_FILE }}
+        # Hosted activation smoke signs the activation session out on success,
+        # so it must not reuse the browser session that later chat/timeline
+        # tests depend on.
+        run: node scripts/mint-smoke-session.mjs >/dev/null
+
       - name: Wait for production agent runtime parity
         if: ${{ steps.targets.outputs.agent_url != '' }}
         working-directory: server
@@ -203,10 +218,15 @@ jobs:
           E2E_EXPECT_TIMELINE_AUTH_MODE: ${{ steps.contract.outputs.smoke_expected_timeline_auth_mode }}
           E2E_CHAT_PROMPT: ${{ steps.contract.outputs.managed_auth_audit_prompt }}
           PRODUCTION_SMOKE_SESSION_FILE: ${{ env.PRODUCTION_SMOKE_SESSION_FILE }}
+          PRODUCTION_ACTIVATION_SESSION_FILE: ${{ env.PRODUCTION_ACTIVATION_SESSION_FILE }}
         run: |
           if [ -f "$PRODUCTION_SMOKE_SESSION_FILE" ]; then
             E2E_AUTH_SESSION_JSON="$(cat "$PRODUCTION_SMOKE_SESSION_FILE")"
             export E2E_AUTH_SESSION_JSON
+          fi
+          if [ -f "$PRODUCTION_ACTIVATION_SESSION_FILE" ]; then
+            E2E_ACTIVATION_SESSION_JSON="$(cat "$PRODUCTION_ACTIVATION_SESSION_FILE")"
+            export E2E_ACTIVATION_SESSION_JSON
           fi
           npm run test:e2e:hosted
 

--- a/.github/workflows/smoke-staging.yml
+++ b/.github/workflows/smoke-staging.yml
@@ -26,7 +26,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set smoke temp paths
-        run: echo "STAGING_SMOKE_SESSION_FILE=$RUNNER_TEMP/sonde-staging-smoke-session.json" >> "$GITHUB_ENV"
+        run: |
+          echo "STAGING_SMOKE_SESSION_FILE=$RUNNER_TEMP/sonde-staging-smoke-session.json" >> "$GITHUB_ENV"
+          echo "STAGING_ACTIVATION_SESSION_FILE=$RUNNER_TEMP/sonde-staging-activation-session.json" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@v6
         with:
@@ -143,6 +145,19 @@ jobs:
           SMOKE_SESSION_FILE: ${{ env.STAGING_SMOKE_SESSION_FILE }}
         run: node scripts/mint-smoke-session.mjs >/dev/null
 
+      - name: Mint staging activation session
+        working-directory: server
+        env:
+          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
+          SMOKE_USER_EMAIL: ${{ secrets.SONDE_STAGING_SMOKE_USER_EMAIL }}
+          SMOKE_USER_PASSWORD: ${{ secrets.SONDE_STAGING_SMOKE_USER_PASSWORD }}
+          SMOKE_SESSION_FILE: ${{ env.STAGING_ACTIVATION_SESSION_FILE }}
+        # Hosted activation smoke signs the activation session out on success,
+        # so it must not reuse the browser session that later chat/timeline
+        # tests depend on.
+        run: node scripts/mint-smoke-session.mjs >/dev/null
+
       - name: Wait for staging agent runtime parity
         if: ${{ steps.targets.outputs.agent_url != '' }}
         working-directory: server
@@ -203,10 +218,15 @@ jobs:
           E2E_EXPECT_TIMELINE_AUTH_MODE: ${{ steps.contract.outputs.smoke_expected_timeline_auth_mode }}
           E2E_CHAT_PROMPT: ${{ steps.contract.outputs.managed_auth_audit_prompt }}
           STAGING_SMOKE_SESSION_FILE: ${{ env.STAGING_SMOKE_SESSION_FILE }}
+          STAGING_ACTIVATION_SESSION_FILE: ${{ env.STAGING_ACTIVATION_SESSION_FILE }}
         run: |
           if [ -f "$STAGING_SMOKE_SESSION_FILE" ]; then
             E2E_AUTH_SESSION_JSON="$(cat "$STAGING_SMOKE_SESSION_FILE")"
             export E2E_AUTH_SESSION_JSON
+          fi
+          if [ -f "$STAGING_ACTIVATION_SESSION_FILE" ]; then
+            E2E_ACTIVATION_SESSION_JSON="$(cat "$STAGING_ACTIVATION_SESSION_FILE")"
+            export E2E_ACTIVATION_SESSION_JSON
           fi
           npm run test:e2e:hosted
 

--- a/ui/e2e/hosted-smoke.spec.ts
+++ b/ui/e2e/hosted-smoke.spec.ts
@@ -24,6 +24,10 @@ const AGENT_HTTP_BASE = process.env.E2E_AGENT_HTTP_BASE ?? null;
 const AGENT_RUNTIME_AUDIT_TOKEN =
   process.env.E2E_AGENT_RUNTIME_AUDIT_TOKEN?.trim() || null;
 const AUTH_SESSION_JSON = process.env.E2E_AUTH_SESSION_JSON?.trim() || null;
+// Activation cleanup signs its Supabase session out after approval, so use a
+// separate seeded browser session when the workflow provides one.
+const ACTIVATION_SESSION_JSON =
+  process.env.E2E_ACTIVATION_SESSION_JSON?.trim() || AUTH_SESSION_JSON;
 const EXPECT_PROGRAM_ID = process.env.E2E_EXPECT_PROGRAM_ID?.trim() || null;
 const EXPECT_EXPERIMENT_ID = process.env.E2E_EXPECT_EXPERIMENT_ID?.trim() || null;
 const EXPECT_TIMELINE_AUTH_MODE =
@@ -441,11 +445,11 @@ test.describe(SUITE_LABEL, () => {
     browserName,
   }) => {
     test.skip(!AGENT_HTTP_BASE, "Skipped: no agent host configured");
-    test.skip(!AUTH_SESSION_JSON, "Skipped: no smoke auth session configured");
+    test.skip(!ACTIVATION_SESSION_JSON, "Skipped: no smoke activation session configured");
     test.skip(browserName !== "chromium", "Run hosted activation smoke once to keep it lean.");
 
     const activation = await startHostedDeviceActivation(request);
-    await seedActivationSession(page, AUTH_SESSION_JSON);
+    await seedActivationSession(page, ACTIVATION_SESSION_JSON);
 
     await page.goto(`/activate/callback?user_code=${encodeURIComponent(activation.user_code)}`);
     await page.waitForURL(/\/activate(\?|$)/, { timeout: 20_000 });
@@ -465,11 +469,11 @@ test.describe(SUITE_LABEL, () => {
     browserName,
   }) => {
     test.skip(!AGENT_HTTP_BASE, "Skipped: no agent host configured");
-    test.skip(!AUTH_SESSION_JSON, "Skipped: no smoke auth session configured");
+    test.skip(!ACTIVATION_SESSION_JSON, "Skipped: no smoke activation session configured");
     test.skip(browserName !== "chromium", "Run hosted activation smoke once to keep it lean.");
 
     const activation = await startHostedDeviceActivation(request);
-    await seedActivationSession(page, AUTH_SESSION_JSON);
+    await seedActivationSession(page, ACTIVATION_SESSION_JSON);
 
     await page.goto(activation.verification_uri_complete);
     await expect(


### PR DESCRIPTION
## Summary
- mint a dedicated hosted activation session for browser approval smoke
- keep the authenticated app smoke on its own session so activation cleanup cannot revoke it
- wire the same isolation into both staging and production smoke workflows

## Root cause
Hosted smoke was seeding the exact same Supabase session into:
- the activation browser client, and
- the authenticated app browser client

The activation flow correctly calls `signOut()` after approval, which revokes that Supabase session. Later timeline and chat smoke steps then reused the revoked session and hit `session_not_found`, which surfaced as `Chat session token request failed (401)` and `Missing or invalid Sonde session token`.

## Validation
- `npm --prefix ui run lint`
- `npm --prefix ui run build`
- `npm --prefix ui run test -- src/lib/device-activation-browser.test.ts src/lib/session-auth.test.ts`
- workflow YAML parsed successfully for staging and production smoke workflows
