### PR TITLE
Promote staging to main

### DIFF
--- a/ui/src/lib/build-metadata.test.ts
+++ b/ui/src/lib/build-metadata.test.ts
@@ -132,6 +132,26 @@ describe("build metadata", () => {
     expect(sleeps).toEqual([5_000]);
   });
 
+  it("falls back to canonical GitHub tag lookup when the build remote has no tags", () => {
+    const metadata = resolveBuildMetadata(
+      {
+        VERCEL_ENV: "production",
+        VERCEL_GIT_COMMIT_REF: "main",
+        VERCEL_GIT_COMMIT_SHA: COMMIT_SHA,
+      },
+      commandRunner({
+        [`git tag --points-at ${COMMIT_SHA}`]: "",
+        'git ls-remote --tags origin "v*"': "",
+        'git ls-remote --tags https://github.com/aeolus-earth/sonde.git "v*"':
+          `${COMMIT_SHA}\trefs/tags/v0.1.9^{}`,
+      }),
+      { strictTagWaitMs: 0 },
+    );
+
+    expect(metadata.appVersion).toBe("v0.1.9");
+    expect(metadata.appVersionSource).toBe("exact-tag");
+  });
+
   it("throws instead of falling back when production main has no exact tag", () => {
     expect(() =>
       resolveBuildMetadata(

--- a/ui/src/lib/build-metadata.ts
+++ b/ui/src/lib/build-metadata.ts
@@ -19,7 +19,9 @@ export type BuildMetadataOptions = {
 const STABLE_TAG_RE = /^v(\d+)\.(\d+)\.(\d+)$/;
 const DESCRIBE_TAG_RE = /^v\d+\.\d+\.\d+(?:[-+].*)?$/;
 const GIT_SHA_RE = /^[0-9a-f]{7,40}$/i;
-const REMOTE_TAGS_COMMAND = 'git ls-remote --tags origin "v*"';
+const ORIGIN_TAGS_COMMAND = 'git ls-remote --tags origin "v*"';
+const CANONICAL_TAGS_COMMAND =
+  'git ls-remote --tags https://github.com/aeolus-earth/sonde.git "v*"';
 const DEFAULT_STRICT_TAG_WAIT_MS = 180_000;
 const DEFAULT_STRICT_TAG_POLL_INTERVAL_MS = 5_000;
 
@@ -162,7 +164,10 @@ function exactStableTagForCommit(commitSha: string, runCommand: RunCommand): str
   if (localTag) return localTag;
 
   if (!GIT_SHA_RE.test(commitSha)) return null;
-  return exactStableTagFromLsRemote(run(runCommand, REMOTE_TAGS_COMMAND), commitSha);
+  return (
+    exactStableTagFromLsRemote(run(runCommand, ORIGIN_TAGS_COMMAND), commitSha) ||
+    exactStableTagFromLsRemote(run(runCommand, CANONICAL_TAGS_COMMAND), commitSha)
+  );
 }
 
 function trustedProductionBranch(env: BuildMetadataEnv): string | null {
@@ -194,7 +199,11 @@ function waitForExactStableTagForCommit(
 
 function strictTagCommands(commitSha: string): string {
   const localTarget = GIT_SHA_RE.test(commitSha) ? commitSha : "HEAD";
-  return [`git tag --points-at ${localTarget}`, REMOTE_TAGS_COMMAND].join("; ");
+  return [
+    `git tag --points-at ${localTarget}`,
+    ORIGIN_TAGS_COMMAND,
+    CANONICAL_TAGS_COMMAND,
+  ].join("; ");
 }
 
 function productionTargetError(

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -19,7 +19,7 @@ function runCommand(command: string): string | null {
   try {
     const out = execSync(command, {
       stdio: ["ignore", "pipe", "ignore"],
-      timeout: 5000,
+      timeout: 15000,
     })
       .toString()
       .trim();


### PR DESCRIPTION
## Summary\n\nThis release PR is managed automatically from the `staging` branch.\n\n- staging commit: `fc5fd6b61406b337d9e548e62680228500016af6`\n- release method: merge commit\n- promotion guard: only `staging -> main` PRs are allowed to pass `merge-readiness`\n\n## Staging gate\n\n- [Staging Smoke](https://github.com/aeolus-earth/sonde/actions/runs/24542936889)\n- [Sync Staging Infra](https://github.com/aeolus-earth/sonde/actions/runs/24542936885)\n- [Config Audit](https://github.com/aeolus-earth/sonde/actions/runs/24542936893)\n- [CLI Hosted Audit](https://github.com/aeolus-earth/sonde/actions/runs/24542936898)