### PR TITLE
[codex] Fix CLI activation session refresh

### DIFF
--- a/cli/tests/test_auth_commands.py
+++ b/cli/tests/test_auth_commands.py
@@ -36,6 +36,19 @@ def test_login_help_emphasizes_plain_login(runner: CliRunner) -> None:
     assert "sonde login --method loopback" in result.output
 
 
+def test_login_short_circuits_when_already_signed_in(runner: CliRunner, monkeypatch) -> None:
+    user = auth.UserInfo(email="mason@aeolus.earth", user_id="user-1", name="Mason Lee")
+    monkeypatch.setattr("sonde.auth.is_authenticated", lambda: True)
+    monkeypatch.setattr("sonde.auth.get_current_user", lambda: user)
+
+    with patch("sonde.auth.login", side_effect=AssertionError("login flow should not run")):
+        result = runner.invoke(cli, ["login"])
+
+    assert result.exit_code == 0
+    assert "Already signed in as mason@aeolus.earth" in result.output
+    assert "sonde logout" in result.output
+
+
 def test_login_reports_config_error_with_loopback_guidance(runner: CliRunner, monkeypatch) -> None:
     monkeypatch.setattr("sonde.auth.is_authenticated", lambda: False)
     monkeypatch.setattr(
@@ -544,6 +557,52 @@ def test_refresh_session_updates_stored_session(monkeypatch):
     user = cast(dict[str, Any], saved["user"])
     meta = cast(dict[str, Any], user["app_metadata"])
     assert meta["programs"] == ["dart-benchmarking", "shared"]
+
+
+def test_is_authenticated_refreshes_expired_human_session(monkeypatch) -> None:
+    session = {
+        "access_token": "expired-access-token",
+        "refresh_token": "refresh-token",
+        "user": {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "email": "test@aeolus.earth",
+            "app_metadata": {"programs": ["shared"]},
+            "user_metadata": {},
+        },
+    }
+    monkeypatch.delenv("SONDE_TOKEN", raising=False)
+
+    with (
+        patch("sonde.auth.load_session", return_value=session),
+        patch("sonde.auth._is_expired", return_value=True),
+        patch("sonde.auth.refresh_session", return_value="new-access-token") as refresh_session,
+    ):
+        assert auth.is_authenticated() is True
+
+    refresh_session.assert_called_once_with()
+
+
+def test_is_authenticated_returns_false_when_human_refresh_fails(monkeypatch) -> None:
+    session = {
+        "access_token": "expired-access-token",
+        "refresh_token": "revoked-refresh-token",
+        "user": {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "email": "test@aeolus.earth",
+            "app_metadata": {"programs": ["shared"]},
+            "user_metadata": {},
+        },
+    }
+    monkeypatch.delenv("SONDE_TOKEN", raising=False)
+
+    with (
+        patch("sonde.auth.load_session", return_value=session),
+        patch("sonde.auth._is_expired", return_value=True),
+        patch("sonde.auth.refresh_session", return_value=None) as refresh_session,
+    ):
+        assert auth.is_authenticated() is False
+
+    refresh_session.assert_called_once_with()
 
 
 # ---------------------------------------------------------------------------

--- a/ui/src/lib/activation-session.test.ts
+++ b/ui/src/lib/activation-session.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+import { ACTIVATION_STORAGE_KEY, clearActivationStorage } from "./activation-session";
+
+describe("activation session cleanup", () => {
+  it("clears only local activation storage entries", () => {
+    const storage = {
+      removeItem: vi.fn(),
+    };
+
+    clearActivationStorage(storage);
+
+    expect(storage.removeItem).toHaveBeenCalledTimes(2);
+    expect(storage.removeItem).toHaveBeenCalledWith(ACTIVATION_STORAGE_KEY);
+    expect(storage.removeItem).toHaveBeenCalledWith(
+      `${ACTIVATION_STORAGE_KEY}-code-verifier`
+    );
+  });
+});

--- a/ui/src/lib/activation-session.ts
+++ b/ui/src/lib/activation-session.ts
@@ -1,0 +1,12 @@
+export const ACTIVATION_STORAGE_KEY = "sonde-activation-auth";
+
+type ActivationStorage = Pick<Storage, "removeItem">;
+
+export function clearActivationStorage(
+  storage: ActivationStorage | undefined = typeof window !== "undefined"
+    ? window.localStorage
+    : undefined
+): void {
+  storage?.removeItem(ACTIVATION_STORAGE_KEY);
+  storage?.removeItem(`${ACTIVATION_STORAGE_KEY}-code-verifier`);
+}

--- a/ui/src/lib/activation-supabase.ts
+++ b/ui/src/lib/activation-supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import { ACTIVATION_STORAGE_KEY, clearActivationStorage } from "./activation-session";
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
@@ -9,7 +10,7 @@ if (!supabaseUrl || !supabaseAnonKey) {
   );
 }
 
-export const ACTIVATION_STORAGE_KEY = "sonde-activation-auth";
+export { ACTIVATION_STORAGE_KEY };
 
 export const activationSupabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
@@ -22,8 +23,5 @@ export const activationSupabase = createClient(supabaseUrl, supabaseAnonKey, {
 });
 
 export async function clearActivationSession(): Promise<void> {
-  await activationSupabase.auth.signOut();
-  if (typeof window !== "undefined") {
-    window.localStorage.removeItem(ACTIVATION_STORAGE_KEY);
-  }
+  clearActivationStorage();
 }


### PR DESCRIPTION
## Summary

- Fix the hosted activation cleanup flow so handing a Supabase session to the CLI does not revoke the refresh token immediately afterward.
- Keep `sonde login` from forcing a browser relogin when an existing session is still valid.
- Add regression coverage for already-authenticated login, human session refresh, failed refresh fallback, and activation storage cleanup.

## Root Cause

The hosted device activation page gave the CLI the browser activation Supabase session, then called `activationSupabase.auth.signOut()` during cleanup. Supabase sign-out defaults to a global sign-out, so the refresh token that had just been saved by the CLI was revoked. The access token continued working until its normal JWT expiry, and then the CLI could not refresh it, causing agents in long-running SSH sessions to be logged out and forcing `sonde login` to reauthenticate every time.

## Fix

Activation cleanup is now local-storage only. The browser removes the temporary activation session and PKCE verifier from local storage without calling Supabase sign-out, preserving the refresh token that was handed to the CLI.

## Validation

- `uv run pytest tests/test_auth_commands.py tests/test_auth_login_ux.py tests/test_cli.py --tb=short`
- `npm run test -- device-activation`
- `npm run test -- activation-session`
- `bash scripts/ci/core.sh cli`
- `bash scripts/ci/core.sh ui`
- `SONDE_AUTH_TEST_PORT=3015 bash scripts/ci/auth.sh`
- `bash scripts/ci/data.sh`
- `bash scripts/ci/browser.sh all`
- `git diff --check`

Note: the first local `scripts/ci/auth.sh` attempt hit an old process already listening on port 3005. After killing the stale process and rerunning on port 3015, the auth suite passed.