### PR TITLE
fix(server): restore /health to liveness-only, keep SHA on /health/runtime

### DIFF
--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -56,11 +56,11 @@ describe("createApp", () => {
     ]);
   });
 
-  it("returns a public health response with commit SHA", async () => {
+  it("returns a minimal public health response", async () => {
+    // /health is liveness-only by contract — the deployed-stack audit fails
+    // if it leaks any metadata. Commit SHA lives on /health/runtime instead.
     process.env.SONDE_COMMIT_SHA = "abc123";
     process.env.SONDE_ENVIRONMENT = "production";
-    process.env.SONDE_SCHEMA_VERSION = "20260407000123";
-    process.env.SONDE_CLI_GIT_REF = "refs/heads/staging";
     process.env.ANTHROPIC_API_KEY = "sk-ant-api03-test-key";
     process.env.VITE_SUPABASE_URL = "https://oxajsxoedrmvrcatqser.supabase.co";
     const app = createApp();
@@ -68,46 +68,8 @@ describe("createApp", () => {
     const response = await app.request("http://localhost/health");
     assert.equal(response.status, 200);
 
-    const body = (await response.json()) as {
-      status: string;
-      commitSha: string | null;
-      environment: string;
-    };
-    assert.equal(body.status, "ok");
-    assert.equal(body.commitSha, "abc123");
-    assert.equal(body.environment, "production");
-  });
-
-  it("health commitSha falls back to RAILWAY_GIT_COMMIT_SHA when SONDE_COMMIT_SHA is unset", async () => {
-    process.env.RAILWAY_GIT_COMMIT_SHA = "railway-sha";
-    process.env.ANTHROPIC_API_KEY = "sk-ant-api03-test-key";
-    process.env.VITE_SUPABASE_URL = "https://oxajsxoedrmvrcatqser.supabase.co";
-    const app = createApp();
-
-    const response = await app.request("http://localhost/health");
-    const body = (await response.json()) as { commitSha: string | null };
-    assert.equal(body.commitSha, "railway-sha");
-  });
-
-  it("health commitSha falls back to VERCEL_GIT_COMMIT_SHA when SONDE and RAILWAY are unset", async () => {
-    process.env.VERCEL_GIT_COMMIT_SHA = "vercel-sha";
-    process.env.ANTHROPIC_API_KEY = "sk-ant-api03-test-key";
-    process.env.VITE_SUPABASE_URL = "https://oxajsxoedrmvrcatqser.supabase.co";
-    const app = createApp();
-
-    const response = await app.request("http://localhost/health");
-    const body = (await response.json()) as { commitSha: string | null };
-    assert.equal(body.commitSha, "vercel-sha");
-  });
-
-  it("health commitSha is null when no SHA env vars are set", async () => {
-    process.env.ANTHROPIC_API_KEY = "sk-ant-api03-test-key";
-    process.env.VITE_SUPABASE_URL = "https://oxajsxoedrmvrcatqser.supabase.co";
-    const app = createApp();
-
-    const response = await app.request("http://localhost/health");
-    const body = (await response.json()) as { commitSha: string | null };
-    assert.equal(body.commitSha, null);
+    const body = (await response.json()) as { status: string };
+    assert.deepEqual(body, { status: "ok" });
   });
 
   it("returns runtime metadata only with the audit bearer token", async () => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,7 +3,7 @@ import { cors } from "hono/cors";
 import type { Context, Next } from "hono";
 import { registerGitHubRoutes } from "./github.js";
 import { handleWebSocket } from "./ws-handler.js";
-import { getCommitSha, getRuntimeMetadata } from "./runtime-metadata.js";
+import { getRuntimeMetadata } from "./runtime-metadata.js";
 import { requireRuntimeAuditAuth } from "./runtime-audit.js";
 import { verifyToken, type VerifiedUser } from "./auth.js";
 import { issueWsSessionToken, verifyWsSessionToken } from "./ws-session-token.js";
@@ -245,17 +245,10 @@ export function createApp(): Hono {
     );
   });
 
-  app.get("/health", (c) =>
-    c.json({
-      status: "ok",
-      commitSha: getCommitSha(),
-      environment:
-        process.env.SONDE_ENVIRONMENT?.trim() ||
-        process.env.RAILWAY_GIT_BRANCH?.trim() ||
-        process.env.NODE_ENV?.trim() ||
-        "development",
-    })
-  );
+  // Public /health is liveness-only by contract — the deployed-stack audit
+  // fails if this leaks any metadata. Commit SHA and environment live on
+  // /health/runtime, which is gated by the runtime-audit token.
+  app.get("/health", (c) => c.json({ status: "ok" }));
   app.get("/health/runtime", (c) => c.json(getRuntimeMetadata()));
   app.get("/auth/device/health", (c) => {
     const config = getDeviceAuthRuntimeStatus();

--- a/ui/e2e/ci-smoke.spec.ts
+++ b/ui/e2e/ci-smoke.spec.ts
@@ -87,7 +87,7 @@ test.describe("CI smoke", () => {
     expect(response.ok()).toBeTruthy();
 
     const body = (await response.json()) as { status: string };
-    expect(body.status).toBe("ok");
+    expect(body).toEqual({ status: "ok" });
   });
 
   test("authenticated routes render behind the auth gate", async ({ page }) => {

--- a/ui/e2e/hosted-smoke.spec.ts
+++ b/ui/e2e/hosted-smoke.spec.ts
@@ -375,7 +375,7 @@ test.describe(SUITE_LABEL, () => {
     expect(response.ok()).toBeTruthy();
 
     const body = (await response.json()) as { status: string };
-    expect(body.status).toBe("ok");
+    expect(body).toEqual({ status: "ok" });
   });
 
   test("agent runtime metadata is available with the audit token", async ({ request }) => {


### PR DESCRIPTION
## Summary
Staging smoke has been red since #161 merged. The versioning PR added \`commitSha\` and \`environment\` to the public \`/health\` response, but the deployed-stack audit (\`server/scripts/audit-deployed-stack.mjs:217\`) asserts \`/health\` returns **only** \`{ status: \"ok\" }\` by contract — public liveness must not leak metadata.

This PR restores that contract. Commit SHA visibility is preserved where it belongs:
- \`/health/runtime\` (audit-bearer-gated) still exposes \`commitSha\` via the shared \`getCommitSha()\` helper
- Server startup log still prints the SHA (logs aren't public)

## What changed
- \`server/src/app.ts\` — \`/health\` body is back to \`{ status: \"ok\" }\`; added a comment pointing to the audit contract so nobody regresses this again
- \`server/src/app.test.ts\` — restored \"minimal public health response\" test; dropped the four \`/health\` SHA-fallback tests (those cases are still covered at the unit level in \`runtime-metadata.test.ts\`)
- \`ui/e2e/ci-smoke.spec.ts\`, \`ui/e2e/hosted-smoke.spec.ts\` — back to strict \`toEqual({ status: \"ok\" })\`

## Evidence of the break
Staging Smoke run 24483641203 on the #161 merge commit (\`5fa4f6d\`) failed with:
\`\`\`
[audit-deployed-stack] Failed: Public agent health should expose only liveness status
\`\`\`

## Test plan
- [x] \`pnpm test\` (server) — all suites green locally (9/9 runtime-metadata, minimal /health test restored)
- [x] \`pnpm build\` (server) — tsc clean
- [ ] Staging Smoke passes on the merge commit
- [ ] \`Promote Main\` workflow is no longer skipped
- [ ] First \`tag-on-promote\` run cuts \`v0.1.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)