### PR TITLE
test(smoke): align timeline proxy assertion with API contract

### DIFF
--- a/ui/e2e/hosted-smoke.spec.ts
+++ b/ui/e2e/hosted-smoke.spec.ts
@@ -17,6 +17,10 @@ import {
   seedActiveProgram,
   seedConfiguredSession,
 } from "./helpers";
+import {
+  readTimelineRepoIdentity,
+  type TimelineProxyResponse,
+} from "../src/lib/timeline-proxy-response";
 
 const BASE_URL = process.env.E2E_BASE_URL;
 const DEPLOY_ENVIRONMENT = process.env.E2E_DEPLOY_ENVIRONMENT?.trim() || "hosted";
@@ -144,17 +148,10 @@ async function assertTimelineProxyAvailable(request: APIRequestContext): Promise
     `Timeline proxy request failed: ${response.status()} ${bodyText.slice(0, 240)}`
   ).toBeTruthy();
 
-  const body = JSON.parse(bodyText) as {
-    commits: Array<{ sha: string }>;
-    repo: { owner: string; repo: string };
-    diagnostics: {
-      authMode: string;
-      upstreamRequests: number;
-    };
-  };
+  const body = JSON.parse(bodyText) as TimelineProxyResponse;
+  const repoIdentity = readTimelineRepoIdentity(body);
 
-  expect(body.repo.owner).toBe(TIMELINE_PROXY_REPO.owner);
-  expect(body.repo.repo).toBe(TIMELINE_PROXY_REPO.repo);
+  expect(repoIdentity).toEqual(TIMELINE_PROXY_REPO);
   expect(body.commits.length).toBeGreaterThan(0);
   expect(normalizeAuthMode(body.diagnostics.authMode)).toBe(
     normalizeAuthMode(EXPECT_TIMELINE_AUTH_MODE)

--- a/ui/src/lib/timeline-proxy-response.test.ts
+++ b/ui/src/lib/timeline-proxy-response.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  readTimelineRepoIdentity,
+  type TimelineProxyResponse,
+} from "./timeline-proxy-response";
+
+function createResponse(
+  overrides?: Partial<TimelineProxyResponse>,
+): TimelineProxyResponse {
+  return {
+    commits: [{ sha: "abc123" }],
+    repo: {
+      defaultBranch: "main",
+      htmlUrl: "https://github.com/aeolus-earth/sonde",
+      private: false,
+    },
+    diagnostics: {
+      authMode: "server_token",
+      upstreamRequests: 1,
+    },
+    ...overrides,
+  };
+}
+
+describe("readTimelineRepoIdentity", () => {
+  it("prefers explicit owner and repo fields when present", () => {
+    const identity = readTimelineRepoIdentity(
+      createResponse({
+        repo: {
+          owner: "aeolus-earth",
+          repo: "sonde",
+          htmlUrl: "https://github.com/other/repo",
+        },
+      }),
+    );
+
+    expect(identity).toEqual({
+      owner: "aeolus-earth",
+      repo: "sonde",
+    });
+  });
+
+  it("parses the repo identity from htmlUrl when owner and repo are absent", () => {
+    const identity = readTimelineRepoIdentity(createResponse());
+
+    expect(identity).toEqual({
+      owner: "aeolus-earth",
+      repo: "sonde",
+    });
+  });
+
+  it("returns null when the response does not include a usable repo identity", () => {
+    const identity = readTimelineRepoIdentity(
+      createResponse({
+        repo: {
+          defaultBranch: "main",
+          htmlUrl: "not-a-url",
+        },
+      }),
+    );
+
+    expect(identity).toBeNull();
+  });
+});

--- a/ui/src/lib/timeline-proxy-response.ts
+++ b/ui/src/lib/timeline-proxy-response.ts
@@ -1,0 +1,69 @@
+export interface TimelineProxyRepo {
+  owner?: string | null;
+  repo?: string | null;
+  defaultBranch?: string | null;
+  htmlUrl?: string | null;
+  private?: boolean;
+}
+
+export interface TimelineProxyDiagnostics {
+  authMode: string;
+  upstreamRequests: number;
+}
+
+export interface TimelineProxyResponse {
+  commits: Array<{ sha: string }>;
+  repo?: TimelineProxyRepo | null;
+  diagnostics: TimelineProxyDiagnostics;
+}
+
+export interface TimelineRepoIdentity {
+  owner: string;
+  repo: string;
+}
+
+function trimSegment(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function parseRepoIdentityFromUrl(
+  htmlUrl: string | null | undefined,
+): TimelineRepoIdentity | null {
+  const trimmed = trimSegment(htmlUrl);
+  if (!trimmed) {
+    return null;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  const [owner, repo] = url.pathname
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  if (!owner || !repo) {
+    return null;
+  }
+
+  return { owner, repo };
+}
+
+export function readTimelineRepoIdentity(
+  response: TimelineProxyResponse,
+): TimelineRepoIdentity | null {
+  const directOwner = trimSegment(response.repo?.owner);
+  const directRepo = trimSegment(response.repo?.repo);
+  if (directOwner && directRepo) {
+    return {
+      owner: directOwner,
+      repo: directRepo,
+    };
+  }
+
+  return parseRepoIdentityFromUrl(response.repo?.htmlUrl);
+}


### PR DESCRIPTION
## Summary
- align the hosted timeline smoke assertion with the actual GitHub proxy response contract
- support both explicit owner/repo fields and the current htmlUrl-based repo summary shape
- add unit coverage for timeline proxy repo identity parsing

## Root cause
Production smoke was still failing after the auth/session fixes, but the failure was no longer auth-related.

The GitHub proxy returned `200` with real commit data. The remaining issue was that the Playwright smoke still asserted `body.repo.owner` and `body.repo.repo`, while the server contract exposes repo identity through the `repo.htmlUrl` summary object.

## Validation
- `npm --prefix ui run test -- src/lib/timeline-proxy-response.test.ts src/lib/session-auth.test.ts`
- `npm --prefix ui run lint`
- `npm --prefix ui run build`
