### PR TITLE
fix(db): paginate next_sequential_id so inserts survive >1000 rows

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -190,3 +190,24 @@ uv tool install --force "git+https://github.com/aeolus-earth/sonde.git@v0.1.1#su
 
 Installs from `main` (or any untagged commit) will show a dev-version
 suffix; installs from a tag will show the clean version.
+
+### Upgrading past the >1000-row ID bug
+
+Versions before the `sonde_next_sequential_id` RPC fix computed the next
+`PREFIX-NNNN` ID by pulling every matching row client-side. PostgREST caps
+those responses at 1000 rows, so once a table (artifacts first, experiments
+and findings next) crossed that threshold, new inserts collided on the PK
+and the retry loop looped on the same stale value. The fix uses a Postgres
+RPC for O(1) allocation, with a paginated client-side fallback for deploys
+that don't yet have the migration applied.
+
+- Users on `@main` auto-update on the next install — just re-run
+  `uv tool install --force …@main`.
+- Users pinned to a tag should reinstall from the first tag that includes
+  the fix:
+  `uv tool install --force "git+https://github.com/aeolus-earth/sonde.git@<tag>#subdirectory=cli"`.
+- The migration is not strictly required: a post-fix CLI against a
+  pre-migration DB logs a one-time WARNING and falls back to the paginated
+  scan (correct, just slower on large tables). Apply
+  `supabase/migrations/20260415000001_add_next_sequential_id_rpc.sql` to
+  get the O(1) server-side path.

--- a/cli/src/sonde/db/ids.py
+++ b/cli/src/sonde/db/ids.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any
+from typing import Any, cast
 
 from postgrest.exceptions import APIError
 
@@ -67,16 +67,23 @@ def _try_rpc_next_id(table: str, prefix: str) -> int | None:
         _rpc_available = False
         return None
 
-    raw: Any = result.data
     # PostgREST scalar functions can return a bare value, a list with one
     # value, or a dict keyed by the function name (mirrors compat.py:65-69).
+    # `ty` aggressively narrows after isinstance checks, so we cast back to
+    # Any at each branch boundary — the real payload shape is only known at
+    # runtime.
+    raw = cast(Any, result.data)
     if isinstance(raw, list):
-        raw = raw[0] if raw else None
+        raw = cast(Any, raw[0] if raw else None)
     if isinstance(raw, dict):
-        raw = raw.get("sonde_next_sequential_id") or raw.get("next_num")
+        raw_dict = cast(dict[str, Any], raw)
+        raw = cast(
+            Any,
+            raw_dict.get("sonde_next_sequential_id") or raw_dict.get("next_num"),
+        )
 
     try:
-        coerced = int(raw) if raw is not None else None
+        coerced: int | None = int(cast(Any, raw)) if raw is not None else None
     except (TypeError, ValueError):
         coerced = None
 

--- a/cli/src/sonde/db/ids.py
+++ b/cli/src/sonde/db/ids.py
@@ -2,50 +2,155 @@
 
 Pattern: PREFIX-NNN(N) where the numeric part is zero-padded.
 Handles concurrent inserts via retry on unique-constraint violation (23505).
+
+Allocation strategy: the `sonde_next_sequential_id` Postgres RPC returns the
+next number in O(1). Older deploys without that RPC fall back to a paginated
+client-side scan; both paths read fresh state on each call so the
+`create_with_retry` retry loop genuinely advances past collisions.
 """
 
 from __future__ import annotations
 
+import logging
 import re
+from typing import Any
+
+from postgrest.exceptions import APIError
 
 from sonde.db import rows as to_rows
 from sonde.db.client import get_client
 
+logger = logging.getLogger(__name__)
+
 _MAX_RETRIES = 5
+_PAGE_SIZE = 1000  # PostgREST's default response cap; matches our scan window.
+
+# Three states for RPC availability:
+#   None  — not yet probed this process.
+#   True  — RPC works; keep using it.
+#   False — RPC missing on this DB; skip the probe and go straight to the scan.
+_rpc_available: bool | None = None
+
+
+def _reset_rpc_cache() -> None:
+    """Test-only: clear the RPC availability cache."""
+    global _rpc_available
+    _rpc_available = None
+
+
+def _try_rpc_next_id(table: str, prefix: str) -> int | None:
+    """Call sonde_next_sequential_id. Returns None if the RPC is missing.
+
+    On the first failure, logs at WARNING (operators should know the DB is
+    behind the migration). Subsequent failures log at DEBUG so we don't spam.
+    """
+    global _rpc_available
+    if _rpc_available is False:
+        return None
+    client = get_client()
+    try:
+        result = client.rpc(
+            "sonde_next_sequential_id",
+            {"p_table": table, "p_prefix": prefix},
+        ).execute()
+    except Exception:
+        if _rpc_available is None:
+            logger.warning(
+                "sonde_next_sequential_id RPC unavailable on this database; "
+                "falling back to paginated client-side scan. Apply the "
+                "20260415000001_add_next_sequential_id_rpc.sql migration for "
+                "the O(1) server-side path.",
+                exc_info=True,
+            )
+        else:
+            logger.debug("sonde_next_sequential_id RPC failed", exc_info=True)
+        _rpc_available = False
+        return None
+
+    raw: Any = result.data
+    # PostgREST scalar functions can return a bare value, a list with one
+    # value, or a dict keyed by the function name (mirrors compat.py:65-69).
+    if isinstance(raw, list):
+        raw = raw[0] if raw else None
+    if isinstance(raw, dict):
+        raw = raw.get("sonde_next_sequential_id") or raw.get("next_num")
+
+    try:
+        coerced = int(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        coerced = None
+
+    if coerced is None:
+        # Any shape we can't coerce (None, empty list, MagicMock from an
+        # existing test fixture that doesn't know about this RPC, etc.) is
+        # treated as "RPC unavailable" so we fall through to the scan path.
+        if _rpc_available is None:
+            logger.warning(
+                "sonde_next_sequential_id RPC returned an unexpected shape "
+                "(%s); falling back to paginated client-side scan.",
+                type(result.data).__name__,
+            )
+        _rpc_available = False
+        return None
+
+    _rpc_available = True
+    return coerced
+
+
+def _scan_max_id_paginated(table: str, prefix: str) -> int:
+    """Paginated client-side fallback. Returns max numeric suffix or 0.
+
+    PostgREST caps responses at _PAGE_SIZE (1000) by default; pull pages in
+    sequence with .range(start, end) until a page comes back short, which
+    signals we've drained the result set.
+    """
+    client = get_client()
+    pattern = re.compile(rf"^{re.escape(prefix)}-(\d+)$")
+    max_num = 0
+    offset = 0
+    while True:
+        result = (
+            client.table(table)
+            .select("id")
+            .like("id", f"{prefix}-%")
+            .range(offset, offset + _PAGE_SIZE - 1)
+            .execute()
+        )
+        rows = to_rows(result.data)
+        if not rows:
+            break
+        for row in rows:
+            m = pattern.match(row["id"])
+            if m:
+                max_num = max(max_num, int(m.group(1)))
+        if len(rows) < _PAGE_SIZE:
+            break
+        offset += _PAGE_SIZE
+    return max_num
 
 
 def next_sequential_id(table: str, prefix: str, digits: int = 4) -> str:
     """Generate the next sequential ID for a table.
 
-    Fetches ALL IDs with the given prefix and finds the true numeric max,
-    avoiding lexicographic sort issues (e.g. PROJ-999 > PROJ-1000).
+    Tries the RPC first (O(1), bypasses PostgREST's 1000-row cap); falls
+    back to a paginated client-side scan on older deploys that don't have
+    the RPC. Auto-expands `digits` if the next number outgrows the padding
+    (PROJ-999 -> PROJ-1000 stays correctly ordered numerically).
     """
-    client = get_client()
-    result = client.table(table).select("id").like("id", f"{prefix}-%").execute()
-    existing = to_rows(result.data)
-    if existing:
-        pattern = re.compile(rf"^{re.escape(prefix)}-(\d+)$")
-        nums = []
-        for row in existing:
-            m = pattern.match(row["id"])
-            if m:
-                nums.append(int(m.group(1)))
-        if nums:
-            next_num = max(nums) + 1
-            # Auto-expand digits if the number outgrows the padding
-            actual_digits = max(digits, len(str(next_num)))
-            return f"{prefix}-{next_num:0{actual_digits}d}"
-    return f"{prefix}-{'1'.zfill(digits)}"
+    next_num = _try_rpc_next_id(table, prefix)
+    if next_num is None:
+        next_num = _scan_max_id_paginated(table, prefix) + 1
+    actual_digits = max(digits, len(str(next_num)))
+    return f"{prefix}-{next_num:0{actual_digits}d}"
 
 
 def create_with_retry(table: str, prefix: str, digits: int, payload: dict) -> dict:
     """Insert a row with a sequential ID, retrying on unique-constraint violation.
 
-    Each retry re-queries the max ID so it advances past the collision.
-    Returns the inserted row as a dict.
+    Each retry recomputes the next ID through `next_sequential_id`, which
+    reads live committed state (RPC or paginated scan), so retries actually
+    advance past collisions instead of looping on the same stale value.
     """
-    from postgrest.exceptions import APIError
-
     client = get_client()
     for attempt in range(_MAX_RETRIES):
         new_id = next_sequential_id(table, prefix, digits)

--- a/cli/tests/test_db_ids.py
+++ b/cli/tests/test_db_ids.py
@@ -7,19 +7,45 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-def _make_client(existing_ids: list[str] | None = None) -> MagicMock:
-    """Build a mock Supabase client for ID generation tests."""
+def _make_client(
+    existing_ids: list[str] | None = None,
+    rpc_data: object = None,
+    rpc_raises: Exception | None = None,
+) -> MagicMock:
+    """Build a mock Supabase client for ID generation tests.
+
+    By default the RPC returns ``data=None`` so callers exercise the
+    paginated client-side fallback. Pass ``rpc_data`` (bare int, list, or
+    dict) to simulate a working RPC, or ``rpc_raises`` to simulate the RPC
+    being missing on this DB.
+    """
     client = MagicMock()
     table = client.table.return_value
-    for method in ("select", "order", "limit", "like", "insert"):
+    for method in ("select", "order", "limit", "like", "range", "insert"):
         getattr(table, method).return_value = table
 
-    # Default: no existing rows
     if existing_ids:
         table.execute.return_value = MagicMock(data=[{"id": eid} for eid in existing_ids])
     else:
         table.execute.return_value = MagicMock(data=[])
+
+    rpc_chain = client.rpc.return_value
+    if rpc_raises is not None:
+        rpc_chain.execute.side_effect = rpc_raises
+    else:
+        rpc_chain.execute.return_value = MagicMock(data=rpc_data)
+
     return client
+
+
+@pytest.fixture(autouse=True)
+def _reset_rpc_state():
+    """Each test starts with a clean RPC-availability cache."""
+    from sonde.db.ids import _reset_rpc_cache
+
+    _reset_rpc_cache()
+    yield
+    _reset_rpc_cache()
 
 
 class TestNextSequentialId:
@@ -59,14 +85,151 @@ class TestNextSequentialId:
         table.like.assert_called_with("id", "EXP-%")
 
 
+class TestRpcPath:
+    """The RPC is the fast path; verify it's used when available."""
+
+    def test_rpc_bare_int_response(self):
+        client = _make_client(rpc_data=43)
+        with patch("sonde.db.ids.get_client", return_value=client):
+            from sonde.db.ids import next_sequential_id
+
+            result = next_sequential_id("experiments", "EXP", 4)
+        assert result == "EXP-0043"
+        client.rpc.assert_called_with(
+            "sonde_next_sequential_id",
+            {"p_table": "experiments", "p_prefix": "EXP"},
+        )
+
+    def test_rpc_list_response(self):
+        """PostgREST sometimes wraps scalar returns in a single-element list."""
+        client = _make_client(rpc_data=[43])
+        with patch("sonde.db.ids.get_client", return_value=client):
+            from sonde.db.ids import next_sequential_id
+
+            result = next_sequential_id("experiments", "EXP", 4)
+        assert result == "EXP-0043"
+
+    def test_rpc_dict_response(self):
+        """And sometimes wraps it in a dict keyed by the function name."""
+        client = _make_client(rpc_data=[{"sonde_next_sequential_id": 43}])
+        with patch("sonde.db.ids.get_client", return_value=client):
+            from sonde.db.ids import next_sequential_id
+
+            result = next_sequential_id("experiments", "EXP", 4)
+        assert result == "EXP-0043"
+
+    def test_rpc_missing_falls_back_to_scan(self, caplog):
+        """RPC raises (function not found) — fall back to client-side scan."""
+        import logging
+
+        client = _make_client(
+            existing_ids=["EXP-0042"],
+            rpc_raises=Exception("function does not exist"),
+        )
+        with caplog.at_level(logging.WARNING, logger="sonde.db.ids"):
+            with patch("sonde.db.ids.get_client", return_value=client):
+                from sonde.db.ids import next_sequential_id
+
+                result = next_sequential_id("experiments", "EXP", 4)
+
+        assert result == "EXP-0043"
+        # Operators should see a one-time warning that the migration is missing.
+        assert any(
+            "RPC unavailable" in record.message for record in caplog.records
+        )
+
+    def test_rpc_missing_is_cached(self):
+        """After the first failure we skip the RPC for the rest of the process."""
+        client = _make_client(
+            existing_ids=["EXP-0001"],
+            rpc_raises=Exception("function does not exist"),
+        )
+        with patch("sonde.db.ids.get_client", return_value=client):
+            from sonde.db.ids import next_sequential_id
+
+            next_sequential_id("experiments", "EXP", 4)
+            next_sequential_id("experiments", "EXP", 4)
+
+        # First call probes the RPC (raises); second call skips the probe.
+        assert client.rpc.return_value.execute.call_count == 1
+
+
+class TestPaginatedFallback:
+    """The original bug: PostgREST capped responses at 1000 rows.
+
+    These tests would have caught the bug before users ran into it.
+    """
+
+    def test_scan_pages_through_2500_rows(self):
+        """With 2500 rows split across 3 pages, the scan must see all of them.
+
+        Before the fix, ``client.table(t).select(...).like(...).execute()`` was
+        capped at 1000 rows and the client computed a stale max. After the fix,
+        we paginate via ``.range(start, end)`` until a short page is returned.
+        """
+        client = _make_client(rpc_raises=Exception("function does not exist"))
+        table = client.table.return_value
+
+        # 2500 ART rows: ART-0001 .. ART-2500. Split across 3 pages.
+        page_1 = [{"id": f"ART-{i:04d}"} for i in range(1, 1001)]
+        page_2 = [{"id": f"ART-{i:04d}"} for i in range(1001, 2001)]
+        page_3 = [{"id": f"ART-{i:04d}"} for i in range(2001, 2501)]
+        table.execute.side_effect = [
+            MagicMock(data=page_1),
+            MagicMock(data=page_2),
+            MagicMock(data=page_3),
+        ]
+
+        with patch("sonde.db.ids.get_client", return_value=client):
+            from sonde.db.ids import next_sequential_id
+
+            result = next_sequential_id("artifacts", "ART", 4)
+
+        # Auto-expands to 5 digits because 2501 > 9999? No — 2501 fits in 4.
+        assert result == "ART-2501"
+
+        # Confirm each page was requested with the correct .range() bounds.
+        range_calls = [c.args for c in table.range.call_args_list]
+        assert range_calls == [(0, 999), (1000, 1999), (2000, 2999)]
+
+    def test_scan_stops_when_page_short_returns(self):
+        """A page shorter than _PAGE_SIZE means we've reached the end."""
+        client = _make_client(rpc_raises=Exception("function does not exist"))
+        table = client.table.return_value
+        table.execute.side_effect = [
+            MagicMock(data=[{"id": f"ART-{i:04d}"} for i in range(1, 501)]),
+        ]
+
+        with patch("sonde.db.ids.get_client", return_value=client):
+            from sonde.db.ids import next_sequential_id
+
+            result = next_sequential_id("artifacts", "ART", 4)
+
+        assert result == "ART-0501"
+        # Only one .range() call because the first page came back short.
+        assert table.range.call_count == 1
+
+    def test_scan_auto_expands_digits_past_9999(self):
+        """PROJ-9999 -> PROJ-10000 must keep numeric ordering correct."""
+        client = _make_client(
+            existing_ids=["ART-9999"],
+            rpc_raises=Exception("function does not exist"),
+        )
+        with patch("sonde.db.ids.get_client", return_value=client):
+            from sonde.db.ids import next_sequential_id
+
+            result = next_sequential_id("artifacts", "ART", 4)
+        assert result == "ART-10000"
+
+
 class TestCreateWithRetry:
     def test_success_first_attempt(self):
         client = _make_client()
         inserted_row = {"id": "EXP-0001", "program": "test"}
-        # select for next_id returns empty, insert returns the row
+        # rpc returns data=None (default), so we hit the scan + insert path.
         table = client.table.return_value
         table.execute.side_effect = [
-            MagicMock(data=[]),  # next_sequential_id query
+            MagicMock(data=[]),  # scan
             MagicMock(data=[inserted_row]),  # insert
         ]
 
@@ -90,16 +253,14 @@ class TestCreateWithRetry:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                # First: next_sequential_id query
-                return MagicMock(data=[])
+                return MagicMock(data=[])  # first scan
             if call_count == 2:
-                # Second: insert fails with 23505
-                raise APIError({"message": "duplicate", "code": "23505", "details": "", "hint": ""})
+                raise APIError(
+                    {"message": "duplicate", "code": "23505", "details": "", "hint": ""}
+                )
             if call_count == 3:
-                # Third: next_sequential_id retry query
-                return MagicMock(data=[{"id": "EXP-0001"}])
-            # Fourth: insert succeeds
-            return MagicMock(data=[inserted_row])
+                return MagicMock(data=[{"id": "EXP-0001"}])  # second scan, fresh state
+            return MagicMock(data=[inserted_row])  # second insert
 
         table.execute.side_effect = execute_side_effect
 
@@ -109,7 +270,41 @@ class TestCreateWithRetry:
             result = create_with_retry("experiments", "EXP", 4, {"program": "test"})
 
         assert result == inserted_row
-        assert call_count == 4  # 2 attempts x (select + insert)
+        assert call_count == 4
+
+    def test_retry_advances_when_rpc_returns_higher_value(self):
+        """Bug-fix property: with the RPC, each retry sees fresh server state.
+
+        Previously every retry recomputed the same stale max because the
+        client SELECT was capped at 1000 rows. Now the RPC reads live data,
+        so a 23505 collision is followed by a higher ID on the next call.
+        """
+        from postgrest.exceptions import APIError
+
+        client = MagicMock()
+        table = client.table.return_value
+        for method in ("select", "order", "limit", "like", "range", "insert"):
+            getattr(table, method).return_value = table
+
+        inserted_row = {"id": "ART-1091", "kind": "log"}
+
+        # RPC returns 1090 first (collides), then 1091 on the second attempt.
+        client.rpc.return_value.execute.side_effect = [
+            MagicMock(data=1090),
+            MagicMock(data=1091),
+        ]
+        table.execute.side_effect = [
+            APIError({"message": "duplicate", "code": "23505", "details": "", "hint": ""}),
+            MagicMock(data=[inserted_row]),
+        ]
+
+        with patch("sonde.db.ids.get_client", return_value=client):
+            from sonde.db.ids import create_with_retry
+
+            result = create_with_retry("artifacts", "ART", 4, {"kind": "log"})
+
+        assert result == inserted_row
+        assert client.rpc.return_value.execute.call_count == 2
 
     def test_max_retries_exceeded(self):
         from postgrest.exceptions import APIError
@@ -117,15 +312,16 @@ class TestCreateWithRetry:
         client = _make_client()
         table = client.table.return_value
 
-        # Always return empty for next_id, always fail insert
         call_count = 0
 
         def execute_side_effect():
             nonlocal call_count
             call_count += 1
             if call_count % 2 == 1:
-                return MagicMock(data=[])  # next_id query
-            raise APIError({"message": "duplicate", "code": "23505", "details": "", "hint": ""})
+                return MagicMock(data=[])  # scan
+            raise APIError(
+                {"message": "duplicate", "code": "23505", "details": "", "hint": ""}
+            )
 
         table.execute.side_effect = execute_side_effect
 
@@ -141,7 +337,7 @@ class TestCreateWithRetry:
         client = _make_client()
         table = client.table.return_value
         table.execute.side_effect = [
-            MagicMock(data=[]),  # next_id
+            MagicMock(data=[]),  # scan
             APIError({"message": "forbidden", "code": "42501", "details": "", "hint": ""}),
         ]
 

--- a/cli/tests/test_db_ids.py
+++ b/cli/tests/test_db_ids.py
@@ -126,17 +126,17 @@ class TestRpcPath:
             existing_ids=["EXP-0042"],
             rpc_raises=Exception("function does not exist"),
         )
-        with caplog.at_level(logging.WARNING, logger="sonde.db.ids"):
-            with patch("sonde.db.ids.get_client", return_value=client):
-                from sonde.db.ids import next_sequential_id
+        with (
+            caplog.at_level(logging.WARNING, logger="sonde.db.ids"),
+            patch("sonde.db.ids.get_client", return_value=client),
+        ):
+            from sonde.db.ids import next_sequential_id
 
-                result = next_sequential_id("experiments", "EXP", 4)
+            result = next_sequential_id("experiments", "EXP", 4)
 
         assert result == "EXP-0043"
         # Operators should see a one-time warning that the migration is missing.
-        assert any(
-            "RPC unavailable" in record.message for record in caplog.records
-        )
+        assert any("RPC unavailable" in record.message for record in caplog.records)
 
     def test_rpc_missing_is_cached(self):
         """After the first failure we skip the RPC for the rest of the process."""
@@ -255,9 +255,7 @@ class TestCreateWithRetry:
             if call_count == 1:
                 return MagicMock(data=[])  # first scan
             if call_count == 2:
-                raise APIError(
-                    {"message": "duplicate", "code": "23505", "details": "", "hint": ""}
-                )
+                raise APIError({"message": "duplicate", "code": "23505", "details": "", "hint": ""})
             if call_count == 3:
                 return MagicMock(data=[{"id": "EXP-0001"}])  # second scan, fresh state
             return MagicMock(data=[inserted_row])  # second insert
@@ -319,9 +317,7 @@ class TestCreateWithRetry:
             call_count += 1
             if call_count % 2 == 1:
                 return MagicMock(data=[])  # scan
-            raise APIError(
-                {"message": "duplicate", "code": "23505", "details": "", "hint": ""}
-            )
+            raise APIError({"message": "duplicate", "code": "23505", "details": "", "hint": ""})
 
         table.execute.side_effect = execute_side_effect
 

--- a/supabase/migrations/20260415000001_add_next_sequential_id_rpc.sql
+++ b/supabase/migrations/20260415000001_add_next_sequential_id_rpc.sql
@@ -1,0 +1,61 @@
+-- Single source of truth for sequential ID allocation.
+--
+-- The CLI's previous behavior was to SELECT every id LIKE 'PREFIX-%' and take
+-- max() client-side. PostgREST silently caps SELECT responses at 1000 rows, so
+-- once any prefix table crossed that threshold the client computed a stale max
+-- and inserts collided on the PK. Already tripping on artifacts (>1000 rows);
+-- experiments and findings are next at current growth.
+--
+-- This RPC returns max(numeric_suffix) + 1 in O(1), bypassing the row cap.
+-- SECURITY DEFINER so the function sees the global max regardless of RLS:
+-- ID allocation is a system-level operation, and an RLS-filtered max would
+-- still produce collisions for any user who can't see the highest existing id.
+-- The privacy implication (a caller can probe row counts via repeated calls)
+-- is acceptable for our single-tenant team app.
+--
+-- The CLI's bundled fallback (paginated client-side scan) handles deploys
+-- where this function isn't yet present, so the migration is not a hard
+-- prerequisite for the CLI release that uses it.
+
+CREATE OR REPLACE FUNCTION public.sonde_next_sequential_id(
+    p_table text,
+    p_prefix text
+)
+RETURNS bigint
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    next_num bigint;
+BEGIN
+    -- Defense-in-depth: format(%I, %L) below already quote the inputs, but
+    -- reject anything that isn't a plausible Postgres identifier or our
+    -- conventional uppercase prefix before we hand it to the SQL builder.
+    IF p_table !~ '^[a-z_][a-z0-9_]*$' THEN
+        RAISE EXCEPTION 'Invalid table name: %', p_table;
+    END IF;
+    IF p_prefix !~ '^[A-Z]+$' THEN
+        RAISE EXCEPTION 'Invalid prefix: %', p_prefix;
+    END IF;
+
+    EXECUTE format(
+        'SELECT coalesce(max((substring(id from %L))::bigint), 0) + 1
+           FROM %I
+          WHERE id LIKE %L',
+        '\d+$',
+        p_table,
+        p_prefix || '-%'
+    ) INTO next_num;
+
+    RETURN next_num;
+END;
+$$;
+
+COMMENT ON FUNCTION public.sonde_next_sequential_id(text, text) IS
+    'Returns max numeric suffix + 1 for rows in p_table with id LIKE p_prefix-%. SECURITY DEFINER so RLS does not hide rows during ID allocation.';
+
+GRANT EXECUTE ON FUNCTION public.sonde_next_sequential_id(text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.sonde_next_sequential_id(text, text) TO service_role;
+-- Intentionally NOT granted to anon: ID allocation is for authenticated users only.


### PR DESCRIPTION
## Summary

`sonde.db.ids.next_sequential_id` silently hits Supabase PostgREST's 1000-row response cap. Once any `PREFIX-NNNN` table crosses that threshold the client computes a stale max and inserts collide on the PK (Postgres 23505). The existing 5-attempt retry loop recomputes the same stale value, so all retries fail. Already tripping on `artifacts` (>1090 rows); `experiments` (~380) and `findings` (~130) are next.

## Fix

Two-layer, backwards-compatible:

1. **Server RPC** — new migration adds `sonde_next_sequential_id(p_table, p_prefix)` returning `max(numeric_suffix)+1` in O(1), bypassing the row cap. `SECURITY DEFINER` so RLS doesn't hide rows during ID allocation (a latent second bug in the old path: RLS-hidden rows produced permanent 23505 loops for users who couldn't see the highest id).
2. **CLI fallback** — `cli/src/sonde/db/ids.py` calls the RPC first; on "function not found" it falls back to a paginated `.range()` scan with the same regex extraction. Logs a one-time WARNING per process on first fallback. Caches RPC availability so we don't re-probe.

Result: `create_with_retry`'s retry loop is now meaningful — each retry reads fresh state, so collisions advance past cleanly. Works against pre-migration and post-migration databases.

## Affected tables (all benefit transparently)

ART, EXP, FIND, DIR, Q, NOTE, REV, RVE, PROJ — all 9 call sites go through `create_with_retry` and don't need individual changes.

## Files

| File | Change |
| --- | --- |
| \`supabase/migrations/20260415000001_add_next_sequential_id_rpc.sql\` | **New** — RPC, grants, comment |
| \`cli/src/sonde/db/ids.py\` | Rewrite: RPC-first + paginated fallback |
| \`cli/tests/test_db_ids.py\` | Updated mock; 3 new test classes, 25 tests total |
| \`cli/README.md\` | "Upgrading past the >1000-row ID bug" section |

## Data safety

**This change cannot remove, modify, or corrupt existing rows.**

- Migration contains no \`DELETE\`/\`UPDATE\`/\`DROP\`/\`TRUNCATE\`/\`ALTER\`/\`REVOKE\` (greppable — only \`CREATE OR REPLACE FUNCTION\`, \`SELECT\` inside the function body, \`GRANT EXECUTE\`, and \`COMMENT ON FUNCTION\`).
- Function body is a fixed \`SELECT coalesce(max(...), 0) + 1 FROM %I WHERE id LIKE %L\` template. \`%I\`/\`%L\` cannot inject a write into a SELECT. Declared \`STABLE\`. Two input-validation regexes (\`p_table\` lowercase identifier, \`p_prefix\` uppercase) fail fast on invalid inputs.
- CLI's only data-modifying call is \`client.table(table).insert(row).execute()\` — INSERT can only add rows, never modify existing ones. No \`.update()\`, \`.delete()\`, or \`.upsert()\` anywhere in the file.
- Rollback: \`DROP FUNCTION IF EXISTS public.sonde_next_sequential_id(text, text);\` — idempotent, one line. CLI falls back to the paginated scan automatically when the function is absent.

Worst-case outcome if the change is wrong: new inserts fail loudly until rolled back. No path to data loss.

## Test plan

- [x] \`cd cli && uv run pytest tests/test_db_ids.py -v\` — 25 tests pass, including the new pagination test that simulates 2500 rows across 3 pages (the test that would have caught the original bug).
- [x] \`cd cli && uv run pytest\` — full CLI suite green: 617 passed, 1 skipped.
- [ ] After merge: run a CLI-hosted audit via staging that inserts an artifact against the RPC-available DB.
- [ ] After merge: rollback migration locally, confirm CLI falls back gracefully and logs the one-time warning.

## Rollback

\`\`\`sql
DROP FUNCTION IF EXISTS public.sonde_next_sequential_id(text, text);
\`\`\`

The deployed CLI continues to work via the paginated fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)