### PR TITLE
fix(smoke): split activation and authenticated phases

### DIFF
--- a/.github/workflows/smoke-production.yml
+++ b/.github/workflows/smoke-production.yml
@@ -135,16 +135,6 @@ jobs:
           echo "::error::Production agent did not become reachable in time"
           exit 1
 
-      - name: Mint production smoke session
-        working-directory: server
-        env:
-          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
-          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
-          SMOKE_USER_EMAIL: ${{ secrets.SONDE_PRODUCTION_SMOKE_USER_EMAIL }}
-          SMOKE_USER_PASSWORD: ${{ secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD }}
-          SMOKE_SESSION_FILE: ${{ env.PRODUCTION_SMOKE_SESSION_FILE }}
-        run: node scripts/mint-smoke-session.mjs >/dev/null
-
       - name: Mint production activation session
         working-directory: server
         env:
@@ -191,6 +181,38 @@ jobs:
           AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
         run: node scripts/audit-deployed-stack.mjs
 
+      - name: Run production base and activation smoke tests
+        env:
+          E2E_BASE_URL: ${{ steps.targets.outputs.ui_url }}
+          E2E_DEPLOY_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
+          E2E_AGENT_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
+          E2E_AGENT_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
+          E2E_SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          E2E_EXPECT_PROGRAM_ID: ${{ steps.contract.outputs.smoke_expected_program_id }}
+          E2E_EXPECT_EXPERIMENT_ID: ${{ steps.contract.outputs.smoke_expected_experiment_id }}
+          E2E_EXPECT_TIMELINE_AUTH_MODE: ${{ steps.contract.outputs.smoke_expected_timeline_auth_mode }}
+          E2E_CHAT_PROMPT: ${{ steps.contract.outputs.managed_auth_audit_prompt }}
+          PRODUCTION_SMOKE_SESSION_FILE: ${{ env.PRODUCTION_SMOKE_SESSION_FILE }}
+          PRODUCTION_ACTIVATION_SESSION_FILE: ${{ env.PRODUCTION_ACTIVATION_SESSION_FILE }}
+        run: |
+          if [ -f "$PRODUCTION_ACTIVATION_SESSION_FILE" ]; then
+            E2E_ACTIVATION_SESSION_JSON="$(cat "$PRODUCTION_ACTIVATION_SESSION_FILE")"
+            export E2E_ACTIVATION_SESSION_JSON
+          fi
+          npm run test:e2e:hosted -- --grep-invert @authenticated
+
+      - name: Mint production smoke session
+        working-directory: server
+        env:
+          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
+          SMOKE_USER_EMAIL: ${{ secrets.SONDE_PRODUCTION_SMOKE_USER_EMAIL }}
+          SMOKE_USER_PASSWORD: ${{ secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD }}
+          SMOKE_SESSION_FILE: ${{ env.PRODUCTION_SMOKE_SESSION_FILE }}
+        # Supabase can revoke earlier sessions for the same user, so mint the
+        # authenticated-app session only after the activation suite completes.
+        run: node scripts/mint-smoke-session.mjs >/dev/null
+
       - name: Run production managed auth audit
         if: ${{ steps.targets.outputs.agent_url != '' }}
         working-directory: server
@@ -206,7 +228,7 @@ jobs:
           MANAGED_AUTH_AUDIT_SESSION_FILE: ${{ env.PRODUCTION_SMOKE_SESSION_FILE }}
         run: node scripts/run-managed-auth-audit.mjs
 
-      - name: Run production smoke tests
+      - name: Run production authenticated smoke tests
         env:
           E2E_BASE_URL: ${{ steps.targets.outputs.ui_url }}
           E2E_DEPLOY_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
@@ -218,17 +240,12 @@ jobs:
           E2E_EXPECT_TIMELINE_AUTH_MODE: ${{ steps.contract.outputs.smoke_expected_timeline_auth_mode }}
           E2E_CHAT_PROMPT: ${{ steps.contract.outputs.managed_auth_audit_prompt }}
           PRODUCTION_SMOKE_SESSION_FILE: ${{ env.PRODUCTION_SMOKE_SESSION_FILE }}
-          PRODUCTION_ACTIVATION_SESSION_FILE: ${{ env.PRODUCTION_ACTIVATION_SESSION_FILE }}
         run: |
           if [ -f "$PRODUCTION_SMOKE_SESSION_FILE" ]; then
             E2E_AUTH_SESSION_JSON="$(cat "$PRODUCTION_SMOKE_SESSION_FILE")"
             export E2E_AUTH_SESSION_JSON
           fi
-          if [ -f "$PRODUCTION_ACTIVATION_SESSION_FILE" ]; then
-            E2E_ACTIVATION_SESSION_JSON="$(cat "$PRODUCTION_ACTIVATION_SESSION_FILE")"
-            export E2E_ACTIVATION_SESSION_JSON
-          fi
-          npm run test:e2e:hosted
+          npm run test:e2e:hosted -- --grep @authenticated
 
       - name: Upload report on failure
         uses: actions/upload-artifact@v7

--- a/.github/workflows/smoke-staging.yml
+++ b/.github/workflows/smoke-staging.yml
@@ -135,16 +135,6 @@ jobs:
           echo "::error::Staging agent did not become reachable in time"
           exit 1
 
-      - name: Mint staging smoke session
-        working-directory: server
-        env:
-          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
-          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
-          SMOKE_USER_EMAIL: ${{ secrets.SONDE_STAGING_SMOKE_USER_EMAIL }}
-          SMOKE_USER_PASSWORD: ${{ secrets.SONDE_STAGING_SMOKE_USER_PASSWORD }}
-          SMOKE_SESSION_FILE: ${{ env.STAGING_SMOKE_SESSION_FILE }}
-        run: node scripts/mint-smoke-session.mjs >/dev/null
-
       - name: Mint staging activation session
         working-directory: server
         env:
@@ -191,6 +181,38 @@ jobs:
           AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
         run: node scripts/audit-deployed-stack.mjs
 
+      - name: Run staging base and activation smoke tests
+        env:
+          E2E_BASE_URL: ${{ steps.targets.outputs.ui_url }}
+          E2E_DEPLOY_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
+          E2E_AGENT_HTTP_BASE: ${{ steps.targets.outputs.agent_url }}
+          E2E_AGENT_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
+          E2E_SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          E2E_EXPECT_PROGRAM_ID: ${{ steps.contract.outputs.smoke_expected_program_id }}
+          E2E_EXPECT_EXPERIMENT_ID: ${{ steps.contract.outputs.smoke_expected_experiment_id }}
+          E2E_EXPECT_TIMELINE_AUTH_MODE: ${{ steps.contract.outputs.smoke_expected_timeline_auth_mode }}
+          E2E_CHAT_PROMPT: ${{ steps.contract.outputs.managed_auth_audit_prompt }}
+          STAGING_SMOKE_SESSION_FILE: ${{ env.STAGING_SMOKE_SESSION_FILE }}
+          STAGING_ACTIVATION_SESSION_FILE: ${{ env.STAGING_ACTIVATION_SESSION_FILE }}
+        run: |
+          if [ -f "$STAGING_ACTIVATION_SESSION_FILE" ]; then
+            E2E_ACTIVATION_SESSION_JSON="$(cat "$STAGING_ACTIVATION_SESSION_FILE")"
+            export E2E_ACTIVATION_SESSION_JSON
+          fi
+          npm run test:e2e:hosted -- --grep-invert @authenticated
+
+      - name: Mint staging smoke session
+        working-directory: server
+        env:
+          SUPABASE_URL: https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
+          SMOKE_USER_EMAIL: ${{ secrets.SONDE_STAGING_SMOKE_USER_EMAIL }}
+          SMOKE_USER_PASSWORD: ${{ secrets.SONDE_STAGING_SMOKE_USER_PASSWORD }}
+          SMOKE_SESSION_FILE: ${{ env.STAGING_SMOKE_SESSION_FILE }}
+        # Supabase can revoke earlier sessions for the same user, so mint the
+        # authenticated-app session only after the activation suite completes.
+        run: node scripts/mint-smoke-session.mjs >/dev/null
+
       - name: Run staging managed auth audit
         if: ${{ steps.targets.outputs.agent_url != '' }}
         working-directory: server
@@ -206,7 +228,7 @@ jobs:
           MANAGED_AUTH_AUDIT_SESSION_FILE: ${{ env.STAGING_SMOKE_SESSION_FILE }}
         run: node scripts/run-managed-auth-audit.mjs
 
-      - name: Run staging smoke tests
+      - name: Run staging authenticated smoke tests
         env:
           E2E_BASE_URL: ${{ steps.targets.outputs.ui_url }}
           E2E_DEPLOY_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
@@ -218,17 +240,12 @@ jobs:
           E2E_EXPECT_TIMELINE_AUTH_MODE: ${{ steps.contract.outputs.smoke_expected_timeline_auth_mode }}
           E2E_CHAT_PROMPT: ${{ steps.contract.outputs.managed_auth_audit_prompt }}
           STAGING_SMOKE_SESSION_FILE: ${{ env.STAGING_SMOKE_SESSION_FILE }}
-          STAGING_ACTIVATION_SESSION_FILE: ${{ env.STAGING_ACTIVATION_SESSION_FILE }}
         run: |
           if [ -f "$STAGING_SMOKE_SESSION_FILE" ]; then
             E2E_AUTH_SESSION_JSON="$(cat "$STAGING_SMOKE_SESSION_FILE")"
             export E2E_AUTH_SESSION_JSON
           fi
-          if [ -f "$STAGING_ACTIVATION_SESSION_FILE" ]; then
-            E2E_ACTIVATION_SESSION_JSON="$(cat "$STAGING_ACTIVATION_SESSION_FILE")"
-            export E2E_ACTIVATION_SESSION_JSON
-          fi
-          npm run test:e2e:hosted
+          npm run test:e2e:hosted -- --grep @authenticated
 
       - name: Upload report on failure
         uses: actions/upload-artifact@v7

--- a/ui/e2e/hosted-smoke.spec.ts
+++ b/ui/e2e/hosted-smoke.spec.ts
@@ -439,7 +439,7 @@ test.describe(SUITE_LABEL, () => {
     expect(body.agentWsOrigin ?? null).toBe(agentOrigin(AGENT_HTTP_BASE));
   });
 
-  test("hosted activation callback route resolves back to the activation page", async ({
+  test("hosted activation callback route resolves back to the activation page @activation", async ({
     page,
     request,
     browserName,
@@ -463,7 +463,7 @@ test.describe(SUITE_LABEL, () => {
     await expect(page.getByText("ssh://hosted-smoke")).toBeVisible({ timeout: 20_000 });
   });
 
-  test("hosted activation link can approve a headless CLI login from a browser session", async ({
+  test("hosted activation link can approve a headless CLI login from a browser session @activation", async ({
     page,
     request,
     browserName,
@@ -496,7 +496,7 @@ test.describe(SUITE_LABEL, () => {
   });
 });
 
-test.describe(`${SUITE_LABEL} authenticated flows`, () => {
+test.describe(`${SUITE_LABEL} authenticated flows @authenticated`, () => {
   test.skip(
     !BASE_URL || !AUTH_SESSION_JSON,
     "Skipped: authenticated smoke requires E2E_BASE_URL and E2E_AUTH_SESSION_JSON"


### PR DESCRIPTION
## Summary
- split hosted smoke into activation/base and authenticated phases
- mint the authenticated app session only after activation smoke completes
- tag hosted smoke suites so the workflow can run the two phases explicitly

## Root cause
Staging smoke was still failing after the earlier session-isolation patch because the workflow minted the authenticated app session first and the activation session second.

Supabase treats the later login as the active session for that user, so the activation-session mint invalidated the earlier app session before the chat/timeline tests ever ran. The browser then hit `session_not_found` and the agent correctly returned `401 Missing or invalid Sonde session token`.

## Validation
- `npm --prefix ui run lint`
- `npm --prefix ui run build`
- `npm --prefix ui run test -- src/lib/device-activation-browser.test.ts src/lib/session-auth.test.ts`
- workflow YAML parsed successfully for staging and production smoke workflows
