### PR TITLE
test(rigor): audit-driven hardening pass across CLI, server, UI

### DIFF
--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -174,7 +174,16 @@ def mock_supabase() -> MagicMock:
 def patched_db(mock_supabase: MagicMock, authenticated: None) -> Generator[MagicMock, None, None]:
     """Mock Supabase client patched into the db layer, with auth already set up.
 
-    This is the convenience fixture for testing commands end-to-end:
+    Patches every ``sonde.*`` module that holds a module-level ``get_client``
+    binding (via ``from sonde.db.client import get_client``). The list of
+    patched modules is discovered at fixture-setup time from ``sys.modules``
+    — new modules that import ``get_client`` get covered automatically,
+    without having to maintain a manual list here. (The old fixture kept a
+    hard-coded list of 18 modules and silently missed 8 others that
+    imported ``get_client``; tests touching those modules risked hitting
+    the real Supabase.)
+
+    Usage:
 
         def test_list(runner, patched_db):
             patched_db.table("experiments").select("*") \\
@@ -184,64 +193,45 @@ def patched_db(mock_supabase: MagicMock, authenticated: None) -> Generator[Magic
             result = runner.invoke(cli, ["list", "-p", "weather-intervention"])
             assert result.exit_code == 0
     """
-    with (
-        patch("sonde.db.client.get_client", return_value=mock_supabase),
-        patch("sonde.db.client._client", mock_supabase),
-        patch("sonde.db.client._client_token", "eyJ-fake-access-token"),
-    ):
-        # Patch the imported reference in all modules that bind get_client at import time
-        import sonde.commands.admin as admin_mod
-        import sonde.db.activity as activity_mod
-        import sonde.db.artifacts.crud as art_crud_mod
-        import sonde.db.artifacts.storage as art_storage_mod
-        import sonde.db.directions as dir_mod
-        import sonde.db.experiments as exp_mod
-        import sonde.db.experiments.maintenance as exp_maintenance_mod
-        import sonde.db.experiments.read as exp_read_mod
-        import sonde.db.experiments.stats as exp_stats_mod
-        import sonde.db.experiments.tree as exp_tree_mod
-        import sonde.db.findings as find_mod
-        import sonde.db.health as health_mod
-        import sonde.db.ids as ids_mod
-        import sonde.db.notes as notes_mod
-        import sonde.db.notes as notes_poly_mod
-        import sonde.db.programs as prog_mod
-        import sonde.db.questions as q_mod
-        import sonde.db.reviews as review_mod
-        import sonde.db.tags as tags_mod
+    import sys
+    from contextlib import ExitStack
 
-        modules: list[Any] = [
-            admin_mod,
-            activity_mod,
-            art_crud_mod,
-            art_storage_mod,
-            dir_mod,
-            exp_mod,
-            exp_maintenance_mod,
-            exp_read_mod,
-            exp_stats_mod,
-            exp_tree_mod,
-            find_mod,
-            health_mod,
-            ids_mod,
-            notes_mod,
-            notes_poly_mod,
-            prog_mod,
-            q_mod,
-            review_mod,
-            tags_mod,
-        ]
-        originals = {mod: mod.get_client for mod in modules}
-        for mod in modules:
-            mod.get_client = lambda: mock_supabase
+    import sonde.db.client as client_mod
+    from sonde.db.compat import reset_cache
 
-        # Ensure the compat cache doesn't leak between tests
-        from sonde.db.compat import reset_cache
+    # Capture the real function before any patching so we can identify
+    # modules that currently hold a reference to it. Lambda rather than a
+    # plain object so we preserve the ``get_client()`` call shape.
+    def _mock_client_factory() -> MagicMock:
+        return mock_supabase
+
+    with ExitStack() as stack:
+        # Canonical patches on the client module.
+        stack.enter_context(
+            patch.object(client_mod, "get_client", return_value=mock_supabase)
+        )
+        stack.enter_context(patch.object(client_mod, "_client", mock_supabase))
+        stack.enter_context(
+            patch.object(client_mod, "_client_token", "eyJ-fake-access-token")
+        )
+
+        # Dynamically patch every already-imported sonde module that bound
+        # get_client at import time. ``patch.object`` handles save/restore
+        # automatically; no manual bookkeeping. A module imported AFTER
+        # this point will see the patched ``sonde.db.client.get_client``
+        # directly at its own import time, so it's covered without being
+        # in this loop.
+        for name, module in list(sys.modules.items()):
+            if not name.startswith("sonde.") or module is client_mod:
+                continue
+            if getattr(module, "get_client", None) is None:
+                continue
+            stack.enter_context(
+                patch.object(module, "get_client", new=_mock_client_factory)
+            )
 
         reset_cache()
         try:
             yield mock_supabase
         finally:
             reset_cache()
-            for mod, orig in originals.items():
-                mod.get_client = orig

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -207,13 +207,9 @@ def patched_db(mock_supabase: MagicMock, authenticated: None) -> Generator[Magic
 
     with ExitStack() as stack:
         # Canonical patches on the client module.
-        stack.enter_context(
-            patch.object(client_mod, "get_client", return_value=mock_supabase)
-        )
+        stack.enter_context(patch.object(client_mod, "get_client", return_value=mock_supabase))
         stack.enter_context(patch.object(client_mod, "_client", mock_supabase))
-        stack.enter_context(
-            patch.object(client_mod, "_client_token", "eyJ-fake-access-token")
-        )
+        stack.enter_context(patch.object(client_mod, "_client_token", "eyJ-fake-access-token"))
 
         # Dynamically patch every already-imported sonde module that bound
         # get_client at import time. ``patch.object`` handles save/restore
@@ -226,9 +222,7 @@ def patched_db(mock_supabase: MagicMock, authenticated: None) -> Generator[Magic
                 continue
             if getattr(module, "get_client", None) is None:
                 continue
-            stack.enter_context(
-                patch.object(module, "get_client", new=_mock_client_factory)
-            )
+            stack.enter_context(patch.object(module, "get_client", new=_mock_client_factory))
 
         reset_cache()
         try:

--- a/cli/tests/test_auth_commands.py
+++ b/cli/tests/test_auth_commands.py
@@ -544,3 +544,92 @@ def test_refresh_session_updates_stored_session(monkeypatch):
     user = cast(dict[str, Any], saved["user"])
     meta = cast(dict[str, Any], user["app_metadata"])
     assert meta["programs"] == ["dart-benchmarking", "shared"]
+
+
+# ---------------------------------------------------------------------------
+# Auth negative-path coverage
+# ---------------------------------------------------------------------------
+#
+# The CLI enforces auth in one place: ``cli.py`` invokes ``is_authenticated()``
+# for every subcommand not in the ``_NO_AUTH`` allowlist. These tests pin that
+# contract so a regression (accidental allowlist expansion, dropped auth
+# check, or a new subcommand registered without going through the gate)
+# fails loudly.
+
+
+def test_noauth_allowlist_is_tight() -> None:
+    """The _NO_AUTH set must stay tight. Any command outside this set
+    requires auth. If this assertion fires, someone added a command to
+    the allowlist — review whether that's intentional."""
+    from sonde.cli import _NO_AUTH
+
+    expected = {"login", "logout", "whoami", "setup", "doctor", "skills"}
+    assert _NO_AUTH == expected, (
+        f"_NO_AUTH changed to {_NO_AUTH!r}. If intentional, update this "
+        f"test; otherwise a previously-auth-required command was silently "
+        f"allowlisted."
+    )
+
+
+def _invoke_unauthenticated(runner: CliRunner, monkeypatch, *args: str):
+    """Run a CLI command with no credentials available."""
+    monkeypatch.delenv("SONDE_TOKEN", raising=False)
+    monkeypatch.delenv("SONDE_ACCESS_TOKEN", raising=False)
+    with (
+        patch("sonde.auth.is_authenticated", return_value=False),
+        patch("sonde.auth.load_session", return_value=None),
+        patch("sonde.auth.get_token", return_value=None),
+    ):
+        return runner.invoke(cli, list(args))
+
+
+def test_list_rejects_unauthenticated(runner: CliRunner, monkeypatch):
+    result = _invoke_unauthenticated(runner, monkeypatch, "list")
+    assert result.exit_code != 0
+    assert "Not logged in" in result.output
+    assert "sonde login" in result.output
+
+
+def test_show_rejects_unauthenticated(runner: CliRunner, monkeypatch):
+    result = _invoke_unauthenticated(runner, monkeypatch, "show", "EXP-0001")
+    assert result.exit_code != 0
+    assert "Not logged in" in result.output
+
+
+def test_push_rejects_unauthenticated(runner: CliRunner, monkeypatch):
+    result = _invoke_unauthenticated(runner, monkeypatch, "push")
+    assert result.exit_code != 0
+    assert "Not logged in" in result.output
+
+
+def test_pull_rejects_unauthenticated(runner: CliRunner, monkeypatch):
+    result = _invoke_unauthenticated(runner, monkeypatch, "pull")
+    assert result.exit_code != 0
+    assert "Not logged in" in result.output
+
+
+def test_recent_rejects_unauthenticated(runner: CliRunner, monkeypatch):
+    result = _invoke_unauthenticated(runner, monkeypatch, "recent")
+    assert result.exit_code != 0
+    assert "Not logged in" in result.output
+
+
+def test_brief_rejects_unauthenticated(runner: CliRunner, monkeypatch):
+    result = _invoke_unauthenticated(runner, monkeypatch, "brief")
+    assert result.exit_code != 0
+    assert "Not logged in" in result.output
+
+
+def test_login_does_not_require_prior_auth(runner: CliRunner, monkeypatch):
+    """`login` must remain reachable without credentials — otherwise users
+    can't recover from an expired session. Pins the allowlist inclusion."""
+    monkeypatch.delenv("SONDE_TOKEN", raising=False)
+    with (
+        patch("sonde.auth.is_authenticated", return_value=False),
+        patch("sonde.auth.load_session", return_value=None),
+    ):
+        # `login --help` is safe to run: it exercises the entry point
+        # without triggering the actual OAuth flow.
+        result = runner.invoke(cli, ["login", "--help"])
+    assert result.exit_code == 0
+    assert "Not logged in" not in result.output

--- a/cli/tests/test_auth_commands.py
+++ b/cli/tests/test_auth_commands.py
@@ -564,7 +564,7 @@ def test_noauth_allowlist_is_tight() -> None:
     from sonde.cli import _NO_AUTH
 
     expected = {"login", "logout", "whoami", "setup", "doctor", "skills"}
-    assert _NO_AUTH == expected, (
+    assert expected == _NO_AUTH, (
         f"_NO_AUTH changed to {_NO_AUTH!r}. If intentional, update this "
         f"test; otherwise a previously-auth-required command was silently "
         f"allowlisted."

--- a/cli/tests/test_conftest_fixture.py
+++ b/cli/tests/test_conftest_fixture.py
@@ -62,8 +62,7 @@ def test_patched_db_covers_core_db_modules(patched_db) -> None:
     for module in (ids_mod, find_mod, reviews_mod, exp_read_mod):
         client = module.get_client()
         assert client is patched_db, (
-            f"{module.__name__}.get_client() returned {client!r}, "
-            f"not the mock fixture."
+            f"{module.__name__}.get_client() returned {client!r}, not the mock fixture."
         )
 
 

--- a/cli/tests/test_conftest_fixture.py
+++ b/cli/tests/test_conftest_fixture.py
@@ -1,0 +1,85 @@
+"""Tests for the test-infrastructure fixtures themselves.
+
+The `patched_db` fixture used to maintain a manual list of 18 modules to
+patch `get_client` on. That list silently missed 8 modules that also
+imported `get_client` (projects, project_takeaways, direction_takeaways,
+program_takeaways, question_links, auth_events, commands/artifact_update,
+commands/search_all). Tests exercising those modules risked hitting the
+real Supabase.
+
+These tests pin the invariant: any `sonde.*` module that imports
+`get_client` at module scope is patched by `patched_db`. If someone
+accidentally reverts the dynamic discovery and hardcodes a list again,
+this test file fails loudly.
+"""
+
+from __future__ import annotations
+
+
+def test_patched_db_covers_previously_missing_modules(patched_db) -> None:
+    """Modules absent from the old hardcoded list must still be patched."""
+    import sonde.commands.artifact_update as artifact_update_mod
+    import sonde.commands.search_all as search_all_mod
+    import sonde.db.auth_events as auth_events_mod
+    import sonde.db.direction_takeaways as direction_takeaways_mod
+    import sonde.db.program_takeaways as program_takeaways_mod
+    import sonde.db.project_takeaways as project_takeaways_mod
+    import sonde.db.projects as projects_mod
+    import sonde.db.question_links as question_links_mod
+
+    # Each of these modules imports `get_client` at the top via
+    # `from sonde.db.client import get_client`. After the fixture patches
+    # them, calling `module.get_client()` must return the mock, not the
+    # real Supabase client.
+    previously_missing = [
+        projects_mod,
+        project_takeaways_mod,
+        direction_takeaways_mod,
+        program_takeaways_mod,
+        question_links_mod,
+        auth_events_mod,
+        artifact_update_mod,
+        search_all_mod,
+    ]
+
+    for module in previously_missing:
+        client = module.get_client()
+        # patched_db yields the mock; identity check pins this down.
+        assert client is patched_db, (
+            f"{module.__name__}.get_client() returned {client!r}, "
+            f"not the mock fixture. The `patched_db` fixture's dynamic "
+            f"discovery is broken."
+        )
+
+
+def test_patched_db_covers_core_db_modules(patched_db) -> None:
+    """The core db modules that were in the old hardcoded list stay covered."""
+    import sonde.db.experiments.read as exp_read_mod
+    import sonde.db.findings as find_mod
+    import sonde.db.ids as ids_mod
+    import sonde.db.reviews as reviews_mod
+
+    for module in (ids_mod, find_mod, reviews_mod, exp_read_mod):
+        client = module.get_client()
+        assert client is patched_db, (
+            f"{module.__name__}.get_client() returned {client!r}, "
+            f"not the mock fixture."
+        )
+
+
+def test_patched_db_restores_after_fixture_exits(patched_db) -> None:
+    """After the fixture unwinds, the real get_client is restored.
+
+    We can't directly test post-fixture state in the same test, but we can
+    verify that while the fixture is active, the canonical module's
+    get_client is the mocked one — so cleanup at fixture exit has
+    something to restore.
+    """
+    import sonde.db.client as client_mod
+
+    # While patched_db is active, client_mod.get_client is mocked.
+    result = client_mod.get_client()
+    # The outer patch(..., return_value=mock_supabase) makes this a MagicMock
+    # that returns mock_supabase. It isn't the sonde.db.client.get_client
+    # function directly; that's the point.
+    assert result is patched_db

--- a/cli/tests/test_db_layer.py
+++ b/cli/tests/test_db_layer.py
@@ -93,11 +93,62 @@ class TestFindings:
         patched_db.table("findings").execute.return_value = MagicMock(data=[_FINDING_ROW])
 
         from sonde.db import findings as db
+        from sonde.models.finding import Finding
 
         results = db.list_findings(program="weather-intervention")
         assert len(results) == 1
-        assert results[0].id == "FIND-001"
-        assert results[0].confidence == "high"
+        finding = results[0]
+
+        # Full-model assertions instead of single-field round-trip. A
+        # regression that dropped fields, mis-coerced types, or silently
+        # filtered rows would previously pass the single-field check.
+        assert isinstance(finding, Finding)
+        assert finding.id == "FIND-001"
+        assert finding.program == "weather-intervention"
+        assert finding.topic == "CCN saturation"
+        assert finding.finding == "Enhancement saturates at CCN ~1500"
+        assert finding.confidence == "high"
+        assert finding.evidence == ["EXP-0001", "EXP-0002"]
+        assert finding.source == "human/test"
+        assert finding.supersedes is None
+        assert finding.valid_until is None
+        # datetime round-trips through ISO string → datetime object
+        assert finding.valid_from.year == 2026
+
+    def test_list_findings_rejects_invalid_confidence(self, patched_db: MagicMock):
+        """The Finding model's Literal confidence field must reject
+        values outside the allowed set. If the DB ever returns a stale
+        row with a dropped confidence level, we want a loud ValidationError
+        at the boundary, not a silent downstream bug."""
+        import pydantic
+
+        bad_row = {**_FINDING_ROW, "confidence": "stellar"}
+        patched_db.table("findings").execute.return_value = MagicMock(data=[bad_row])
+
+        from sonde.db import findings as db
+
+        # Exact exception type — not a catch-all Exception. If Pydantic
+        # stops raising ValidationError for literal violations, the test
+        # must break so we notice.
+        try:
+            db.list_findings(program="weather-intervention")
+        except pydantic.ValidationError as exc:
+            assert "confidence" in str(exc).lower()
+        else:
+            raise AssertionError(
+                "Finding model accepted an invalid confidence literal; "
+                "validation must fail loudly at the boundary"
+            )
+
+    def test_list_findings_empty_result(self, patched_db: MagicMock):
+        """Empty DB response must round-trip as an empty list — not raise,
+        not return None. Pins the 'no findings yet' UX."""
+        patched_db.table("findings").execute.return_value = MagicMock(data=[])
+
+        from sonde.db import findings as db
+
+        results = db.list_findings(program="weather-intervention")
+        assert results == []
 
     def test_count_findings(self, patched_db: MagicMock):
         patched_db.table("findings").execute.return_value = MagicMock(data=[], count=5)

--- a/cli/tests/test_db_reviews.py
+++ b/cli/tests/test_db_reviews.py
@@ -1,0 +1,115 @@
+"""Tests for sonde.db.reviews — pins the retry-fresh-state contract.
+
+`ensure_thread` handles a race: if two processes both try to open the one
+allowed review thread for an experiment, one wins and the other must
+recover by re-reading the winner's row. The retry is only meaningful if
+the second `get_thread` call sees fresh data. These tests pin that —
+analogous to the `next_sequential_id` paradigm where the pre-fix code
+would re-query stale data on every retry, rendering the retry loop a
+no-op.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from postgrest.exceptions import APIError
+
+from sonde.models.review import ExperimentReview
+
+
+def _make_review(review_id: str, experiment_id: str) -> ExperimentReview:
+    now = datetime.now(timezone.utc)
+    return ExperimentReview(
+        id=review_id,
+        experiment_id=experiment_id,
+        opened_by="agent/smoke",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _api_error(code: str) -> APIError:
+    return APIError({"code": code, "message": "test", "details": "", "hint": ""})
+
+
+class TestEnsureThreadRace:
+    """The retry path in `ensure_thread` (reviews.py:46-63) must see fresh
+    state on the re-read. A stale re-read would silently re-raise the
+    23505, losing the race instead of recovering from it.
+    """
+
+    def test_lost_race_resolves_to_other_process_thread(self) -> None:
+        other_process_thread = _make_review("REV-0042", "EXP-0001")
+        # get_thread is called twice: once before the create attempt (to
+        # check for an existing thread) and once after the 23505 (to find
+        # the winner). The side_effect sequence forces the second call to
+        # return a DIFFERENT value than the first.
+        get_returns = [None, other_process_thread]
+
+        with (
+            patch("sonde.db.reviews.get_thread", side_effect=get_returns),
+            patch("sonde.db.reviews.create_thread", side_effect=_api_error("23505")),
+        ):
+            from sonde.db.reviews import ensure_thread
+
+            review, created = ensure_thread("EXP-0001", "agent/smoke")
+
+        assert created is False, "lost the race — must not be reported as newly created"
+        assert review.id == "REV-0042", (
+            "the re-read after 23505 must fetch the thread the winning "
+            "process created; if get_thread returned stale None, "
+            "ensure_thread would have re-raised the APIError instead"
+        )
+
+    def test_stale_reread_reraises(self) -> None:
+        """If the re-read itself fails to see the winning thread (stale
+        read replica, cache desync, etc.), we must re-raise rather than
+        hang or return a bogus result."""
+        with (
+            patch("sonde.db.reviews.get_thread", side_effect=[None, None]),
+            patch("sonde.db.reviews.create_thread", side_effect=_api_error("23505")),
+        ):
+            from sonde.db.reviews import ensure_thread
+
+            with pytest.raises(APIError) as exc_info:
+                ensure_thread("EXP-0001", "agent/smoke")
+
+            assert exc_info.value.code == "23505"
+
+    def test_non_conflict_error_propagates_without_reread(self) -> None:
+        """Errors other than 23505 skip the re-read — the error isn't
+        about a race, so re-reading is wasted work and could mask the
+        real failure."""
+        with (
+            patch("sonde.db.reviews.get_thread", side_effect=[None]) as get_mock,
+            patch("sonde.db.reviews.create_thread", side_effect=_api_error("42501")),
+        ):
+            from sonde.db.reviews import ensure_thread
+
+            with pytest.raises(APIError) as exc_info:
+                ensure_thread("EXP-0001", "agent/smoke")
+
+            assert exc_info.value.code == "42501"
+            assert get_mock.call_count == 1, (
+                "get_thread should be called exactly once for a non-23505 "
+                "error; the re-read path is 23505-specific"
+            )
+
+    def test_happy_path_no_create_when_thread_exists(self) -> None:
+        """If the thread already exists, ensure_thread must not attempt
+        a create at all. This pins the ordering get → (maybe create)."""
+        existing = _make_review("REV-0001", "EXP-0001")
+        with (
+            patch("sonde.db.reviews.get_thread", return_value=existing),
+            patch("sonde.db.reviews.create_thread") as create_mock,
+        ):
+            from sonde.db.reviews import ensure_thread
+
+            review, created = ensure_thread("EXP-0001", "agent/smoke")
+
+        assert created is False
+        assert review.id == "REV-0001"
+        assert create_mock.call_count == 0

--- a/cli/tests/test_db_reviews.py
+++ b/cli/tests/test_db_reviews.py
@@ -11,7 +11,7 @@ no-op.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -21,7 +21,7 @@ from sonde.models.review import ExperimentReview
 
 
 def _make_review(review_id: str, experiment_id: str) -> ExperimentReview:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     return ExperimentReview(
         id=review_id,
         experiment_id=experiment_id,

--- a/cli/tests/test_experiment_commands.py
+++ b/cli/tests/test_experiment_commands.py
@@ -76,15 +76,18 @@ def _experiment_model(**overrides: Any) -> Experiment:
 
 class TestLog:
     def test_log_quick(self, runner: CliRunner, patched_db: MagicMock):
-        # Mock the ID generation query
+        # Mocks simulate an empty table so the ID-generation scan returns
+        # no rows, and the insert succeeds. The rewritten assertions
+        # verify the CLI transformed the arguments into the expected
+        # INSERT payload — a pure round-trip through the mock (insert
+        # returns whatever was passed in) would not catch a regression
+        # that silently drops --params or mis-assigns --program.
         patched_db.table("experiments").select("id").order("created_at", desc=True).limit(
             1
         ).execute.return_value = MagicMock(data=[])
 
-        # Mock the insert
-        patched_db.table("experiments").insert.return_value.execute.return_value = MagicMock(
-            data=[_EXPERIMENT_ROW]
-        )
+        insert_mock = patched_db.table("experiments").insert
+        insert_mock.return_value.execute.return_value = MagicMock(data=[_EXPERIMENT_ROW])
 
         result = runner.invoke(
             cli,
@@ -99,7 +102,39 @@ class TestLog:
                 '{"delta": 5.8}',
             ],
         )
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
+
+        # The CLI must have issued exactly one INSERT with the user-provided
+        # program, params, and result. If argument parsing regresses and
+        # drops a field, these assertions fail — the mock would still
+        # happily return the canned row, so the output check below is
+        # not enough on its own.
+        # The CLI writes to multiple tables (experiments, activity_log);
+        # the shared MagicMock records all of them on the same .insert.
+        # Pull out the experiment insert by shape rather than ordering —
+        # stable even if a future change reorders the writes.
+        experiment_inserts = [
+            call.args[0]
+            for call in insert_mock.call_args_list
+            if call.args
+            and isinstance(call.args[0], dict)
+            and "program" in call.args[0]
+            and "parameters" in call.args[0]
+        ]
+        assert len(experiment_inserts) == 1, (
+            f"expected exactly one experiment insert; got {len(experiment_inserts)} "
+            f"(call_args_list={insert_mock.call_args_list!r})"
+        )
+        inserted = experiment_inserts[0]
+        assert inserted["program"] == "weather-intervention"
+        assert inserted["parameters"] == {"ccn": 1200}
+        assert inserted["results"] == {"delta": 5.8}
+        assert inserted["status"] in {"complete", "running"}
+        # Source defaults to a human/* or codex/* label — exact format
+        # may vary but it must be set so the activity log isn't orphaned.
+        assert inserted["source"] and isinstance(inserted["source"], str)
+
+        # Output check: the insert-returned ID round-trips to the user.
         assert "EXP-0001" in result.output
 
     def test_log_requires_program(self, runner: CliRunner, patched_db: MagicMock):

--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -914,4 +914,64 @@ describe("createApp", () => {
     assert.equal(body.error.type, "repo_not_allowed");
     assert.match(body.error.message, /private-org\/private-repo/);
   });
+
+  // Every auth-gated endpoint must reject requests that arrive without a
+  // valid session token. Individual happy-path tests rely on
+  // SONDE_TEST_AUTH_BYPASS_TOKEN; these tests confirm the real auth gate
+  // still fires when the bypass token isn't presented. Prevents a class
+  // of regression where an endpoint silently stops requiring auth.
+  const AUTH_GATED_ENDPOINTS: Array<{
+    name: string;
+    method: "GET" | "POST";
+    path: string;
+    body?: string;
+  }> = [
+    { name: "POST /auth/device/introspect", method: "POST", path: "/auth/device/introspect", body: "{}" },
+    { name: "POST /auth/device/approve", method: "POST", path: "/auth/device/approve", body: "{}" },
+    { name: "GET /admin/runtime", method: "GET", path: "/admin/runtime" },
+    { name: "GET /admin/managed-costs/summary", method: "GET", path: "/admin/managed-costs/summary" },
+    { name: "GET /admin/managed-sessions", method: "GET", path: "/admin/managed-sessions" },
+    { name: "GET /admin/managed-sessions/:id", method: "GET", path: "/admin/managed-sessions/abc-123" },
+    { name: "POST /admin/managed-costs/reconcile", method: "POST", path: "/admin/managed-costs/reconcile", body: "{}" },
+    { name: "POST /chat/session-token", method: "POST", path: "/chat/session-token", body: "{}" },
+    { name: "POST /chat/prewarm", method: "POST", path: "/chat/prewarm", body: "{}" },
+  ];
+
+  for (const endpoint of AUTH_GATED_ENDPOINTS) {
+    it(`rejects ${endpoint.name} without an Authorization header`, async () => {
+      // Intentionally leave the bypass token set so the test mirrors the
+      // real staging/prod config: the auth middleware must refuse
+      // unauthenticated requests even when the bypass token is configured.
+      process.env.ANTHROPIC_API_KEY = "sk-ant-api03-test-key";
+      process.env.VITE_SUPABASE_URL = "https://oxajsxoedrmvrcatqser.supabase.co";
+      const app = createApp();
+
+      const init: RequestInit = { method: endpoint.method };
+      if (endpoint.body !== undefined) {
+        init.headers = { "content-type": "application/json" };
+        init.body = endpoint.body;
+      }
+
+      const response = await app.request(`http://localhost${endpoint.path}`, init);
+      assert.equal(
+        response.status,
+        401,
+        `${endpoint.name} should return 401 without auth, got ${response.status}`,
+      );
+
+      const body = (await response.json()) as {
+        error?: { type: string; message: string };
+      };
+      assert.ok(body.error, `${endpoint.name} 401 response should include an error object`);
+      assert.equal(body.error?.type, "unauthorized");
+    });
+  }
+
+  // Admin-vs-user 403 coverage intentionally deferred: asserting "authed
+  // but not admin → 403" requires mocking verifyToken to return
+  // isAdmin: false, which TypeScript's ES module lock makes awkward
+  // without invasive refactoring. The 401 tests above catch the larger
+  // class of regression (endpoint dropping auth entirely); the
+  // authed-user-not-admin path can be added when we extract the auth
+  // middleware behind a seam that's easier to stub.
 });

--- a/server/src/managed-chat.test.ts
+++ b/server/src/managed-chat.test.ts
@@ -263,8 +263,33 @@ describe("managed chat websocket", () => {
     });
 
     const sessionEvent = messages.find((message) => message.type === "session");
-    assert.ok(sessionEvent);
+    assert.ok(sessionEvent, "websocket must emit a session event");
     assert.equal(sessionEvent.sessionId, sessionId);
+
+    // Contract assertions the frontend depends on. Previously this test
+    // only checked sessionId, so a regression that dropped other fields
+    // (e.g. stopped emitting the session event's model label, broke the
+    // message ordering so session came after done, etc.) would pass
+    // silently.
+    assert.equal(
+      typeof sessionEvent.sessionId,
+      "string",
+      "sessionId must be a string, not wrapped in an object",
+    );
+    const sessionIndex = messages.findIndex((m) => m.type === "session");
+    const doneIndex = messages.findIndex((m) => m.type === "done");
+    assert.ok(doneIndex > sessionIndex, "session event must arrive before done");
+
+    // At least one content-bearing message must reach the client. The
+    // old assertion would pass even if only a session+done pair arrived
+    // with no actual agent output — a silent chat failure.
+    const agentMessages = messages.filter(
+      (m) => m.type === "assistant_message" || m.type === "text_delta",
+    );
+    assert.ok(
+      agentMessages.length > 0,
+      `expected at least one agent content message; got types=${messages.map((m) => m.type).join(",")}`,
+    );
   });
 
   it("auto-allows read-only managed bash actions and continues streaming", async () => {

--- a/server/src/request-guard.test.ts
+++ b/server/src/request-guard.test.ts
@@ -78,4 +78,98 @@ describe("request guards", () => {
       ["INCR", "PEXPIRE", "PTTL"],
     );
   });
+
+  // Retry-sees-fresh-state contract: each call must fetch the current
+  // Redis counter, not a cached value. If the rate limit logic ever
+  // memoized the first INCR's result, a user already over limit would
+  // continue to be allowed. This test would catch that class of bug —
+  // the counter is the "fresh state" that each call must re-read.
+  it("redis rate limiter re-reads the live counter on every call", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://upstash.example.com";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "redis-token";
+
+    // Simulate a monotonic counter: first call sees count=1, second
+    // sees 2, third sees 3 (over limit=2). This proves each decision is
+    // derived from a fresh INCR, not a cached first result.
+    let incrCount = 0;
+    globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as string[][];
+      const command = body[0] ?? [];
+      const name = command[0];
+      if (name === "INCR") {
+        incrCount += 1;
+        return new Response(JSON.stringify([{ result: incrCount }]), { status: 200 });
+      }
+      if (name === "PEXPIRE") {
+        return new Response(JSON.stringify([{ result: 1 }]), { status: 200 });
+      }
+      if (name === "PTTL") {
+        return new Response(JSON.stringify([{ result: 500 }]), { status: 200 });
+      }
+      throw new Error(`Unexpected command: ${command.join(" ")}`);
+    };
+
+    const limit = 2;
+    const first = await checkUserRateLimit("chat", "user-1", limit, 1_000, 1_000);
+    const second = await checkUserRateLimit("chat", "user-1", limit, 1_000, 1_000);
+    const third = await checkUserRateLimit("chat", "user-1", limit, 1_000, 1_000);
+
+    assert.equal(first.allowed, true, "first call (count=1) should be allowed");
+    assert.equal(second.allowed, true, "second call (count=2) should be allowed");
+    assert.equal(
+      third.allowed,
+      false,
+      "third call (count=3) must be blocked — a cached stale count would allow it",
+    );
+    assert.ok(
+      third.retryAfterMs > 0,
+      "over-limit decision must include a positive retryAfterMs from the live PTTL",
+    );
+    assert.equal(incrCount, 3, "each checkUserRateLimit call must issue its own INCR");
+  });
+
+  it("redis concurrent bucket re-reads the live count on each start attempt", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://upstash.example.com";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "redis-token";
+
+    let counter = 0;
+    globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as string[][];
+      const command = body[0] ?? [];
+      const name = command[0];
+      if (name === "INCR") {
+        counter += 1;
+        return new Response(JSON.stringify([{ result: counter }]), { status: 200 });
+      }
+      if (name === "DECR") {
+        counter = Math.max(0, counter - 1);
+        return new Response(JSON.stringify([{ result: counter }]), { status: 200 });
+      }
+      if (name === "PEXPIRE" || name === "DEL") {
+        return new Response(JSON.stringify([{ result: 1 }]), { status: 200 });
+      }
+      throw new Error(`Unexpected command: ${command.join(" ")}`);
+    };
+
+    // Two concurrent starts under max=1: the first wins, the second
+    // must observe the live counter hitting the cap and back off.
+    const release1 = await tryStartUserOperation("chat", "user-1", 1);
+    const blocked = await tryStartUserOperation("chat", "user-1", 1);
+
+    assert.ok(release1, "first operation should start");
+    assert.equal(
+      blocked,
+      null,
+      "second operation must see the live counter (2 > max=1) and be rejected — cached counter would let it through",
+    );
+
+    // After release, a fresh start must see the decremented counter.
+    await release1?.();
+    const release2 = await tryStartUserOperation("chat", "user-1", 1);
+    assert.ok(
+      release2,
+      "after release, the live counter must show room again — cached counter would stay blocked",
+    );
+    await release2?.();
+  });
 });

--- a/server/src/security-config.test.ts
+++ b/server/src/security-config.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import {
   assertSecurityConfig,
   getInternalAdminTokenStatus,
+  hasSharedRateLimitConfig,
+  isSharedRateLimitRequired,
 } from "./security-config.js";
 
 describe("assertSecurityConfig", () => {
@@ -116,5 +118,189 @@ describe("assertSecurityConfig", () => {
     });
     assert.equal(valid.valid, true);
     assert.equal(valid.value, "internal-admin-token");
+  });
+
+  // Fallback-chain branch coverage for security-config env vars.
+  //
+  // Every env-var with a `foo || bar || baz` fallback needs one test per
+  // branch. Previously, tests set only the "first" variable in each chain,
+  // so a regression that dropped a later-branch read (e.g. UPSTASH_*)
+  // would pass silently. Mirrors the coverage pattern established for
+  // `getCommitSha` in runtime-metadata.test.ts.
+
+  describe("GitHub server token fallback chain", () => {
+    // Chain: GITHUB_TOKEN || GH_TOKEN || SONDE_GITHUB_TOKEN
+    // Tested via assertSecurityConfig, which throws when the token is
+    // configured without an allowlist. Each branch should independently
+    // activate the throw.
+    const strictBase = {
+      NODE_ENV: "staging",
+      SONDE_WS_TOKEN_SECRET: "ws",
+      SONDE_RUNTIME_AUDIT_TOKEN: "audit",
+      SUPABASE_SERVICE_ROLE_KEY: "service-role",
+      ANTHROPIC_API_KEY: "sk-ant-valid",
+      SONDE_MANAGED_ENVIRONMENT_ID: "env_staging",
+      SONDE_MANAGED_AGENT_ID: "agent_staging",
+      SONDE_DEVICE_AUTH_ENCRYPTION_KEY:
+        "dev-key-that-is-at-least-32-characters-long-0000",
+      SONDE_ALLOWED_ORIGINS: "https://sonde-staging.vercel.app",
+    } as const;
+
+    it("detects GITHUB_TOKEN and requires allowlist", () => {
+      assert.throws(
+        () => assertSecurityConfig({ ...strictBase, GITHUB_TOKEN: "ghp_example" }),
+        /SONDE_GITHUB_ALLOWED_REPOS must be set/,
+      );
+    });
+
+    it("detects GH_TOKEN and requires allowlist", () => {
+      assert.throws(
+        () => assertSecurityConfig({ ...strictBase, GH_TOKEN: "ghp_example" }),
+        /SONDE_GITHUB_ALLOWED_REPOS must be set/,
+      );
+    });
+
+    it("detects SONDE_GITHUB_TOKEN and requires allowlist", () => {
+      assert.throws(
+        () =>
+          assertSecurityConfig({
+            ...strictBase,
+            SONDE_GITHUB_TOKEN: "ghp_example",
+          }),
+        /SONDE_GITHUB_ALLOWED_REPOS must be set/,
+      );
+    });
+
+    it("does not throw when no GitHub token is set", () => {
+      assert.doesNotThrow(() => assertSecurityConfig(strictBase));
+    });
+  });
+
+  describe("shared Redis rate-limit URL/token fallback chain", () => {
+    // URL chain: SONDE_REDIS_REST_URL || UPSTASH_REDIS_REST_URL
+    // Token chain: SONDE_REDIS_REST_TOKEN || UPSTASH_REDIS_REST_TOKEN
+    // Both must be present for `hasSharedRateLimitConfig` to return true.
+
+    it("detects SONDE_* Redis URL and token pair", () => {
+      assert.equal(
+        hasSharedRateLimitConfig({
+          SONDE_REDIS_REST_URL: "https://redis.example.com",
+          SONDE_REDIS_REST_TOKEN: "redis-token",
+        }),
+        true,
+      );
+    });
+
+    it("detects UPSTASH_* Redis URL and token pair", () => {
+      assert.equal(
+        hasSharedRateLimitConfig({
+          UPSTASH_REDIS_REST_URL: "https://redis.example.com",
+          UPSTASH_REDIS_REST_TOKEN: "redis-token",
+        }),
+        true,
+      );
+    });
+
+    it("accepts mixed SONDE_URL + UPSTASH_TOKEN pairing", () => {
+      // The chain is independent per-variable, so either namespace works
+      // for URL and token. This pins that independence.
+      assert.equal(
+        hasSharedRateLimitConfig({
+          SONDE_REDIS_REST_URL: "https://redis.example.com",
+          UPSTASH_REDIS_REST_TOKEN: "redis-token",
+        }),
+        true,
+      );
+    });
+
+    it("returns false when only URL is set (token missing)", () => {
+      assert.equal(
+        hasSharedRateLimitConfig({
+          SONDE_REDIS_REST_URL: "https://redis.example.com",
+        }),
+        false,
+      );
+    });
+
+    it("returns false when only token is set (URL missing)", () => {
+      assert.equal(
+        hasSharedRateLimitConfig({
+          SONDE_REDIS_REST_TOKEN: "redis-token",
+        }),
+        false,
+      );
+    });
+
+    it("returns false when neither is set", () => {
+      assert.equal(hasSharedRateLimitConfig({}), false);
+    });
+
+    it("treats whitespace-only values as unset", () => {
+      assert.equal(
+        hasSharedRateLimitConfig({
+          SONDE_REDIS_REST_URL: "   ",
+          SONDE_REDIS_REST_TOKEN: "redis-token",
+        }),
+        false,
+      );
+    });
+  });
+
+  describe("shared rate-limit requirement flag fallback chain", () => {
+    // Chain: SONDE_REQUIRE_SHARED_RATE_LIMIT || SONDE_REQUIRE_SHARED_REDIS
+
+    it("recognizes SONDE_REQUIRE_SHARED_RATE_LIMIT=true", () => {
+      assert.equal(
+        isSharedRateLimitRequired({
+          SONDE_REQUIRE_SHARED_RATE_LIMIT: "true",
+        }),
+        true,
+      );
+    });
+
+    it("recognizes SONDE_REQUIRE_SHARED_RATE_LIMIT=1", () => {
+      assert.equal(
+        isSharedRateLimitRequired({
+          SONDE_REQUIRE_SHARED_RATE_LIMIT: "1",
+        }),
+        true,
+      );
+    });
+
+    it("recognizes the legacy SONDE_REQUIRE_SHARED_REDIS alias", () => {
+      assert.equal(
+        isSharedRateLimitRequired({
+          SONDE_REQUIRE_SHARED_REDIS: "true",
+        }),
+        true,
+      );
+    });
+
+    it("prefers the primary variable over the legacy alias", () => {
+      // If the primary is set to a non-truthy value and the alias is
+      // truthy, the primary wins (no fallthrough). Primary is empty →
+      // alias is checked → returns true.
+      assert.equal(
+        isSharedRateLimitRequired({
+          SONDE_REQUIRE_SHARED_RATE_LIMIT: "",
+          SONDE_REQUIRE_SHARED_REDIS: "true",
+        }),
+        true,
+      );
+    });
+
+    it("returns false when neither is set", () => {
+      assert.equal(isSharedRateLimitRequired({}), false);
+    });
+
+    it("returns false for any non-truthy value", () => {
+      for (const value of ["false", "0", "no", "off", "yes", ""]) {
+        assert.equal(
+          isSharedRateLimitRequired({ SONDE_REQUIRE_SHARED_RATE_LIMIT: value }),
+          value === "1" || value === "true",
+          `expected value="${value}" to map to ${value === "1" || value === "true"}`,
+        );
+      }
+    });
   });
 });

--- a/ui/e2e/ci-smoke.spec.ts
+++ b/ui/e2e/ci-smoke.spec.ts
@@ -82,6 +82,26 @@ test.describe("CI smoke", () => {
     await expect(page.getByRole("button", { name: "Continue with Google" })).toBeVisible();
   });
 
+  test("unauthenticated admin deep-link redirects to login", async ({ page }) => {
+    // Specifically pin the admin guard: a direct deep-link to an
+    // admin-only route must bounce to login when no session cookie or
+    // localStorage token is present. Regression protection for the
+    // class of bug where an _authenticated route accidentally drops
+    // its guard.
+    await page.goto("/admin");
+    await page.waitForURL(/\/login/, { timeout: 10_000 });
+    await expect(page.getByRole("button", { name: "Continue with Google" })).toBeVisible();
+  });
+
+  test("unauthenticated experiments deep-link redirects to login", async ({ page }) => {
+    // Deep-linking to a protected user route with empty localStorage
+    // must redirect to login. Pairs with the admin test above: catches
+    // an auth-guard removal on the user (non-admin) side.
+    await page.goto("/experiments");
+    await page.waitForURL(/\/login/, { timeout: 10_000 });
+    await expect(page.getByRole("button", { name: "Continue with Google" })).toBeVisible();
+  });
+
   test("agent health is reachable through the UI proxy", async ({ request, baseURL }) => {
     const response = await request.get(new URL("/agent/health", baseURL).toString());
     expect(response.ok()).toBeTruthy();

--- a/ui/src/components/chat/chat-input.tsx
+++ b/ui/src/components/chat/chat-input.tsx
@@ -11,7 +11,12 @@ import {
   Boxes,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { dedupeMentions, mentionTokenExists } from "@/lib/chat-mentions";
+import {
+  dedupeMentions,
+  escapeRegExp,
+  mentionTokenExists,
+  sameMention,
+} from "@/lib/chat-mentions";
 import { useChatMentions } from "@/hooks/use-chat-mentions";
 import { ChatMentionPopover } from "./chat-mention-popover";
 import type { ConnectionStatus, MentionRef, PageContext } from "@/types/chat";

--- a/ui/src/components/chat/chat-input.tsx
+++ b/ui/src/components/chat/chat-input.tsx
@@ -11,6 +11,7 @@ import {
   Boxes,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { dedupeMentions, mentionTokenExists } from "@/lib/chat-mentions";
 import { useChatMentions } from "@/hooks/use-chat-mentions";
 import { ChatMentionPopover } from "./chat-mention-popover";
 import type { ConnectionStatus, MentionRef, PageContext } from "@/types/chat";
@@ -32,23 +33,8 @@ function isFileDragEvent(e: React.DragEvent): boolean {
   return e.dataTransfer.types.includes("Files");
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function mentionTokenExists(text: string, id: string): boolean {
-  return new RegExp(`(^|\\s)@${escapeRegExp(id)}(?=\\s|$)`).test(text);
-}
-
-function sameMention(a: MentionRef, b: MentionRef): boolean {
-  return a.id === b.id && a.type === b.type && a.program === b.program;
-}
-
-function dedupeMentions(items: MentionRef[]): MentionRef[] {
-  return items.filter(
-    (item, index, arr) => arr.findIndex((other) => sameMention(other, item)) === index
-  );
-}
+// dedupeMentions, mentionTokenExists, sameMention, and escapeRegExp
+// live in @/lib/chat-mentions (extracted for direct unit testing).
 
 function mentionTypeLabel(type: MentionTargetType): string {
   switch (type) {

--- a/ui/src/lib/auth-redirect.test.ts
+++ b/ui/src/lib/auth-redirect.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the open-redirect defense in auth-redirect.ts.
+ *
+ * `safeAuthRedirect` is the gate between user-controllable input (?redirect=…
+ * in the URL) and the post-login `navigate()` call. A regression here could
+ * let an attacker craft a login link that redirects victims to an attacker-
+ * controlled origin — a class of phishing vulnerability. These tests pin
+ * the invariant that only same-origin paths survive.
+ */
+
+import { describe, expect, it } from "vitest";
+import { currentAuthReturnPath, safeAuthRedirect } from "./auth-redirect";
+
+describe("safeAuthRedirect", () => {
+  describe("accepts legitimate same-origin paths", () => {
+    it("returns a simple path unchanged", () => {
+      expect(safeAuthRedirect("/experiments")).toBe("/experiments");
+    });
+
+    it("preserves nested paths", () => {
+      expect(safeAuthRedirect("/experiments/EXP-0001")).toBe(
+        "/experiments/EXP-0001",
+      );
+    });
+
+    it("preserves query strings", () => {
+      expect(safeAuthRedirect("/experiments?program=shared")).toBe(
+        "/experiments?program=shared",
+      );
+    });
+
+    it("preserves hash fragments", () => {
+      expect(safeAuthRedirect("/dashboard#findings")).toBe(
+        "/dashboard#findings",
+      );
+    });
+
+    it("trims surrounding whitespace", () => {
+      expect(safeAuthRedirect("  /admin  ")).toBe("/admin");
+    });
+  });
+
+  describe("rejects open-redirect attack shapes", () => {
+    // Each of these is a classic open-redirect payload. If any of them
+    // survives `safeAuthRedirect`, a login page containing `?redirect=`
+    // could be weaponized for phishing.
+
+    it("rejects protocol-relative URLs (//evil.com)", () => {
+      expect(safeAuthRedirect("//evil.com")).toBe("/");
+    });
+
+    it("rejects protocol-relative URLs with paths (//evil.com/x)", () => {
+      expect(safeAuthRedirect("//evil.com/victim")).toBe("/");
+    });
+
+    it("rejects absolute URLs (http://)", () => {
+      expect(safeAuthRedirect("http://evil.com")).toBe("/");
+    });
+
+    it("rejects absolute URLs (https://)", () => {
+      expect(safeAuthRedirect("https://evil.com/login")).toBe("/");
+    });
+
+    it("rejects javascript: URIs", () => {
+      expect(safeAuthRedirect("javascript:alert(1)")).toBe("/");
+    });
+
+    it("rejects data: URIs", () => {
+      expect(safeAuthRedirect("data:text/html,<script>alert(1)</script>")).toBe(
+        "/",
+      );
+    });
+
+    it("rejects paths that look relative but don't start with /", () => {
+      expect(safeAuthRedirect("experiments")).toBe("/");
+    });
+
+    it("rejects backslash-prefix (common Windows-path obfuscation)", () => {
+      expect(safeAuthRedirect("\\evil.com")).toBe("/");
+    });
+  });
+
+  describe("handles nullish or non-string inputs", () => {
+    it("returns / for undefined", () => {
+      expect(safeAuthRedirect(undefined)).toBe("/");
+    });
+
+    it("returns / for empty string", () => {
+      expect(safeAuthRedirect("")).toBe("/");
+    });
+
+    it("returns / for whitespace-only string", () => {
+      // Post-trim this becomes empty, which does not start with '/'.
+      expect(safeAuthRedirect("   ")).toBe("/");
+    });
+  });
+});
+
+describe("currentAuthReturnPath", () => {
+  it("combines pathname and search from a location-like", () => {
+    expect(
+      currentAuthReturnPath({ pathname: "/experiments", search: "?program=x" }),
+    ).toBe("/experiments?program=x");
+  });
+
+  it("returns / when pathname is empty", () => {
+    // pathname "" → "" + search → stripped to "/"
+    expect(currentAuthReturnPath({ pathname: "", search: "" })).toBe("/");
+  });
+
+  it("returns / when locationLike is null", () => {
+    expect(currentAuthReturnPath(null)).toBe("/");
+  });
+
+  it("returns / when locationLike is undefined", () => {
+    expect(currentAuthReturnPath(undefined)).toBe("/");
+  });
+
+  it("sanitizes a protocol-relative pathname through safeAuthRedirect", () => {
+    // Defense in depth: even if something weird ends up in window.location
+    // (unlikely but possible via pushState gymnastics), the redirect value
+    // we produce is safe.
+    expect(
+      currentAuthReturnPath({ pathname: "//evil.com", search: "" }),
+    ).toBe("/");
+  });
+});

--- a/ui/src/lib/chat-mentions.test.ts
+++ b/ui/src/lib/chat-mentions.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for chat-mentions helpers.
+ *
+ * These are small-but-load-bearing pure functions — a bug in any of them
+ * corrupts the outgoing chat message:
+ *   - missing regex escape → ReDoS or false positives on crafted IDs
+ *   - broken dedupe → the same mention submitted twice
+ *   - sameMention treating cross-program refs as identical → wrong program scope
+ */
+
+import { describe, expect, it } from "vitest";
+import type { MentionRef } from "@/types/chat";
+import {
+  dedupeMentions,
+  escapeRegExp,
+  mentionTokenExists,
+  sameMention,
+} from "./chat-mentions";
+
+function makeMention(overrides: Partial<MentionRef> = {}): MentionRef {
+  return {
+    id: "EXP-0001",
+    type: "experiment",
+    program: "weather-intervention",
+    label: "Experiment 0001",
+    ...overrides,
+  } as MentionRef;
+}
+
+describe("escapeRegExp", () => {
+  it("escapes all regex metacharacters from the set", () => {
+    // This set matches the implementation's character class.
+    expect(escapeRegExp(".*+?^${}()|[]\\"))
+      .toBe("\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\");
+  });
+
+  it("leaves non-metacharacters untouched", () => {
+    expect(escapeRegExp("EXP-0001")).toBe("EXP-0001");
+    expect(escapeRegExp("weather_intervention")).toBe("weather_intervention");
+  });
+
+  it("produces a string safe for RegExp consumption (round-trip)", () => {
+    const weird = "hello (world) [test]";
+    const pattern = new RegExp(`^${escapeRegExp(weird)}$`);
+    expect(pattern.test(weird)).toBe(true);
+    expect(pattern.test("hello world test")).toBe(false);
+  });
+
+  it("handles empty string", () => {
+    expect(escapeRegExp("")).toBe("");
+  });
+});
+
+describe("mentionTokenExists", () => {
+  it("matches a mention at the start of text", () => {
+    expect(mentionTokenExists("@EXP-0001 hello", "EXP-0001")).toBe(true);
+  });
+
+  it("matches a mention in the middle of text", () => {
+    expect(mentionTokenExists("hello @EXP-0001 world", "EXP-0001")).toBe(true);
+  });
+
+  it("matches a mention at the end of text", () => {
+    expect(mentionTokenExists("hello @EXP-0001", "EXP-0001")).toBe(true);
+  });
+
+  it("does not match when the id is a prefix of another mention", () => {
+    // @EXP-0001 should not match when only @EXP-00010 is present.
+    expect(mentionTokenExists("hello @EXP-00010 world", "EXP-0001")).toBe(false);
+  });
+
+  it("does not match a mid-word occurrence (must be @-prefixed)", () => {
+    expect(mentionTokenExists("xy@EXP-0001 world", "EXP-0001")).toBe(false);
+  });
+
+  it("does not match when the token does not start with @", () => {
+    expect(mentionTokenExists("EXP-0001", "EXP-0001")).toBe(false);
+  });
+
+  it("handles ids with regex metacharacters safely", () => {
+    // A naive implementation would let '.' wildcard-match anything.
+    expect(mentionTokenExists("@EXP.0001", "EXP.0001")).toBe(true);
+    expect(mentionTokenExists("@EXPX0001", "EXP.0001")).toBe(false);
+  });
+
+  it("returns false for empty id", () => {
+    // Empty id would build a degenerate regex; the function doesn't
+    // special-case this, but the result should still be false rather
+    // than an accidental match. Test pins that.
+    expect(mentionTokenExists("hello world", "")).toBe(false);
+  });
+});
+
+describe("sameMention", () => {
+  it("returns true for identical id, type, and program", () => {
+    expect(
+      sameMention(
+        makeMention({ id: "EXP-0001", type: "experiment", program: "p" }),
+        makeMention({ id: "EXP-0001", type: "experiment", program: "p" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when id differs", () => {
+    expect(
+      sameMention(
+        makeMention({ id: "EXP-0001" }),
+        makeMention({ id: "EXP-0002" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when type differs (same id across different record types)", () => {
+    // A finding FIND-0001 and a question Q-0001 with the same numeric
+    // suffix would collide if we only compared ids.
+    expect(
+      sameMention(
+        makeMention({ id: "0001", type: "experiment" }),
+        makeMention({ id: "0001", type: "finding" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when program differs", () => {
+    // Cross-program refs with the same id/type aren't the same record.
+    expect(
+      sameMention(
+        makeMention({ program: "weather-intervention" }),
+        makeMention({ program: "energy-trading" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores non-identity fields like label", () => {
+    // Label is display-only and may differ between invocations.
+    expect(
+      sameMention(
+        makeMention({ label: "Alpha" }),
+        makeMention({ label: "Beta" }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("dedupeMentions", () => {
+  it("returns an empty array for empty input", () => {
+    expect(dedupeMentions([])).toEqual([]);
+  });
+
+  it("returns the input unchanged when there are no duplicates", () => {
+    const input = [
+      makeMention({ id: "EXP-0001" }),
+      makeMention({ id: "EXP-0002" }),
+    ];
+    expect(dedupeMentions(input)).toEqual(input);
+  });
+
+  it("removes exact duplicates", () => {
+    const a = makeMention({ id: "EXP-0001" });
+    const result = dedupeMentions([a, a]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("EXP-0001");
+  });
+
+  it("preserves first-seen order when dropping dupes", () => {
+    const first = makeMention({ id: "EXP-0001", label: "first" });
+    const dup = makeMention({ id: "EXP-0001", label: "dup" });
+    const different = makeMention({ id: "EXP-0002", label: "different" });
+    const result = dedupeMentions([first, different, dup]);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.label).toBe("first");
+    expect(result[1]?.label).toBe("different");
+  });
+
+  it("treats cross-program same-id mentions as distinct", () => {
+    // Pins the sameMention contract through dedupe — a regression that
+    // dropped program from the identity check would collapse these.
+    const a = makeMention({ id: "EXP-0001", program: "weather-intervention" });
+    const b = makeMention({ id: "EXP-0001", program: "energy-trading" });
+    expect(dedupeMentions([a, b])).toHaveLength(2);
+  });
+
+  it("treats cross-type same-id mentions as distinct", () => {
+    const a = makeMention({ id: "0001", type: "experiment" });
+    const b = makeMention({ id: "0001", type: "finding" });
+    expect(dedupeMentions([a, b])).toHaveLength(2);
+  });
+});

--- a/ui/src/lib/chat-mentions.ts
+++ b/ui/src/lib/chat-mentions.ts
@@ -1,0 +1,33 @@
+/**
+ * Chat mention parsing helpers.
+ *
+ * Extracted from `components/chat/chat-input.tsx` so they're directly
+ * unit-testable. These functions handle user input that gets fed into
+ * a regex — a bug here (e.g. `escapeRegExp` missing a metacharacter)
+ * could cause ReDoS or let a crafted mention token bypass deduplication
+ * and appear twice in the submitted message.
+ */
+
+import type { MentionRef } from "@/types/chat";
+
+/** Escape regex metacharacters so `value` can be used as a literal in RegExp. */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** True if `text` already contains `@id` as a whole-token mention. */
+export function mentionTokenExists(text: string, id: string): boolean {
+  return new RegExp(`(^|\\s)@${escapeRegExp(id)}(?=\\s|$)`).test(text);
+}
+
+/** Two MentionRefs refer to the same record across id, type, and program. */
+export function sameMention(a: MentionRef, b: MentionRef): boolean {
+  return a.id === b.id && a.type === b.type && a.program === b.program;
+}
+
+/** Remove duplicates by (id, type, program), preserving first-seen order. */
+export function dedupeMentions(items: MentionRef[]): MentionRef[] {
+  return items.filter(
+    (item, index, arr) => arr.findIndex((other) => sameMention(other, item)) === index,
+  );
+}

--- a/ui/src/lib/finding-confidence.test.ts
+++ b/ui/src/lib/finding-confidence.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for finding-confidence.ts.
+ *
+ * The confidence filter drives URL query-string persistence for the brief
+ * and findings pages. A break in parse/serialize corrupts shareable URLs
+ * or silently drops the user's filter on navigation.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  FINDING_CONFIDENCE_LEVELS,
+  findingConfidenceLabel,
+  isFindingConfidence,
+  parseFindingConfidenceFilter,
+  serializeFindingConfidenceFilter,
+} from "./finding-confidence";
+
+describe("isFindingConfidence", () => {
+  it("accepts all five valid levels", () => {
+    for (const level of FINDING_CONFIDENCE_LEVELS) {
+      expect(isFindingConfidence(level)).toBe(true);
+    }
+  });
+
+  it("rejects near-miss strings (case-sensitive)", () => {
+    expect(isFindingConfidence("High")).toBe(false);
+    expect(isFindingConfidence("VERY_HIGH")).toBe(false);
+    expect(isFindingConfidence("very high")).toBe(false);
+    expect(isFindingConfidence("")).toBe(false);
+  });
+
+  it("rejects adjacent levels that are not in the set", () => {
+    expect(isFindingConfidence("critical")).toBe(false);
+    expect(isFindingConfidence("unknown")).toBe(false);
+  });
+});
+
+describe("findingConfidenceLabel", () => {
+  it("returns human-readable labels with a space for multi-word levels", () => {
+    expect(findingConfidenceLabel("very_low")).toBe("very low");
+    expect(findingConfidenceLabel("very_high")).toBe("very high");
+  });
+
+  it("returns the level name for single-word levels", () => {
+    expect(findingConfidenceLabel("low")).toBe("low");
+    expect(findingConfidenceLabel("medium")).toBe("medium");
+    expect(findingConfidenceLabel("high")).toBe("high");
+  });
+});
+
+describe("parseFindingConfidenceFilter", () => {
+  it("parses canonical order regardless of input order", () => {
+    expect(parseFindingConfidenceFilter("high,very_low")).toEqual([
+      "very_low",
+      "high",
+    ]);
+  });
+
+  it("trims whitespace around each value", () => {
+    expect(parseFindingConfidenceFilter(" high , medium ")).toEqual([
+      "medium",
+      "high",
+    ]);
+  });
+
+  it("deduplicates repeated values", () => {
+    expect(parseFindingConfidenceFilter("high,high,very_high")).toEqual([
+      "high",
+      "very_high",
+    ]);
+  });
+
+  it("drops unknown levels silently", () => {
+    expect(parseFindingConfidenceFilter("high,critical,low")).toEqual([
+      "low",
+      "high",
+    ]);
+  });
+
+  it("returns empty for undefined", () => {
+    expect(parseFindingConfidenceFilter(undefined)).toEqual([]);
+  });
+
+  it("returns empty for empty string", () => {
+    expect(parseFindingConfidenceFilter("")).toEqual([]);
+  });
+});
+
+describe("serializeFindingConfidenceFilter", () => {
+  it("emits canonical order", () => {
+    expect(serializeFindingConfidenceFilter(["high", "very_low"])).toBe(
+      "very_low,high",
+    );
+  });
+
+  it("round-trips through parse", () => {
+    const serialized = serializeFindingConfidenceFilter(["very_high", "low"]);
+    expect(parseFindingConfidenceFilter(serialized)).toEqual(["low", "very_high"]);
+  });
+
+  it("returns undefined for empty input", () => {
+    expect(serializeFindingConfidenceFilter([])).toBeUndefined();
+  });
+
+  it("drops invalid values silently (robust against upstream drift)", () => {
+    expect(
+      serializeFindingConfidenceFilter([
+        "high",
+        "stellar" as never,
+        "low",
+      ]),
+    ).toBe("low,high");
+  });
+});

--- a/ui/src/lib/finding-importance.test.ts
+++ b/ui/src/lib/finding-importance.test.ts
@@ -171,17 +171,22 @@ describe("sortFindingsByImportanceAndRecency", () => {
   });
 
   it("falls back to created_at when valid_from is null", () => {
+    // The UI `Finding` type declares `valid_from: string` but the sort
+    // code has a defensive `?? right.created_at` fallback — so in
+    // practice the DB can return null. Force null past the type check
+    // to exercise the runtime fallback path.
+    const nullish = null as unknown as string;
     const findings = [
       makeFinding({
         id: "F-older",
         importance: "high",
-        valid_from: null,
+        valid_from: nullish,
         created_at: "2026-04-01T00:00:00Z",
       }),
       makeFinding({
         id: "F-newer",
         importance: "high",
-        valid_from: null,
+        valid_from: nullish,
         created_at: "2026-04-15T00:00:00Z",
       }),
     ];

--- a/ui/src/lib/finding-importance.test.ts
+++ b/ui/src/lib/finding-importance.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for finding-importance.ts.
+ *
+ * `sortFindingsByImportanceAndRecency` drives the default order shown in
+ * brief / dashboard / admin. A regression that silently reorders by the
+ * wrong key (or breaks date parsing) would mean low-importance or stale
+ * findings appear first — users make worse decisions without noticing.
+ * The filter parse/serialize functions back query-string round-trips;
+ * a break there corrupts shareable URLs.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Finding } from "@/types/sonde";
+import {
+  compareFindingImportance,
+  FINDING_IMPORTANCE_LEVELS,
+  findingImportanceLabel,
+  findingImportanceRank,
+  isFindingImportance,
+  parseFindingImportanceFilter,
+  serializeFindingImportanceFilter,
+  sortFindingsByImportanceAndRecency,
+} from "./finding-importance";
+
+function makeFinding(overrides: Partial<Finding>): Finding {
+  return {
+    id: "FIND-0001",
+    program: "weather-intervention",
+    topic: "test",
+    finding: "test",
+    confidence: "medium",
+    importance: "medium",
+    evidence: [],
+    source: "human/test",
+    supersedes: null,
+    superseded_by: null,
+    valid_from: "2026-04-10T00:00:00Z",
+    valid_until: null,
+    created_at: "2026-04-10T00:00:00Z",
+    updated_at: "2026-04-10T00:00:00Z",
+    ...overrides,
+  } as Finding;
+}
+
+describe("isFindingImportance", () => {
+  it("accepts the three valid levels", () => {
+    for (const level of FINDING_IMPORTANCE_LEVELS) {
+      expect(isFindingImportance(level)).toBe(true);
+    }
+  });
+
+  it("rejects arbitrary strings", () => {
+    expect(isFindingImportance("critical")).toBe(false);
+    expect(isFindingImportance("")).toBe(false);
+    expect(isFindingImportance("HIGH")).toBe(false);
+  });
+});
+
+describe("findingImportanceRank", () => {
+  it("ranks high < medium < low (lower = higher priority)", () => {
+    expect(findingImportanceRank("high")).toBeLessThan(
+      findingImportanceRank("medium"),
+    );
+    expect(findingImportanceRank("medium")).toBeLessThan(
+      findingImportanceRank("low"),
+    );
+  });
+});
+
+describe("compareFindingImportance", () => {
+  it("high < medium < low in sort order", () => {
+    const order = ["low", "high", "medium"] as const;
+    const sorted = [...order].sort(compareFindingImportance);
+    expect(sorted).toEqual(["high", "medium", "low"]);
+  });
+
+  it("returns 0 for equal importance", () => {
+    expect(compareFindingImportance("medium", "medium")).toBe(0);
+  });
+});
+
+describe("findingImportanceLabel", () => {
+  it("returns a label for each level", () => {
+    expect(findingImportanceLabel("low")).toBe("low");
+    expect(findingImportanceLabel("medium")).toBe("medium");
+    expect(findingImportanceLabel("high")).toBe("high");
+  });
+});
+
+describe("parseFindingImportanceFilter", () => {
+  it("parses a comma-separated value into levels in canonical order", () => {
+    expect(parseFindingImportanceFilter("high,low")).toEqual(["low", "high"]);
+  });
+
+  it("trims whitespace around each value", () => {
+    expect(parseFindingImportanceFilter(" high , medium ")).toEqual([
+      "medium",
+      "high",
+    ]);
+  });
+
+  it("deduplicates repeated values", () => {
+    expect(parseFindingImportanceFilter("high,high,medium")).toEqual([
+      "medium",
+      "high",
+    ]);
+  });
+
+  it("drops unknown levels silently (query-string round-trip safety)", () => {
+    expect(parseFindingImportanceFilter("high,bogus,low")).toEqual([
+      "low",
+      "high",
+    ]);
+  });
+
+  it("returns an empty list for undefined input", () => {
+    expect(parseFindingImportanceFilter(undefined)).toEqual([]);
+  });
+
+  it("returns an empty list for empty string", () => {
+    expect(parseFindingImportanceFilter("")).toEqual([]);
+  });
+});
+
+describe("serializeFindingImportanceFilter", () => {
+  it("emits levels in canonical order, not input order", () => {
+    expect(serializeFindingImportanceFilter(["high", "low"])).toBe("low,high");
+  });
+
+  it("round-trips through parse", () => {
+    const input = ["high", "medium"] as const;
+    const serialized = serializeFindingImportanceFilter(input);
+    expect(parseFindingImportanceFilter(serialized)).toEqual(["medium", "high"]);
+  });
+
+  it("deduplicates on serialization", () => {
+    expect(serializeFindingImportanceFilter(["high", "high"])).toBe("high");
+  });
+
+  it("returns undefined for empty input (omits the query key)", () => {
+    expect(serializeFindingImportanceFilter([])).toBeUndefined();
+  });
+});
+
+describe("sortFindingsByImportanceAndRecency", () => {
+  it("sorts by importance first, high to low", () => {
+    const findings = [
+      makeFinding({ id: "F-low", importance: "low" }),
+      makeFinding({ id: "F-high", importance: "high" }),
+      makeFinding({ id: "F-medium", importance: "medium" }),
+    ];
+    const sorted = sortFindingsByImportanceAndRecency(findings);
+    expect(sorted.map((f) => f.id)).toEqual(["F-high", "F-medium", "F-low"]);
+  });
+
+  it("breaks ties by recency (valid_from descending)", () => {
+    const findings = [
+      makeFinding({
+        id: "F-older",
+        importance: "high",
+        valid_from: "2026-04-01T00:00:00Z",
+      }),
+      makeFinding({
+        id: "F-newer",
+        importance: "high",
+        valid_from: "2026-04-15T00:00:00Z",
+      }),
+    ];
+    const sorted = sortFindingsByImportanceAndRecency(findings);
+    expect(sorted.map((f) => f.id)).toEqual(["F-newer", "F-older"]);
+  });
+
+  it("falls back to created_at when valid_from is null", () => {
+    const findings = [
+      makeFinding({
+        id: "F-older",
+        importance: "high",
+        valid_from: null,
+        created_at: "2026-04-01T00:00:00Z",
+      }),
+      makeFinding({
+        id: "F-newer",
+        importance: "high",
+        valid_from: null,
+        created_at: "2026-04-15T00:00:00Z",
+      }),
+    ];
+    const sorted = sortFindingsByImportanceAndRecency(findings);
+    expect(sorted.map((f) => f.id)).toEqual(["F-newer", "F-older"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const findings = [
+      makeFinding({ id: "F-1", importance: "low" }),
+      makeFinding({ id: "F-2", importance: "high" }),
+    ];
+    const originalOrder = findings.map((f) => f.id);
+    sortFindingsByImportanceAndRecency(findings);
+    expect(findings.map((f) => f.id)).toEqual(originalOrder);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(sortFindingsByImportanceAndRecency([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Context

Two recent production scares exposed a rigor problem in the test suite:

1. **Sequential-ID bug** (PR #168) — `next_sequential_id` silently broke at >1000 rows. The existing test used 1 row and passed.
2. **Versioning /health regression** — tests didn't cover env-var fallback paths, so a /health rewrite shipped without catching that staging/production would lose commit-SHA visibility until a linter reverted it.

Both bugs share a signature: tests exercised the happy path with hard-coded data that matched the assertion, so they passed even when the code under test was fundamentally wrong for real production scenarios.

This PR is an **audit-driven hardening pass** across CLI, server, and UI — the same anti-patterns recurred in all three. Six focused commits, one per theme. Most work rewrites or extends existing tests; three new test files cover critical-path logic that had zero tests.

## Commits (read top-down)

### 1. `test(fixtures): patch sonde.db.client dynamically across all modules`

The `patched_db` fixture in `cli/tests/conftest.py` maintained a hardcoded list of 18 modules to patch `get_client` on. A grep found 26 modules that import `get_client` — **8 were silently missing**, meaning tests touching them risked hitting real Supabase:

- `sonde.db.projects`, `sonde.db.project_takeaways`, `sonde.db.direction_takeaways`
- `sonde.db.program_takeaways`, `sonde.db.question_links`, `sonde.db.auth_events`
- `sonde.commands.artifact_update`, `sonde.commands.search_all`

Replaced the manual list with a `sys.modules` scan + `contextlib.ExitStack`. Any `sonde.*` module that imports `get_client` is automatically patched. Added `test_conftest_fixture.py` to pin the invariant — if anyone reverts to a hardcoded list and drops a module, tests fail loudly.

### 2. `test(rigor): add auth-required negative-path coverage`

Every test exercising an auth-gated surface did so via a test-only bypass. If an endpoint silently stopped requiring auth, nothing caught it.

- **server**: 9 new 401 assertions — one per previously-untested auth-gated endpoint (`/auth/device/introspect`, `/auth/device/approve`, 5 `/admin/*` routes, `/chat/session-token`, `/chat/prewarm`). Table-driven.
- **UI**: 2 new Playwright specs covering `/admin` and `/experiments` deep-link redirects to `/login` with empty localStorage.
- **CLI**: pinned the `_NO_AUTH` allowlist (exact set: login, logout, whoami, setup, doctor, skills) + 6 negative-path tests (list, show, push, pull, recent, brief).

### 3. `test(rigor): prove retries see fresh state`

The sequential-ID bug's signature (retries looping on stale data) applied to two other retry sites that had only basic "retry happened" tests:

- `cli/src/sonde/db/reviews.py` `ensure_thread` race handler: 4 new tests in `test_db_reviews.py` that force the second `get_thread()` to return a **different** row than the first — catches the "stale re-read" regression.
- `server/src/request-guard.ts` Redis rate limiter: 2 new tests with a monotonic `INCR` mock (1 → 2 → 3) asserting the third call is blocked. A cached stale counter would let it through.

### 4. `test(rigor): cover security-config env-var fallback branches`

Three fallback chains in `server/src/security-config.ts` previously had at most one branch each tested. The /health regression was this exact pattern. Added per-branch coverage for:

- `GITHUB_TOKEN || GH_TOKEN || SONDE_GITHUB_TOKEN`
- `SONDE_REDIS_REST_{URL,TOKEN} || UPSTASH_REDIS_REST_{URL,TOKEN}` (incl. mixed-namespace pairing)
- `SONDE_REQUIRE_SHARED_RATE_LIMIT || SONDE_REQUIRE_SHARED_REDIS` (incl. legacy-alias fallthrough and non-truthy values)

### 5. `test(rigor): strengthen mock-surgery tests with behavior assertions`

Tests where the mock returned the exact value the assertion checked, making the test a mock round-trip:

- **`test_log_quick`**: now verifies the INSERT payload content (program, parameters, results), not just that "EXP-0001" appears in output. Pulls the experiment insert from `call_args_list` by shape so it's stable even if the CLI reorders writes.
- **`managed-chat` session event**: added contract assertions — message ordering (session before done), presence of agent-content messages, sessionId type. Previously only checked presence + equality.
- **`TestFindings`**: full Pydantic-model assertions + `test_list_findings_rejects_invalid_confidence` (validation must fail loudly on invalid Literal) + empty-result test.

Inspected and left alone: `managed-costs summary` (actually sums buckets, not a round-trip) and `session-auth.test.ts` (already pairs data assertions with behavior assertions like `toHaveBeenCalledOnce`).

### 6. `test(rigor): cover critical-path UI logic that had zero tests`

Four load-bearing UI surfaces had no tests at all:

- **`auth-redirect.ts`** (security-critical open-redirect defense): 21 tests covering all classic attack payloads (`//evil.com`, `http://`, `javascript:`, `data:`, `\\evil.com`) plus same-origin happy paths.
- **`finding-importance.ts`** (drives admin/brief/dashboard sort): 21 tests covering sort order, tiebreak by recency, `created_at` fallback when `valid_from` is null, input non-mutation, filter parse/serialize round-trips.
- **`finding-confidence.ts`** (filter query-string persistence): 15 tests covering the 5-level scale with round-trip safety.
- **`chat-mentions.ts`** (new — extracted from `chat-input.tsx`): 23 tests covering regex-metachar escaping (ReDoS defense), word-boundary matching (`@EXP-0001` vs `@EXP-00010`), cross-program/cross-type mention distinctness, dedup-preserving-order.

## Test count delta

| Package | Before | After | Added |
| --- | ---:| ---:| ---:|
| CLI | ~608 | 625 | +17 |
| Server | ~38 | ~58 | +20 |
| UI | 105 | 185 | +80 |

## What this is NOT

- Not a suite-wide rewrite. Targeted the systemic patterns; the rest of the suite is fine.
- Not adding new tests for their own sake. Three new test files cover critical-path code that had zero tests; everything else rewrites or extends existing tests.
- Not touching production code except one small extract (4 pure helper functions moved from `chat-input.tsx` to a new `chat-mentions.ts` lib file, so they can be unit-tested). No behavior change.

## Deferred (intentionally out of scope)

- Admin-authed-but-not-admin 403 coverage: requires mocking `verifyToken` past the TS ES-module lock. The 401 tests catch the larger class of regression (auth dropped entirely).
- `vite.config.ts` env-var branch coverage: build-time code, hard to isolate.
- Missing endpoint tests for `/admin/runtime` and `/admin/managed-sessions/:id` 404 shapes: happy-path 200 tests exist; 404 pathways were out of scope for this pass.
- Playwright `waitForTimeout` cleanup and `retries: 0` experiment.
- `CONTRIBUTING.md` conventions section and CI guard for `pytest.raises(Exception)` / `waitForTimeout(`.

## Test plan

- [x] `cd cli && uv run pytest` — 625 passed, 1 skipped.
- [x] `cd server && npm test` — 0 failures across all test files.
- [x] `cd ui && npx vitest run` — 185 passed.
- [x] `cd ui && npx tsc --noEmit` — no errors after `chat-input.tsx` refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)