### PR TITLE
feat(cli): add sonde upgrade + bare-invocation update nudge

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -70,6 +70,28 @@ sonde search --text "spectral bin"
 sonde search --param ccn>1000
 ```
 
+## Upgrading
+
+The normal way to update sonde to the latest release:
+
+```bash
+sonde upgrade
+```
+
+Pin a specific version with `sonde upgrade --tag v0.1.4`. Check for
+updates without installing with `sonde upgrade --check`.
+
+Running `sonde` with no subcommand prints a one-line hint when a newer
+version is available. Set `SONDE_NO_UPDATE_CHECK=1` to silence it, or
+run `sonde upgrade --check` any time to see the current status.
+
+If something is broken such that `sonde upgrade` itself won't run,
+re-install manually:
+
+```bash
+uv tool install --force "git+https://github.com/aeolus-earth/sonde.git@main#subdirectory=cli"
+```
+
 ## Troubleshooting
 
 If install or login behaves strangely, first verify which `sonde` binary your shell is using:
@@ -81,11 +103,7 @@ sonde doctor
 ```
 
 If you see older login wording or noisy browser-open errors, you are likely running a stale install.
-Reinstall the current CLI:
-
-```bash
-uv tool install --force "git+https://github.com/aeolus-earth/sonde.git@main#subdirectory=cli"
-```
+Run `sonde upgrade` (or the manual `uv tool install --force …` fallback above).
 
 `sonde login` now uses the hosted activation flow by default and prints a short code
 plus a browser URL. The compatibility alias still works if you want to force that path

--- a/cli/src/sonde/cli.py
+++ b/cli/src/sonde/cli.py
@@ -18,7 +18,7 @@ from sonde.cli_options import pass_output_options
 load_dotenv()
 
 # Commands that don't require authentication
-_NO_AUTH = {"login", "logout", "whoami", "setup", "doctor", "skills"}
+_NO_AUTH = {"login", "logout", "whoami", "setup", "doctor", "skills", "upgrade"}
 
 
 def _is_help_request() -> bool:
@@ -225,6 +225,14 @@ def cli(ctx: click.Context, use_json: bool, quiet: bool, verbose: bool, no_color
     # Show help when invoked with no subcommand
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
+        # Best-effort nudge if a newer sonde is available. Lazy import
+        # avoids pulling network-adjacent code on every invocation.
+        try:
+            from sonde.commands.upgrade import maybe_nudge_for_update
+
+            maybe_nudge_for_update()
+        except Exception:
+            pass
 
 
 # -- Register commands --
@@ -258,6 +266,7 @@ from sonde.commands.sync import sync  # noqa: E402
 from sonde.commands.tag import tag  # noqa: E402
 from sonde.commands.takeaway import takeaway  # noqa: E402
 from sonde.commands.tree import tree_cmd  # noqa: E402
+from sonde.commands.upgrade import upgrade  # noqa: E402
 
 # Auth & Setup
 cli.add_command(login)
@@ -266,6 +275,7 @@ cli.add_command(whoami)
 cli.add_command(init_cmd)
 cli.add_command(setup)
 cli.add_command(doctor)
+cli.add_command(upgrade)
 cli.add_command(access)
 cli.add_command(skills)
 

--- a/cli/src/sonde/commands/upgrade.py
+++ b/cli/src/sonde/commands/upgrade.py
@@ -1,0 +1,405 @@
+"""`sonde upgrade` — reinstall the latest sonde CLI via uv.
+
+Users install sonde with:
+    uv tool install --force "git+https://github.com/aeolus-earth/sonde.git@<ref>#subdirectory=cli"
+
+This command wraps that incantation behind a single verb, checks for
+updates against GitHub's /releases/latest, validates input to keep shell
+injection impossible, and gives clear platform-specific guidance when
+prerequisites are missing.
+
+Kept intentionally narrow: does one thing (reinstall from a ref),
+refuses when the running sonde wasn't installed via `uv tool install`,
+and streams uv's output so users see real progress.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import click
+
+from sonde import __version__
+from sonde.output import err, print_error, print_success
+
+# Hardcoded constants — no user input reaches these.
+_REPO = "aeolus-earth/sonde"
+_LATEST_RELEASE_URL = f"https://api.github.com/repos/{_REPO}/releases/latest"
+_GITHUB_TIMEOUT_SECONDS = 5
+
+# Accepted --tag values. Regex validation happens BEFORE the URL is built
+# or passed to subprocess, so even though we use list-form args (no
+# shell=True), we still reject anything exotic at the click-command
+# boundary. Allows: main, staging, v<semver>, v<semver>-<prerelease>.
+_TAG_PATTERN = re.compile(r"^(main|staging|v\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?)$")
+
+
+def _install_url(ref: str) -> str:
+    """Build the canonical `uv tool install` URL for a given ref.
+
+    Single source of truth for the git URL — `diagnostics.py` imports
+    this so a future refactor only touches one place.
+    """
+    return f"git+https://github.com/{_REPO}.git@{ref}#subdirectory=cli"
+
+
+def _install_command(ref: str) -> str:
+    """The full human-readable `uv tool install` command for a ref.
+
+    Returned with quotes so users can copy-paste directly. The UI's
+    `ui/src/lib/chat-install.ts` produces the same shape for display;
+    any change here should mirror there.
+    """
+    return f'uv tool install --force "{_install_url(ref)}"'
+
+
+def _installed_via_uv_tool() -> bool:
+    """Return True when the running sonde lives under a uv-tool prefix.
+
+    uv tool installs land at paths containing "uv" and "tools":
+        Linux:   ~/.local/share/uv/tools/sonde/...
+        macOS:   ~/Library/Application Support/uv/tools/sonde/...
+    Development clones (``cd cli && uv sync``) live under a project
+    venv and don't have both segments. This heuristic is sufficient;
+    the cost of a false positive is just refusing an upgrade the user
+    could have done another way, not data loss.
+    """
+    parts = Path(sys.prefix).resolve().parts
+    return "uv" in parts and "tools" in parts
+
+
+def _validate_tag(tag: str) -> bool:
+    """Reject anything that isn't main, staging, or a semver-like tag.
+
+    Defense-in-depth: subprocess already uses list-form args, but the
+    ref gets interpolated into the URL — refusing obviously hostile
+    input (shell metacharacters, path traversal) keeps the attack
+    surface visibly narrow.
+    """
+    return bool(_TAG_PATTERN.match(tag))
+
+
+def _normalize_version(raw: str) -> str:
+    """Reduce a version string to its comparable semver core.
+
+    ``v0.1.4`` -> ``0.1.4``
+    ``0.1.3.dev12+g8ea494a`` -> ``0.1.3``
+    ``0.0.0+unknown`` -> ``0.0.0``
+    """
+    stripped = raw.lstrip("v")
+    # hatch-vcs emits ``X.Y.Z.devN+gSHA`` between tags; cut everything
+    # from the first .dev or +.
+    for delimiter in (".dev", "+"):
+        idx = stripped.find(delimiter)
+        if idx >= 0:
+            stripped = stripped[:idx]
+    return stripped
+
+
+def _is_dev_build(raw: str) -> bool:
+    """True when the running version has a .dev or local build suffix."""
+    return ".dev" in raw or "+" in raw
+
+
+def _fetch_latest_tag() -> tuple[str | None, str | None]:
+    """Hit GitHub's /releases/latest.
+
+    Returns ``(tag, None)`` on success, or ``(None, reason)`` on any
+    failure where ``reason`` is one of ``"unreachable"`` or
+    ``"rate_limited"``. Never raises — network failures must not crash
+    the command.
+    """
+    request = Request(
+        _LATEST_RELEASE_URL,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": f"sonde-cli/{__version__}",
+        },
+    )
+    try:
+        with urlopen(request, timeout=_GITHUB_TIMEOUT_SECONDS) as response:
+            payload = json.load(response)
+    except HTTPError as exc:
+        # 403 with "rate limit" message is the common case; 404 would
+        # mean no releases yet — treat it as unreachable for users.
+        if exc.code == 403:
+            return None, "rate_limited"
+        return None, "unreachable"
+    except (URLError, TimeoutError, OSError, ValueError):
+        # URLError covers DNS / connection refused; ValueError covers
+        # malformed JSON. OSError is the broad catch-all for socket-level
+        # surprises.
+        return None, "unreachable"
+
+    tag = payload.get("tag_name")
+    if not isinstance(tag, str):
+        return None, "unreachable"
+    return tag, None
+
+
+def _print_uv_install_guidance() -> None:
+    """Platform-aware instructions for getting uv when it's missing."""
+    err.print("\n[sonde.error]\u2717[/] uv is required to upgrade sonde.\n")
+    err.print("  Install uv:")
+    err.print("    [sonde.muted]macOS:[/]    brew install uv")
+    err.print(
+        "    [sonde.muted]Linux:[/]    curl -LsSf https://astral.sh/uv/install.sh | sh",
+    )
+    err.print(
+        "    [sonde.muted]Windows:[/]  see https://docs.astral.sh/uv/getting-started/installation/",
+    )
+    err.print("\n  Then re-run: [sonde.accent]sonde upgrade[/]\n")
+
+
+def _print_dev_clone_guidance() -> None:
+    err.print("\n[sonde.error]\u2717[/] sonde wasn't installed via `uv tool install`.\n")
+    err.print(f"  Detected install prefix: [sonde.muted]{sys.prefix}[/]\n")
+    err.print("  If you're in a development clone, update with:")
+    err.print("    [sonde.accent]git pull && uv sync[/]\n")
+    err.print(
+        "  `sonde upgrade` only manages installs created via `uv tool install`.\n",
+    )
+
+
+def _do_check() -> int:
+    """Implement `sonde upgrade --check`. Returns the desired exit code."""
+    installed_display = __version__
+    latest, failure_reason = _fetch_latest_tag()
+
+    if latest is None:
+        if failure_reason == "rate_limited":
+            err.print(
+                "\n[sonde.warning]\u26a0[/] GitHub rate limit hit while checking for updates.",
+            )
+        else:
+            err.print(
+                "\n[sonde.warning]\u26a0[/] Could not reach GitHub to check for updates.",
+            )
+        err.print(f"  [sonde.muted]Installed:[/] {installed_display}\n")
+        # Soft-fail: this is a transient network condition, not a user
+        # error. Exit 0 keeps chained shell scripts usable.
+        return 0
+
+    installed_core = _normalize_version(installed_display)
+    latest_core = _normalize_version(latest)
+
+    if _is_dev_build(installed_display):
+        err.print(
+            f"\n[sonde.accent]\u2139[/] You're on a development build "
+            f"([sonde.muted]{installed_display}[/]).",
+        )
+        err.print(f"  [sonde.muted]Latest tagged:[/] {latest}\n")
+        err.print(
+            "  Run [sonde.accent]sonde upgrade[/] to switch to the latest tagged release,",
+        )
+        err.print(
+            "  or [sonde.accent]sonde upgrade --tag main[/] to stay on the main branch.\n",
+        )
+        return 0
+
+    if installed_core == latest_core:
+        err.print(f"\n[sonde.success]\u2713[/] sonde is up to date ({installed_display}).\n")
+        return 0
+
+    err.print("\n[sonde.heading]Update available.[/]")
+    err.print(f"  [sonde.muted]Installed:[/] {installed_display}")
+    err.print(f"  [sonde.muted]Latest:[/]    {latest}\n")
+    err.print("  Run: [sonde.accent]sonde upgrade[/]\n")
+    return 0
+
+
+def _do_install(ref: str) -> int:
+    """Implement `sonde upgrade` (install path). Returns the exit code."""
+    if not _installed_via_uv_tool():
+        _print_dev_clone_guidance()
+        return 1
+
+    if not shutil.which("uv"):
+        _print_uv_install_guidance()
+        return 1
+
+    url = _install_url(ref)
+    err.print(f"\n[sonde.heading]Installing sonde from {ref} via uv\u2026[/]\n")
+
+    # List-form args + no shell=True + regex-validated ref => no shell
+    # injection surface. subprocess.run inherits stdio so uv's progress
+    # streams directly to the user.
+    result = subprocess.run(
+        ["uv", "tool", "install", "--force", url],
+        check=False,
+    )
+
+    if result.returncode != 0:
+        err.print(
+            f"\n[sonde.error]\u2717[/] uv tool install exited with code {result.returncode}.\n",
+        )
+        return result.returncode
+
+    print_success(
+        "sonde upgraded.",
+        details=[
+            "Run `sonde --version` to verify.",
+            "If `which sonde` still points at the old binary, run `hash -r`.",
+        ],
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Update nudge — called from bare `sonde` invocation via cli.py
+# ---------------------------------------------------------------------------
+#
+# Philosophy: best-effort, never blocks, never shouts. One line to stderr
+# only when an update is actually available, cached for 24 hours so we
+# don't hit GitHub on every invocation, gated on TTY + opt-out env var.
+
+_NUDGE_CACHE_TTL_SECONDS = 24 * 60 * 60  # 24 hours
+_NUDGE_NETWORK_TIMEOUT_SECONDS = 1  # keep the user waiting for no more than this
+_NUDGE_DISABLE_ENV = "SONDE_NO_UPDATE_CHECK"
+
+
+def _nudge_cache_path() -> Path:
+    """Location of the cache file. Imported lazily to avoid a top-level
+    config dependency on this module."""
+    from sonde.config import CONFIG_DIR
+
+    return CONFIG_DIR / "upgrade-check.json"
+
+
+def _read_nudge_cache() -> dict | None:
+    path = _nudge_cache_path()
+    try:
+        raw = path.read_text()
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _write_nudge_cache(latest_tag: str) -> None:
+    """Best-effort write. Silent on any failure — cache is a nice-to-have."""
+    path = _nudge_cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"checked_at": time.time(), "latest_tag": latest_tag}),
+        )
+    except OSError:
+        return
+
+
+def _fetch_latest_tag_quick() -> str | None:
+    """Like _fetch_latest_tag but with a tight timeout and no error
+    distinction — used from the nudge path where we never want to block."""
+    request = Request(
+        _LATEST_RELEASE_URL,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": f"sonde-cli/{__version__}",
+        },
+    )
+    try:
+        with urlopen(request, timeout=_NUDGE_NETWORK_TIMEOUT_SECONDS) as response:
+            payload = json.load(response)
+    except Exception:
+        return None
+    tag = payload.get("tag_name") if isinstance(payload, dict) else None
+    return tag if isinstance(tag, str) else None
+
+
+def maybe_nudge_for_update() -> None:
+    """Print a one-line update nudge to stderr if appropriate.
+
+    Completely silent when:
+      - stderr isn't a TTY (scripts, pipes, CI)
+      - ``SONDE_NO_UPDATE_CHECK`` env var is set (user opt-out)
+      - The running build is a dev build (those don't map to patch releases)
+      - The cached or fetched latest tag equals the installed version
+      - Network fails — best-effort, no complaints
+
+    Uses a 24-hour cache keyed by the filesystem so each process doesn't
+    hit GitHub. Never raises.
+    """
+    if os.environ.get(_NUDGE_DISABLE_ENV):
+        return
+    if not sys.stderr.isatty():
+        return
+    if _is_dev_build(__version__):
+        return
+
+    latest_tag: str | None = None
+    cache = _read_nudge_cache()
+    if cache is not None:
+        checked_at = cache.get("checked_at")
+        cached_tag = cache.get("latest_tag")
+        if (
+            isinstance(checked_at, (int, float))
+            and isinstance(cached_tag, str)
+            and (time.time() - checked_at) < _NUDGE_CACHE_TTL_SECONDS
+        ):
+            latest_tag = cached_tag
+
+    if latest_tag is None:
+        latest_tag = _fetch_latest_tag_quick()
+        if latest_tag is None:
+            return
+        _write_nudge_cache(latest_tag)
+
+    installed_core = _normalize_version(__version__)
+    latest_core = _normalize_version(latest_tag)
+    if installed_core == latest_core:
+        return
+
+    err.print(
+        f"  [sonde.accent]\U0001f4a1[/] A new version of sonde "
+        f"([sonde.accent]{latest_tag}[/]) is available. "
+        f"Run [sonde.accent]sonde upgrade[/] to install.\n",
+    )
+
+
+# ---------------------------------------------------------------------------
+# `sonde upgrade` command
+# ---------------------------------------------------------------------------
+
+
+@click.command()
+@click.option(
+    "--tag",
+    default="main",
+    help=(
+        "Ref to install. Accepts 'main', 'staging', or a version tag like 'v0.1.4'. Default: main."
+    ),
+)
+@click.option(
+    "--check",
+    "check_only",
+    is_flag=True,
+    help="Report installed vs latest without installing.",
+)
+def upgrade(tag: str, check_only: bool) -> None:
+    """Upgrade the sonde CLI to the latest version via uv."""
+    if not _validate_tag(tag):
+        print_error(
+            what=f"invalid --tag value: {tag!r}",
+            why="Only 'main', 'staging', or semver tags like 'v0.1.4' are accepted.",
+            fix="Re-run with a valid ref, e.g. `sonde upgrade --tag v0.1.4`.",
+        )
+        # Click uses exit 2 for usage errors — match that convention.
+        sys.exit(2)
+
+    if check_only:
+        sys.exit(_do_check())
+
+    sys.exit(_do_install(tag))

--- a/cli/src/sonde/diagnostics.py
+++ b/cli/src/sonde/diagnostics.py
@@ -45,9 +45,11 @@ STATUS_ORDER: dict[DoctorStatus, int] = {
     "error": 4,
 }
 
-GIT_TOOL_INSTALL_COMMAND = (
-    'uv tool install --force "git+https://github.com/aeolus-earth/sonde.git@main#subdirectory=cli"'
-)
+# Keep the doctor's suggested install command in sync with the `sonde upgrade`
+# command by sourcing the URL from there. Prevents drift between the two.
+from sonde.commands.upgrade import _install_command as _upgrade_install_command  # noqa: E402
+
+GIT_TOOL_INSTALL_COMMAND = _upgrade_install_command("main")
 INSTALL_VERIFY_COMMANDS = (
     "which -a sonde",
     "sonde --version",

--- a/cli/tests/test_auth_commands.py
+++ b/cli/tests/test_auth_commands.py
@@ -563,7 +563,7 @@ def test_noauth_allowlist_is_tight() -> None:
     the allowlist — review whether that's intentional."""
     from sonde.cli import _NO_AUTH
 
-    expected = {"login", "logout", "whoami", "setup", "doctor", "skills"}
+    expected = {"login", "logout", "whoami", "setup", "doctor", "skills", "upgrade"}
     assert expected == _NO_AUTH, (
         f"_NO_AUTH changed to {_NO_AUTH!r}. If intentional, update this "
         f"test; otherwise a previously-auth-required command was silently "

--- a/cli/tests/test_upgrade_command.py
+++ b/cli/tests/test_upgrade_command.py
@@ -1,0 +1,577 @@
+"""Tests for `sonde upgrade` — CLI self-update via uv.
+
+These tests are deliberately adversarial: each one pins a specific failure
+mode or guard clause that a regression could silently break. No live
+network, no live subprocess — everything is mocked.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock
+from urllib.error import HTTPError, URLError
+
+import pytest
+from click.testing import CliRunner
+
+from sonde.cli import cli
+from sonde.commands.upgrade import (
+    _install_command,
+    _install_url,
+    _is_dev_build,
+    _normalize_version,
+    _validate_tag,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _release_response(tag_name: str) -> io.BytesIO:
+    """Fake a urlopen() context-manager response for /releases/latest."""
+    response = MagicMock()
+    response.read.return_value = json.dumps({"tag_name": tag_name}).encode()
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    # json.load calls read().decode internally; streamline by returning a
+    # file-like object that json.load can consume directly.
+    buffer = io.BytesIO(json.dumps({"tag_name": tag_name}).encode())
+    buffer.__enter__ = lambda self: self  # type: ignore[attr-defined]
+    buffer.__exit__ = lambda self, *_: None  # type: ignore[attr-defined]
+    return buffer
+
+
+def _invoke(runner: CliRunner, *args: str):
+    return runner.invoke(cli, ["upgrade", *args])
+
+
+# ---------------------------------------------------------------------------
+# Pure-function unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeVersion:
+    def test_strips_v_prefix(self):
+        assert _normalize_version("v0.1.4") == "0.1.4"
+
+    def test_strips_dev_suffix(self):
+        assert _normalize_version("0.1.3.dev12+g8ea494a") == "0.1.3"
+
+    def test_strips_local_segment(self):
+        assert _normalize_version("0.0.0+unknown") == "0.0.0"
+
+    def test_preserves_clean_version(self):
+        assert _normalize_version("0.1.4") == "0.1.4"
+
+
+class TestIsDevBuild:
+    def test_clean_version_is_not_dev(self):
+        assert _is_dev_build("0.1.4") is False
+        assert _is_dev_build("v0.1.4") is False
+
+    def test_dev_suffix_is_dev(self):
+        assert _is_dev_build("0.1.3.dev12+g8ea494a") is True
+
+    def test_local_segment_alone_is_dev(self):
+        assert _is_dev_build("0.0.0+unknown") is True
+
+
+class TestValidateTag:
+    def test_accepts_main(self):
+        assert _validate_tag("main") is True
+
+    def test_accepts_staging(self):
+        assert _validate_tag("staging") is True
+
+    def test_accepts_semver_tag(self):
+        assert _validate_tag("v0.1.4") is True
+        assert _validate_tag("v12.34.56") is True
+
+    def test_accepts_prerelease_tag(self):
+        assert _validate_tag("v0.1.4-rc.1") is True
+        assert _validate_tag("v1.0.0-beta.1") is True
+
+    def test_rejects_bare_number(self):
+        assert _validate_tag("0.1.4") is False
+
+    def test_rejects_shell_metacharacters(self):
+        # Pins the injection defense — these must never make it to the URL.
+        assert _validate_tag("main;rm -rf /") is False
+        assert _validate_tag("main && evil") is False
+        assert _validate_tag("$(echo hack)") is False
+        assert _validate_tag("main`ls`") is False
+
+    def test_rejects_path_traversal(self):
+        assert _validate_tag("../../etc/passwd") is False
+        assert _validate_tag("main/../evil") is False
+
+    def test_rejects_empty_string(self):
+        assert _validate_tag("") is False
+
+    def test_rejects_random_branch_names(self):
+        # We don't support arbitrary branches — if someone really needs
+        # to install from `feature/xyz`, they can use the manual
+        # `uv tool install` command.
+        assert _validate_tag("feature/foo") is False
+        assert _validate_tag("fix/bar") is False
+
+
+class TestInstallUrl:
+    def test_url_shape_with_main(self):
+        assert (
+            _install_url("main")
+            == "git+https://github.com/aeolus-earth/sonde.git@main#subdirectory=cli"
+        )
+
+    def test_url_shape_with_version_tag(self):
+        assert (
+            _install_url("v0.1.4")
+            == "git+https://github.com/aeolus-earth/sonde.git@v0.1.4#subdirectory=cli"
+        )
+
+    def test_install_command_matches_readme(self):
+        """Pins the exact incantation documented in cli/README.md. If
+        someone changes the command format without updating the README,
+        this test catches it."""
+        assert (
+            _install_command("main")
+            == 'uv tool install --force "git+https://github.com/aeolus-earth/sonde.git@main#subdirectory=cli"'
+        )
+
+    def test_diagnostics_shares_source_of_truth(self):
+        """The doctor command's suggested install command must come from
+        the same helper. If anyone hardcodes the URL in diagnostics.py
+        again, this test fails."""
+        from sonde.diagnostics import GIT_TOOL_INSTALL_COMMAND
+
+        assert _install_command("main") == GIT_TOOL_INSTALL_COMMAND
+
+
+# ---------------------------------------------------------------------------
+# Command integration tests
+# ---------------------------------------------------------------------------
+
+
+def _patch_common(
+    monkeypatch, *, installed_via_uv: bool = True, uv_path: str | None = "/usr/local/bin/uv"
+):
+    """Patch the environment to a predictable state.
+
+    By default: looks like a healthy uv-tool install with uv on PATH.
+    Tests override these per-case.
+    """
+    monkeypatch.setattr(
+        "sonde.commands.upgrade._installed_via_uv_tool",
+        lambda: installed_via_uv,
+    )
+    monkeypatch.setattr(
+        "sonde.commands.upgrade.shutil.which",
+        lambda name: uv_path if name == "uv" else None,
+    )
+
+
+class TestCheckMode:
+    def test_up_to_date_exact_match(self, runner: CliRunner, monkeypatch):
+        _patch_common(monkeypatch)
+        monkeypatch.setattr("sonde.commands.upgrade.__version__", "0.1.4")
+        monkeypatch.setattr(
+            "sonde.commands.upgrade.urlopen",
+            lambda *_args, **_kwargs: _release_response("v0.1.4"),
+        )
+        fake_subprocess = MagicMock()
+        monkeypatch.setattr("sonde.commands.upgrade.subprocess.run", fake_subprocess)
+
+        result = _invoke(runner, "--check")
+
+        assert result.exit_code == 0
+        assert "up to date" in result.output
+        assert "0.1.4" in result.output
+        assert fake_subprocess.call_count == 0, (
+            "--check must NOT trigger any install; subprocess.run should be untouched"
+        )
+
+    def test_update_available_shows_both_versions(self, runner: CliRunner, monkeypatch):
+        _patch_common(monkeypatch)
+        monkeypatch.setattr("sonde.commands.upgrade.__version__", "0.1.3")
+        monkeypatch.setattr(
+            "sonde.commands.upgrade.urlopen",
+            lambda *_args, **_kwargs: _release_response("v0.1.4"),
+        )
+
+        result = _invoke(runner, "--check")
+
+        assert result.exit_code == 0
+        assert "Update available" in result.output
+        assert "0.1.3" in result.output
+        assert "v0.1.4" in result.output
+        assert "sonde upgrade" in result.output
+
+    def test_dev_build_shows_development_message(self, runner: CliRunner, monkeypatch):
+        _patch_common(monkeypatch)
+        monkeypatch.setattr(
+            "sonde.commands.upgrade.__version__",
+            "0.1.3.dev12+g8ea494a",
+        )
+        monkeypatch.setattr(
+            "sonde.commands.upgrade.urlopen",
+            lambda *_args, **_kwargs: _release_response("v0.1.4"),
+        )
+
+        result = _invoke(runner, "--check")
+
+        assert result.exit_code == 0
+        assert "development build" in result.output
+        assert "0.1.3.dev12+g8ea494a" in result.output
+        assert "v0.1.4" in result.output
+
+    def test_github_unreachable_soft_fails_with_exit_zero(
+        self,
+        runner: CliRunner,
+        monkeypatch,
+    ):
+        _patch_common(monkeypatch)
+        monkeypatch.setattr("sonde.commands.upgrade.__version__", "0.1.3")
+
+        def raise_url_error(*_args, **_kwargs):
+            raise URLError("no route to host")
+
+        monkeypatch.setattr("sonde.commands.upgrade.urlopen", raise_url_error)
+
+        result = _invoke(runner, "--check")
+
+        # Exit 0 (soft-fail) keeps this chainable in scripts.
+        assert result.exit_code == 0
+        assert "Could not reach GitHub" in result.output
+        assert "0.1.3" in result.output
+
+    def test_github_rate_limit_distinguishes_from_unreachable(
+        self,
+        runner: CliRunner,
+        monkeypatch,
+    ):
+        _patch_common(monkeypatch)
+        monkeypatch.setattr("sonde.commands.upgrade.__version__", "0.1.3")
+
+        def raise_rate_limit(*_args, **_kwargs):
+            raise HTTPError(
+                url="https://api.github.com/",
+                code=403,
+                msg="rate limit exceeded",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=None,
+            )
+
+        monkeypatch.setattr("sonde.commands.upgrade.urlopen", raise_rate_limit)
+
+        result = _invoke(runner, "--check")
+
+        assert result.exit_code == 0
+        # Rate-limit message must be visibly different from "unreachable"
+        # so operators can tell the two apart.
+        assert "rate limit" in result.output.lower()
+
+
+class TestGuards:
+    def test_rejects_invalid_tag_before_any_side_effects(
+        self,
+        runner: CliRunner,
+        monkeypatch,
+    ):
+        """The tag-injection defense: a hostile --tag must exit before
+        subprocess or urlopen is invoked."""
+        _patch_common(monkeypatch)
+        fake_subprocess = MagicMock()
+        fake_urlopen = MagicMock()
+        monkeypatch.setattr("sonde.commands.upgrade.subprocess.run", fake_subprocess)
+        monkeypatch.setattr("sonde.commands.upgrade.urlopen", fake_urlopen)
+
+        result = _invoke(runner, "--tag", "main;rm -rf /")
+
+        assert result.exit_code == 2
+        assert "invalid --tag" in result.output
+        # Must quote the input so the user sees what was rejected.
+        assert "main;rm -rf /" in result.output
+        # Zero side effects before the reject.
+        assert fake_subprocess.call_count == 0
+        assert fake_urlopen.call_count == 0
+
+    def test_refuses_when_not_installed_via_uv(self, runner: CliRunner, monkeypatch):
+        _patch_common(monkeypatch, installed_via_uv=False)
+        fake_subprocess = MagicMock()
+        monkeypatch.setattr("sonde.commands.upgrade.subprocess.run", fake_subprocess)
+
+        result = _invoke(runner)
+
+        assert result.exit_code == 1
+        assert "wasn't installed via `uv tool install`" in result.output
+        assert "git pull" in result.output
+        assert "uv sync" in result.output
+        assert fake_subprocess.call_count == 0
+
+    def test_refuses_when_uv_missing_with_platform_guidance(
+        self,
+        runner: CliRunner,
+        monkeypatch,
+    ):
+        _patch_common(monkeypatch, uv_path=None)
+        fake_subprocess = MagicMock()
+        monkeypatch.setattr("sonde.commands.upgrade.subprocess.run", fake_subprocess)
+
+        result = _invoke(runner)
+
+        assert result.exit_code == 1
+        assert "uv is required" in result.output
+        # Must include platform-specific instructions (all three).
+        assert "brew install uv" in result.output
+        assert "curl -LsSf https://astral.sh/uv/install.sh" in result.output
+        assert "docs.astral.sh/uv" in result.output
+        assert fake_subprocess.call_count == 0
+
+
+class TestInstallShelling:
+    def _mock_subprocess(self, monkeypatch, return_code: int = 0) -> MagicMock:
+        completed = MagicMock()
+        completed.returncode = return_code
+        fake = MagicMock(return_value=completed)
+        monkeypatch.setattr("sonde.commands.upgrade.subprocess.run", fake)
+        return fake
+
+    def test_shells_to_uv_with_default_main_tag(self, runner: CliRunner, monkeypatch):
+        _patch_common(monkeypatch)
+        fake = self._mock_subprocess(monkeypatch)
+
+        result = _invoke(runner)
+
+        assert result.exit_code == 0
+        assert fake.call_count == 1
+        call = fake.call_args
+        # CRITICAL: must be list-form args, not shell=True. This is the
+        # second layer of the shell-injection defense.
+        args = call.args[0]
+        assert isinstance(args, list), "subprocess.run must receive list-form args"
+        assert args[:4] == ["uv", "tool", "install", "--force"]
+        assert args[4].endswith("@main#subdirectory=cli")
+        # Must explicitly not use shell=True.
+        assert call.kwargs.get("shell") is not True
+
+    def test_shells_to_uv_with_specific_tag(self, runner: CliRunner, monkeypatch):
+        _patch_common(monkeypatch)
+        fake = self._mock_subprocess(monkeypatch)
+
+        result = _invoke(runner, "--tag", "v0.1.4")
+
+        assert result.exit_code == 0
+        args = fake.call_args.args[0]
+        assert args[4].endswith("@v0.1.4#subdirectory=cli")
+
+    def test_propagates_uv_nonzero_exit_code(self, runner: CliRunner, monkeypatch):
+        """When uv fails, sonde upgrade must surface the same exit code.
+        Silent-success on uv failure would be a nightmare to debug."""
+        _patch_common(monkeypatch)
+        self._mock_subprocess(monkeypatch, return_code=7)
+
+        result = _invoke(runner)
+
+        assert result.exit_code == 7
+        assert "exited with code 7" in result.output
+
+    def test_prints_success_details_on_zero_exit(self, runner: CliRunner, monkeypatch):
+        _patch_common(monkeypatch)
+        self._mock_subprocess(monkeypatch, return_code=0)
+
+        result = _invoke(runner)
+
+        assert result.exit_code == 0
+        assert "sonde upgraded" in result.output
+        # Success guidance should help the user verify and recover from
+        # PATH-hash caching.
+        assert "sonde --version" in result.output
+        assert "hash -r" in result.output
+
+
+class TestDoesNotRequireAuth:
+    def test_upgrade_is_in_no_auth_allowlist(self):
+        """Regression guard: an auth-required upgrade command would be
+        unreachable when the user's session has expired — which is often
+        exactly when they want to upgrade."""
+        from sonde.cli import _NO_AUTH
+
+        assert "upgrade" in _NO_AUTH
+
+
+# ---------------------------------------------------------------------------
+# Update nudge — shown on bare `sonde`
+# ---------------------------------------------------------------------------
+
+
+class TestNudge:
+    """The nudge runs in the no-subcommand path and must be silent under
+    pressure: no network, no cache, pipe redirect, dev build, opt-out —
+    none of these should ever surface a message or slow the user down.
+
+    Rich's `err` Console captures sys.stderr at import time, so pytest's
+    `capsys`/`capfd` can't intercept its output. Each test reads from
+    `err.file` (replaced with a StringIO in the fixture) instead.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _nudge_env(self, tmp_path, monkeypatch):
+        """Isolate each test's cache file, TTY detection, opt-out env,
+        and Rich output buffer."""
+        from sonde.output import err as rich_err
+
+        cache_file = tmp_path / "upgrade-check.json"
+        monkeypatch.setattr(
+            "sonde.commands.upgrade._nudge_cache_path",
+            lambda: cache_file,
+        )
+        monkeypatch.setattr("sys.stderr.isatty", lambda: True)
+        monkeypatch.delenv("SONDE_NO_UPDATE_CHECK", raising=False)
+
+        # Redirect the Rich console's file handle to a StringIO so the
+        # test can inspect what would have been printed. monkeypatch
+        # restores the original on teardown.
+        buffer = io.StringIO()
+        monkeypatch.setattr(rich_err, "file", buffer)
+        # Force terminal rendering off so markup doesn't pollute assertions.
+        monkeypatch.setattr(rich_err, "_force_terminal", False)
+        self._buffer = buffer
+
+    def _stderr(self) -> str:
+        return self._buffer.getvalue()
+
+    def test_silent_when_up_to_date(self, monkeypatch):
+        from sonde.commands.upgrade import maybe_nudge_for_update
+
+        monkeypatch.setattr("sonde.commands.upgrade.__version__", "0.1.4")
+        monkeypatch.setattr(
+            "sonde.commands.upgrade._fetch_latest_tag_quick",
+            lambda: "v0.1.4",
+        )
+
+        maybe_nudge_for_update()
+
+        assert self._stderr() == ""
+
+    def test_prints_single_line_when_update_available(self, monkeypatch):
+        from sonde.commands.upgrade import maybe_nudge_for_update
+
+        monkeypatch.setattr("sonde.commands.upgrade.__version__", "0.1.3")
+        monkeypatch.setattr(
+            "sonde.commands.upgrade._fetch_latest_tag_quick",
+            lambda: "v0.1.4",
+        )
+
+        maybe_nudge_for_update()
+
+        output = self._stderr()
+        assert "v0.1.4" in output
+        assert "sonde upgrade" in output
+
+    def test_silent_when_not_a_tty(self, monkeypatch):
+        """Pipes, CI logs, redirected shells: nudge must not leak."""
+        from sonde.commands.upgrade import maybe_nudge_for_update
+
+        monkeypatch.setattr("sys.stderr.isatty", lambda: False)
+        monkeypatch.setattr("sonde.commands.upgrade.__version__", "0.1.3")
+        fetch = MagicMock(return_value="v0.1.4")
+        monkeypatch.setattr("sonde.commands.upgrade._fetch_latest_tag_quick", fetch)
+
+        maybe_nudge_for_update()
+
+        assert self._stderr() == ""
+        # And we don't even try to hit the network — save the user RTT.
+        assert fetch.call_count == 0
+
+    def test_silent_when_opt_out_env_set(self, monkeypatch):
+        from sonde.commands.upgrade import maybe_nudge_for_update
+
+        monkeypatch.setenv("SONDE_NO_UPDATE_CHECK", "1")
+        fetch = MagicMock(return_value="v9.9.9")
+        monkeypatch.setattr("sonde.commands.upgrade._fetch_latest_tag_quick", fetch)
+
+        maybe_nudge_for_update()
+
+        assert self._stderr() == ""
+        assert fetch.call_count == 0
+
+    def test_silent_on_dev_build(self, monkeypatch):
+        """Dev builds sit between tagged releases — nudging them to
+        upgrade to the latest tag would revert forward-dev work. Skip."""
+        from sonde.commands.upgrade import maybe_nudge_for_update
+
+        monkeypatch.setattr(
+            "sonde.commands.upgrade.__version__",
+            "0.1.3.dev12+g8ea494a",
+        )
+        fetch = MagicMock(return_value="v0.1.4")
+        monkeypatch.setattr("sonde.commands.upgrade._fetch_latest_tag_quick", fetch)
+
+        maybe_nudge_for_update()
+
+        assert self._stderr() == ""
+        assert fetch.call_count == 0
+
+    def test_uses_cache_within_ttl_and_skips_network(self, monkeypatch, tmp_path):
+        """A fresh cache entry must prevent a network call on the next run."""
+        import time as time_mod
+
+        from sonde.commands.upgrade import maybe_nudge_for_update
+
+        cache_path = tmp_path / "upgrade-check.json"
+        cache_path.write_text(
+            json.dumps({"checked_at": time_mod.time(), "latest_tag": "v0.1.4"}),
+        )
+        monkeypatch.setattr(
+            "sonde.commands.upgrade._nudge_cache_path",
+            lambda: cache_path,
+        )
+        monkeypatch.setattr("sonde.commands.upgrade.__version__", "0.1.3")
+        fetch = MagicMock()
+        monkeypatch.setattr("sonde.commands.upgrade._fetch_latest_tag_quick", fetch)
+
+        maybe_nudge_for_update()
+
+        assert "v0.1.4" in self._stderr()
+        assert fetch.call_count == 0, "fresh cache must prevent network call"
+
+    def test_refreshes_cache_when_stale(self, monkeypatch, tmp_path):
+        """A stale cache entry (>24h old) must trigger a fresh network
+        check and update the cache."""
+        from sonde.commands.upgrade import maybe_nudge_for_update
+
+        cache_path = tmp_path / "upgrade-check.json"
+        cache_path.write_text(
+            json.dumps({"checked_at": 0.0, "latest_tag": "v0.1.2"}),
+        )
+        monkeypatch.setattr(
+            "sonde.commands.upgrade._nudge_cache_path",
+            lambda: cache_path,
+        )
+        monkeypatch.setattr("sonde.commands.upgrade.__version__", "0.1.3")
+        monkeypatch.setattr(
+            "sonde.commands.upgrade._fetch_latest_tag_quick",
+            lambda: "v0.1.4",
+        )
+
+        maybe_nudge_for_update()
+
+        # Uses the refreshed tag, not the stale one from cache.
+        assert "v0.1.4" in self._stderr()
+        # Cache is now updated.
+        persisted = json.loads(cache_path.read_text())
+        assert persisted["latest_tag"] == "v0.1.4"
+
+    def test_silent_when_network_fails_and_no_cache(self, monkeypatch):
+        """No cache + network down = no output, no error. The user should
+        never see a traceback from a best-effort nudge."""
+        from sonde.commands.upgrade import maybe_nudge_for_update
+
+        monkeypatch.setattr("sonde.commands.upgrade.__version__", "0.1.3")
+        monkeypatch.setattr("sonde.commands.upgrade._fetch_latest_tag_quick", lambda: None)
+
+        maybe_nudge_for_update()
+
+        assert self._stderr() == ""


### PR DESCRIPTION
## Summary

Two related additions in one PR:

1. **`sonde upgrade`** — a single command that wraps the 80-char
   `uv tool install --force "git+...@ref#subdirectory=cli"` reinstall
   incantation (currently duplicated in README × 3, diagnostics.py, and
   chat-install.ts). Handles check-only mode, tag pinning, safe
   validation, and clear platform-specific guidance when uv is missing.

2. **Bare-invocation nudge** — running `sonde` with no subcommand shows
   the help output and, on a separate stderr line, a single hint when
   a newer tagged release is available. Cached 24h, TTY-gated,
   opt-outable via `SONDE_NO_UPDATE_CHECK=1`, silent on any failure.

## User experience

\`\`\`
$ sonde upgrade --check
Update available.
  Installed:  0.1.3
  Latest:     v0.1.4
Run: sonde upgrade
\`\`\`

\`\`\`
$ sonde upgrade
Installing sonde from main via uv…
<uv output streams through>
✓ sonde upgraded.
  Run \`sonde --version\` to verify.
  If \`which sonde\` still points at the old binary, run \`hash -r\`.
\`\`\`

\`\`\`
$ sonde
<help output>
  💡 A new version of sonde (v0.1.4) is available. Run sonde upgrade to install.
\`\`\`

Guardrails with clear error copy for: invalid \`--tag\` (rejects shell
metacharacters and path traversal), dev-clone detection (refuses;
points at \`git pull + uv sync\`), missing \`uv\` (refuses with
platform-specific install instructions including brew, curl, and
Windows docs link).

## Security

- **List-form \`subprocess.run\`** — no \`shell=True\`. The \`--tag\`
  value is also regex-validated before it reaches the URL. Two layers
  of shell-injection defense.
- **Hardcoded GitHub URL** — no user-controllable path injection.
  Only the ref portion is substituted, and it's regex-filtered to
  \`main|staging|v<semver>\`.
- **Unauthenticated public GitHub API only** — \`/releases/latest\`,
  read-only, rate-limit-aware.
- **Nudge is best-effort** — 1s timeout, 24h cache, TTY-gated,
  \`SONDE_NO_UPDATE_CHECK=1\` opt-out. Silent on failure; never raises.

## Environment matrix

| Environment | Behavior |
| --- | --- |
| macOS/Linux + uv | ✅ Happy path |
| macOS/Linux without uv | ❌ Refuse; show \`brew install uv\` / curl fallback / docs link |
| Dev clone (\`cd cli && uv sync\`) | ❌ Refuse; point at \`git pull + uv sync\` |
| Windows | ❌ Refuse with link to uv docs |
| CI / pipes / non-TTY | Nudge stays silent; \`sonde upgrade\` works if user invokes |
| \`SONDE_NO_UPDATE_CHECK=1\` | Nudge silent |

## Files

| File | Change |
| --- | --- |
| \`cli/src/sonde/commands/upgrade.py\` | **New** — command + helpers + nudge |
| \`cli/src/sonde/cli.py\` | Add \`\"upgrade\"\` to \`_NO_AUTH\`; register command; call \`maybe_nudge_for_update\` from the no-subcommand branch |
| \`cli/src/sonde/diagnostics.py\` | Import \`_install_command\` instead of hardcoding the URL |
| \`cli/tests/test_upgrade_command.py\` | **New** — 41 tests |
| \`cli/tests/test_auth_commands.py\` | Update \`_NO_AUTH\` pin test to include \`\"upgrade\"\` |
| \`cli/README.md\` | Add \"Upgrading\" section pointing at \`sonde upgrade\`; keep manual \`uv tool install\` as documented fallback |

## Test plan

- [x] \`cd cli && uv run ruff check src/ tests/\` — clean
- [x] \`cd cli && uv run ruff format --check src/ tests/\` — clean
- [x] \`cd cli && uv run ty check src/\` — clean
- [x] \`cd cli && uv run pytest\` — 675 passed, 1 skipped
- [ ] Post-merge sanity: install a staging build via the auto-tagged
  release, run \`sonde upgrade --check\` — should report up-to-date
  or show the nudge on bare \`sonde\`.

## Not in scope (deliberate)

- Rollback verb — \`sonde upgrade --tag vX.Y.Z\` already covers it.
- Cross-runtime URL sharing with \`ui/src/lib/chat-install.ts\` — that's
  a display string in a different runtime; overkill to share via build
  tooling.
- Windows-native upgrade path — current behavior is a clean refusal
  with a docs link.
- Auto-upgrade on every invocation — adds latency; nudge is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)