### PR TITLE
fix(ui): add frame-src to CSP so PDF artifact previews render

### DIFF
--- a/scripts/ci/hosted-preflight.sh
+++ b/scripts/ci/hosted-preflight.sh
@@ -147,5 +147,25 @@ for (const [name, json] of [
     throw new Error(`${name} vercel config is missing ${expectedWsOrigin} in connect-src`);
   }
 }
+// The UI CSP must allow cross-origin iframes/objects for Supabase Storage
+// so PDF artifact previews render. Historically this was omitted and
+// browsers fell back to `default-src 'self'`, silently blocking embeds.
+{
+  const uiConfig = JSON.parse(uiJson);
+  const uiCsp = cspHeader(uiConfig);
+  if (!/\bframe-src\b/.test(uiCsp)) {
+    throw new Error("ui vercel config is missing frame-src CSP (breaks PDF previews)");
+  }
+  if (!/\bframe-src\s+[^;]*https:\/\/\*\.supabase\.co/.test(uiCsp)) {
+    throw new Error(
+      "ui vercel config frame-src is missing https://*.supabase.co (breaks PDF previews)",
+    );
+  }
+  if (!/\bobject-src\s+[^;]*https:\/\/\*\.supabase\.co/.test(uiCsp)) {
+    throw new Error(
+      "ui vercel config object-src is missing https://*.supabase.co (PDF/embed fallback)",
+    );
+  }
+}
 console.log("vercel config CSP ok");
 NODE

--- a/ui/src/components/artifacts/embedded-document-preview.test.ts
+++ b/ui/src/components/artifacts/embedded-document-preview.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for the pure-function half of embedded-document-preview.
+ *
+ * The React component itself (iframe rendering + onError fallback) isn't
+ * covered here because the UI test suite doesn't have React Testing
+ * Library / jsdom set up, and adding that just for this one component
+ * would be disproportionate. The fallback UI is covered by visual QA
+ * on the preview deployment, and the CSP regression risk is guarded by
+ * `scripts/ci/hosted-preflight.sh`'s CSP validation.
+ *
+ * What IS testable here: the `officeOnlineEmbedUrl` helper. A regression
+ * in URL encoding there would silently break PPTX previews.
+ */
+
+import { describe, expect, it } from "vitest";
+import { officeOnlineEmbedUrl } from "./embedded-document-preview";
+
+describe("officeOnlineEmbedUrl", () => {
+  it("builds a view.officeapps.live.com embed URL", () => {
+    const result = officeOnlineEmbedUrl("https://example.com/deck.pptx");
+    expect(result).toMatch(/^https:\/\/view\.officeapps\.live\.com\/op\/embed\.aspx\?src=/);
+  });
+
+  it("URL-encodes the src parameter so query strings in the file URL survive", () => {
+    // A Supabase signed URL carries `?token=...&expires=...` in its query.
+    // Those query params must be encoded as part of the `src=` value; if
+    // they bleed through as raw `&` they'd turn into siblings of
+    // Office's own params and corrupt both.
+    const signed =
+      "https://project.supabase.co/storage/v1/object/sign/artifacts/a.pptx?token=xyz&expires=1234";
+    const result = officeOnlineEmbedUrl(signed);
+    expect(result).toContain(`src=${encodeURIComponent(signed)}`);
+    // No raw `&token=` leaking as a top-level query param.
+    expect(result).not.toMatch(/\?src=[^&]*&token=/);
+  });
+
+  it("preserves special characters via percent-encoding (spaces, slashes, colons)", () => {
+    const url = "https://example.com/folder with space/file.pptx";
+    const result = officeOnlineEmbedUrl(url);
+    expect(result).toContain("folder%20with%20space");
+    expect(result).toContain("https%3A%2F%2Fexample.com");
+  });
+
+  it("handles an empty string without throwing", () => {
+    // Not a useful call in practice, but should not crash.
+    expect(() => officeOnlineEmbedUrl("")).not.toThrow();
+    expect(officeOnlineEmbedUrl("")).toBe(
+      "https://view.officeapps.live.com/op/embed.aspx?src=",
+    );
+  });
+});

--- a/ui/src/components/artifacts/embedded-document-preview.tsx
+++ b/ui/src/components/artifacts/embedded-document-preview.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
-import { Download, ExternalLink } from "lucide-react";
+import { useState } from "react";
+import { Download, ExternalLink, FileWarning } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 function DownloadLink({ url, filename }: { url: string; filename: string }) {
@@ -33,16 +34,38 @@ export function EmbeddedDocumentPreview({
   iframeClassName?: string;
   footerClassName?: string;
 }) {
+  // Track iframe failures so a CSP-blocked or cross-origin-refused embed
+  // surfaces a visible message instead of a mystery grey box. `error`
+  // fires for blocked subresources and network failures; combined with
+  // the Open/Download links below this gives the user a working path
+  // out when the preview itself can't render.
+  const [hasError, setHasError] = useState(false);
+
   return (
     <div className="space-y-2">
-      <iframe
-        src={embedUrl}
-        className={cn(
-          "h-[500px] w-full rounded-[8px] border border-border-subtle",
-          iframeClassName,
-        )}
-        title={title}
-      />
+      {hasError ? (
+        <div
+          role="alert"
+          data-testid="embedded-preview-fallback"
+          className={cn(
+            "flex h-[500px] w-full flex-col items-center justify-center gap-2 rounded-[8px] border border-border-subtle bg-surface-raised text-text-tertiary",
+            iframeClassName,
+          )}
+        >
+          <FileWarning className="h-6 w-6" aria-hidden="true" />
+          <p className="text-[12px]">Preview unavailable. Use Open or Download.</p>
+        </div>
+      ) : (
+        <iframe
+          src={embedUrl}
+          onError={() => setHasError(true)}
+          className={cn(
+            "h-[500px] w-full rounded-[8px] border border-border-subtle",
+            iframeClassName,
+          )}
+          title={title}
+        />
+      )}
       <div
         className={cn("flex items-center justify-center gap-3", footerClassName)}
       >

--- a/ui/src/lib/vercel-config.test.ts
+++ b/ui/src/lib/vercel-config.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the UI's Vercel config — specifically the CSP header.
+ *
+ * Context: a previous CSP tightening silently dropped `frame-src` and
+ * `object-src` directives. Browsers then fell back to `default-src
+ * 'self'`, blocking all cross-origin iframes — which silently broke
+ * PDF artifact previews (Supabase Storage signed URLs are cross-origin).
+ * The bug shipped because CI only validated `connect-src`.
+ *
+ * These tests pin the invariant at the unit-test level (in addition to
+ * the `scripts/ci/hosted-preflight.sh` check). If someone regresses the
+ * CSP in a future refactor, this fails locally before CI even runs.
+ */
+
+import { describe, expect, it } from "vitest";
+// eslint-disable-next-line import/no-relative-packages
+import config from "../../vercel";
+
+type VercelConfig = {
+  headers?: Array<{
+    source: string;
+    headers: Array<{ key: string; value: string }>;
+  }>;
+};
+
+function cspHeader(vercelConfig: VercelConfig): string {
+  for (const rule of vercelConfig.headers ?? []) {
+    for (const header of rule.headers ?? []) {
+      if (header.key.toLowerCase() === "content-security-policy") {
+        return header.value;
+      }
+    }
+  }
+  return "";
+}
+
+describe("ui/vercel.ts CSP", () => {
+  const csp = cspHeader(config as VercelConfig);
+
+  it("has a Content-Security-Policy header", () => {
+    expect(csp).not.toBe("");
+  });
+
+  it("includes connect-src with Supabase and GitHub API origins", () => {
+    // Sanity — the existing CI check already validates this, but mirror
+    // it here so regressions surface in `npm test` too.
+    expect(csp).toContain("connect-src");
+    expect(csp).toContain("https://*.supabase.co");
+    expect(csp).toContain("https://api.github.com");
+  });
+
+  it("includes frame-src allowing Supabase Storage iframes (PDF preview)", () => {
+    // Root-cause coverage for the PDF-preview bug: without frame-src,
+    // browsers fall back to default-src 'self' and block all
+    // cross-origin iframes. Signed Supabase Storage URLs are cross-origin.
+    expect(csp).toMatch(/\bframe-src\s+[^;]*https:\/\/\*\.supabase\.co/);
+  });
+
+  it("allows the Office Online viewer origin in frame-src (PPTX preview)", () => {
+    // PPTX artifacts embed through officeOnlineEmbedUrl, which points at
+    // https://view.officeapps.live.com. Same CSP class of failure.
+    expect(csp).toMatch(
+      /\bframe-src\s+[^;]*https:\/\/view\.officeapps\.live\.com/,
+    );
+  });
+
+  it("includes object-src with Supabase Storage for <object>/<embed> fallback", () => {
+    // If we ever swap iframe for object/embed (or a browser routes PDFs
+    // that way), object-src must also allow the Supabase origin.
+    // default-src 'self' fallback would block it otherwise.
+    expect(csp).toMatch(/\bobject-src\s+[^;]*https:\/\/\*\.supabase\.co/);
+  });
+
+  it("keeps frame-ancestors 'none' (clickjacking defense for our own pages)", () => {
+    // Regression guard — frame-ancestors protects us from being embedded;
+    // frame-src controls what WE embed. Two different directives,
+    // shouldn't get confused.
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+});

--- a/ui/src/lib/vercel-config.test.ts
+++ b/ui/src/lib/vercel-config.test.ts
@@ -13,7 +13,6 @@
  */
 
 import { describe, expect, it } from "vitest";
-// eslint-disable-next-line import/no-relative-packages
 import config from "../../vercel";
 
 type VercelConfig = {

--- a/ui/vercel.ts
+++ b/ui/vercel.ts
@@ -66,7 +66,7 @@ function buildConfig() {
           },
           {
             key: "Content-Security-Policy",
-            value: `default-src 'self'; script-src 'self' 'sha256-R/guIIIfwBNMKTuvNTrvVOAlszaDjyjpfpXQXmnPS/I='; style-src 'self' 'unsafe-inline' https://rsms.me https://fonts.googleapis.com; font-src 'self' https://rsms.me https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src ${connectSrc}; frame-ancestors 'none'; base-uri 'self'; form-action 'self'`,
+            value: `default-src 'self'; script-src 'self' 'sha256-R/guIIIfwBNMKTuvNTrvVOAlszaDjyjpfpXQXmnPS/I='; style-src 'self' 'unsafe-inline' https://rsms.me https://fonts.googleapis.com; font-src 'self' https://rsms.me https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src ${connectSrc}; frame-src 'self' https://*.supabase.co https://view.officeapps.live.com; object-src 'self' https://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'`,
           },
         ],
       },


### PR DESCRIPTION
## Summary

PDF previews for project-report artifacts have been broken on main since Apr 13. Clicking a PDF in the artifact preview pane shows a broken-document glyph instead of the PDF; the `Open` and `Download` buttons still work, but the preview pane is silently blank.

## Root cause

Commit `c0ee8be` ("harden hosted smoke agent configuration") tightened the CSP on `ui/vercel.ts:68-70` but omitted `frame-src` and `object-src` directives. Per the CSP spec, missing directives fall back to `default-src 'self'`, which **blocks every cross-origin iframe**. Supabase Storage signed URLs (`https://<project>.supabase.co/storage/v1/...`) are cross-origin, so the iframe in `EmbeddedDocumentPreview` silently fails and renders the broken-document glyph we see in the screenshot.

Zero tests and zero CI guards caught it — the existing `hosted-preflight.sh` CSP validation only checked `connect-src`.

## Fix — four parts

**1. `ui/vercel.ts`** — add the missing directives:

```diff
- img-src 'self' data: blob:; connect-src ${connectSrc}; frame-ancestors 'none'; ...
+ img-src 'self' data: blob:; connect-src ${connectSrc};
+ frame-src 'self' https://*.supabase.co https://view.officeapps.live.com;
+ object-src 'self' https://*.supabase.co;
+ frame-ancestors 'none'; ...
```

- `https://*.supabase.co` matches the wildcard already used in `connect-src` (consistency).
- `https://view.officeapps.live.com` is the Office Online viewer origin used by `officeOnlineEmbedUrl` for PPTX previews (fixed as a side-effect).
- `object-src` covers the `<object>`/`<embed>` path in case a browser routes PDFs there.

**2. `embedded-document-preview.tsx`** — add `onError` + fallback UI. If the iframe fails for any reason (CSP, X-Frame-Options, network), render \`"Preview unavailable. Use Open or Download."\` so the next silent CSP regression surfaces visibly instead of as a mystery grey box. Open and Download links keep working regardless.

**3. New tests (10 total)**
- `ui/src/lib/vercel-config.test.ts` (6 tests) — pins the CSP shape: `frame-src` with Supabase + Office Online, `object-src` with Supabase, `frame-ancestors 'none'` preserved, `connect-src` sanity. Fails locally before CI if anyone drops a directive.
- `ui/src/components/artifacts/embedded-document-preview.test.ts` (4 tests) — covers `officeOnlineEmbedUrl` URL-encoding: signed Supabase URLs carry `?token=&expires=` which must be encoded as part of the `src=` value, not leak as siblings of Office's own query params.

**React-render coverage is skipped intentionally** — the UI suite doesn't have React Testing Library / jsdom, and adding that for one component is disproportionate for this fix. The fallback UI is covered by visual QA on the preview deployment below.

**4. `scripts/ci/hosted-preflight.sh`** — extend the existing CSP validation to also require `frame-src` and `object-src` with the Supabase origin on the UI config. Same class of silent regression would now fail CI at the deploy gate.

## Files changed

| File | Change |
| --- | --- |
| \`ui/vercel.ts\` | Add \`frame-src\` + \`object-src\` to CSP |
| \`ui/src/components/artifacts/embedded-document-preview.tsx\` | \`onError\` + fallback UI |
| \`ui/src/components/artifacts/embedded-document-preview.test.ts\` | **New** — 4 tests on officeOnlineEmbedUrl |
| \`ui/src/lib/vercel-config.test.ts\` | **New** — 6 tests on CSP shape |
| \`scripts/ci/hosted-preflight.sh\` | Extend CSP validation with frame-src check |

## Test plan

- [x] \`cd ui && npx tsc --noEmit\` — clean
- [x] \`cd ui && npm test\` — 195 passed (was 185, +10 new)
- [x] \`bash scripts/ci/hosted-preflight.sh\` — \"vercel config CSP ok\"
- [ ] **Post-deploy visual check**: open the Vercel preview URL, navigate to a project with a PDF artifact. PDF should render inline (browser's native viewer). Open and Download still work. No CSP errors in console.
- [ ] **Fallback UI sanity**: temporarily drop \`frame-src\` locally and confirm \"Preview unavailable\" message appears with Open/Download still functional. Revert.

## Not in scope

- Adding React Testing Library + jsdom to enable component-level tests. Worth considering as a follow-up but disproportionate for this fix.
- Narrowing the \`*.supabase.co\` wildcard to our specific project subdomain. We already use the same wildcard in \`connect-src\`; narrowing requires doing both at once in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)