### PR TITLE
[codex] Fix hosted agent token exchange

### DIFF
--- a/server/src/agent-token-exchange.ts
+++ b/server/src/agent-token-exchange.ts
@@ -1,7 +1,15 @@
 import { createHash } from "node:crypto";
-import { getServiceRoleSupabaseClient } from "./supabase.js";
+import {
+  getServiceRoleSupabaseClient,
+  getSupabaseAnonKey,
+  getSupabaseServiceRoleKey,
+  getSupabaseUrl,
+} from "./supabase.js";
 
 export const OPAQUE_AGENT_TOKEN_PREFIX = "sonde_ak_";
+const AGENT_AUTH_EMAIL_DOMAIN = "aeolus.earth";
+const MAX_AUTH_USER_SCAN_PAGES = 20;
+const AUTH_USER_SCAN_PAGE_SIZE = 1000;
 
 export interface AgentTokenExchangeInput {
   token: string;
@@ -22,6 +30,41 @@ export class AgentTokenExchangeConfigError extends Error {}
 
 export class AgentTokenExchangeDeniedError extends Error {}
 
+interface AgentTokenMetadata {
+  token_id: string;
+  name: string;
+  programs: string[];
+  expires_at: string;
+}
+
+interface SupabaseAuthConfig {
+  url: string;
+  anonKey: string;
+  serviceRoleKey: string;
+}
+
+interface SupabaseAuthUser {
+  id: string;
+  email?: string;
+}
+
+interface SupabaseAuthUserList {
+  users?: SupabaseAuthUser[];
+}
+
+interface SupabaseGenerateLinkResponse {
+  hashed_token?: string;
+  properties?: {
+    hashed_token?: string;
+  };
+}
+
+interface SupabaseVerifyResponse {
+  access_token?: string;
+  token_type?: string;
+  expires_in?: number;
+}
+
 function tokenHash(token: string): string {
   return createHash("sha256").update(token, "utf8").digest("hex");
 }
@@ -31,31 +74,301 @@ function cleanMetadataValue(value: string | null | undefined): string | null {
   return trimmed ? trimmed.slice(0, 200) : null;
 }
 
-function parseExchangeResult(value: unknown): AgentTokenExchangeResult {
+function parseTokenMetadata(value: unknown): AgentTokenMetadata {
   if (!value || typeof value !== "object") {
     throw new Error("Agent token exchange returned an empty response.");
   }
   const data = value as Record<string, unknown>;
-  const accessToken = typeof data.access_token === "string" ? data.access_token : "";
-  const tokenType = typeof data.token_type === "string" ? data.token_type : "";
-  const expiresIn = typeof data.expires_in === "number" ? data.expires_in : 0;
-  const expiresAt = typeof data.expires_at === "string" ? data.expires_at : "";
   const tokenId = typeof data.token_id === "string" ? data.token_id : "";
+  const name = typeof data.name === "string" ? data.name : "";
+  const expiresAt = typeof data.expires_at === "string" ? data.expires_at : "";
   const programs = Array.isArray(data.programs)
     ? data.programs.filter((program): program is string => typeof program === "string")
     : [];
 
-  if (!accessToken || tokenType !== "bearer" || expiresIn <= 0 || !expiresAt || !tokenId) {
+  if (!tokenId || !name || !expiresAt) {
     throw new Error("Agent token exchange returned an incomplete response.");
   }
 
   return {
+    token_id: tokenId,
+    name,
+    programs,
+    expires_at: expiresAt,
+  };
+}
+
+function getAuthConfig(env: NodeJS.ProcessEnv): SupabaseAuthConfig {
+  const serviceRoleKey = getSupabaseServiceRoleKey(env);
+  if (!serviceRoleKey) {
+    throw new AgentTokenExchangeConfigError(
+      "SUPABASE_SERVICE_ROLE_KEY is required for agent token exchange.",
+    );
+  }
+
+  try {
+    return {
+      url: getSupabaseUrl(env).replace(/\/+$/, ""),
+      anonKey: getSupabaseAnonKey(env),
+      serviceRoleKey,
+    };
+  } catch (error) {
+    throw new AgentTokenExchangeConfigError(
+      error instanceof Error ? error.message : "Supabase configuration is incomplete.",
+    );
+  }
+}
+
+function agentEmail(tokenId: string): string {
+  return `agent-${tokenId}@${AGENT_AUTH_EMAIL_DOMAIN}`;
+}
+
+function authHeaders(key: string): Record<string, string> {
+  return {
+    apikey: key,
+    authorization: `Bearer ${key}`,
+    "content-type": "application/json",
+  };
+}
+
+function extractSupabaseMessage(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const data = value as Record<string, unknown>;
+  for (const key of ["msg", "message", "error_description", "error"]) {
+    const candidate = data[key];
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return { message: text };
+  }
+}
+
+async function fetchAuthJson<T>(
+  config: SupabaseAuthConfig,
+  path: string,
+  key: string,
+  init: Omit<RequestInit, "headers"> = {},
+): Promise<T> {
+  const response = await fetch(`${config.url}${path}`, {
+    ...init,
+    headers: authHeaders(key),
+  });
+  const body = await readJson(response);
+  if (!response.ok) {
+    const message =
+      extractSupabaseMessage(body) ||
+      `Supabase Auth request failed with HTTP ${response.status}.`;
+    throw new Error(message);
+  }
+  return body as T;
+}
+
+function agentAppMetadata(metadata: AgentTokenMetadata): Record<string, unknown> {
+  return {
+    agent: true,
+    programs: metadata.programs,
+    token_id: metadata.token_id,
+    token_name: metadata.name,
+    agent_name: metadata.name,
+  };
+}
+
+function agentUserMetadata(metadata: AgentTokenMetadata): Record<string, unknown> {
+  return {
+    agent_name: metadata.name,
+  };
+}
+
+async function findAgentAuthUser(
+  config: SupabaseAuthConfig,
+  email: string,
+): Promise<SupabaseAuthUser | null> {
+  for (let page = 1; page <= MAX_AUTH_USER_SCAN_PAGES; page += 1) {
+    const params = new URLSearchParams({
+      page: String(page),
+      per_page: String(AUTH_USER_SCAN_PAGE_SIZE),
+    });
+    const result = await fetchAuthJson<SupabaseAuthUserList>(
+      config,
+      `/auth/v1/admin/users?${params.toString()}`,
+      config.serviceRoleKey,
+      { method: "GET" },
+    );
+    const users = Array.isArray(result.users) ? result.users : [];
+    const found = users.find((user) => user.email?.toLowerCase() === email.toLowerCase());
+    if (found) {
+      return found;
+    }
+    if (users.length < AUTH_USER_SCAN_PAGE_SIZE) {
+      return null;
+    }
+  }
+
+  throw new Error("Unable to scan Supabase Auth users for the agent token account.");
+}
+
+async function createAgentAuthUser(
+  config: SupabaseAuthConfig,
+  email: string,
+  metadata: AgentTokenMetadata,
+): Promise<SupabaseAuthUser> {
+  return fetchAuthJson<SupabaseAuthUser>(
+    config,
+    "/auth/v1/admin/users",
+    config.serviceRoleKey,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        email,
+        email_confirm: true,
+        app_metadata: agentAppMetadata(metadata),
+        user_metadata: agentUserMetadata(metadata),
+      }),
+    },
+  );
+}
+
+async function updateAgentAuthUser(
+  config: SupabaseAuthConfig,
+  user: SupabaseAuthUser,
+  metadata: AgentTokenMetadata,
+): Promise<void> {
+  await fetchAuthJson<SupabaseAuthUser>(
+    config,
+    `/auth/v1/admin/users/${encodeURIComponent(user.id)}`,
+    config.serviceRoleKey,
+    {
+      method: "PUT",
+      body: JSON.stringify({
+        email_confirm: true,
+        app_metadata: agentAppMetadata(metadata),
+        user_metadata: agentUserMetadata(metadata),
+      }),
+    },
+  );
+}
+
+async function ensureAgentAuthUser(
+  config: SupabaseAuthConfig,
+  metadata: AgentTokenMetadata,
+): Promise<string> {
+  const email = agentEmail(metadata.token_id);
+  const existing = await findAgentAuthUser(config, email);
+  if (existing) {
+    await updateAgentAuthUser(config, existing, metadata);
+  } else {
+    try {
+      await createAgentAuthUser(config, email, metadata);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "";
+      if (!/already|registered|exists/i.test(message)) {
+        throw error;
+      }
+      const racedUser = await findAgentAuthUser(config, email);
+      if (!racedUser) {
+        throw error;
+      }
+      await updateAgentAuthUser(config, racedUser, metadata);
+    }
+  }
+  return email;
+}
+
+async function generateMagicLinkHash(
+  config: SupabaseAuthConfig,
+  email: string,
+): Promise<string> {
+  const result = await fetchAuthJson<SupabaseGenerateLinkResponse>(
+    config,
+    "/auth/v1/admin/generate_link",
+    config.serviceRoleKey,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        type: "magiclink",
+        email,
+      }),
+    },
+  );
+
+  const hash = result.hashed_token || result.properties?.hashed_token || "";
+  if (!hash) {
+    throw new Error("Supabase Auth did not return a magic-link token hash.");
+  }
+  return hash;
+}
+
+function jwtExpiry(accessToken: string, fallbackExpiresIn: number): {
+  expiresIn: number;
+  expiresAt: string;
+} {
+  const fallbackExpiresAt = new Date(Date.now() + fallbackExpiresIn * 1000).toISOString();
+  const [, payload] = accessToken.split(".");
+  if (!payload) {
+    return { expiresIn: fallbackExpiresIn, expiresAt: fallbackExpiresAt };
+  }
+
+  try {
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      exp?: unknown;
+    };
+    if (typeof claims.exp === "number" && Number.isFinite(claims.exp)) {
+      return {
+        expiresIn: Math.max(1, Math.floor(claims.exp - Date.now() / 1000)),
+        expiresAt: new Date(claims.exp * 1000).toISOString(),
+      };
+    }
+  } catch {
+    return { expiresIn: fallbackExpiresIn, expiresAt: fallbackExpiresAt };
+  }
+
+  return { expiresIn: fallbackExpiresIn, expiresAt: fallbackExpiresAt };
+}
+
+async function createAgentSession(
+  config: SupabaseAuthConfig,
+  email: string,
+  metadata: AgentTokenMetadata,
+): Promise<AgentTokenExchangeResult> {
+  const tokenHashValue = await generateMagicLinkHash(config, email);
+  const session = await fetchAuthJson<SupabaseVerifyResponse>(
+    config,
+    "/auth/v1/verify",
+    config.anonKey,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        type: "magiclink",
+        token_hash: tokenHashValue,
+      }),
+    },
+  );
+
+  const accessToken = session.access_token || "";
+  const tokenType = session.token_type || "";
+  const fallbackExpiresIn = typeof session.expires_in === "number" ? session.expires_in : 3600;
+  if (!accessToken || tokenType.toLowerCase() !== "bearer" || fallbackExpiresIn <= 0) {
+    throw new Error("Supabase Auth returned an incomplete agent session.");
+  }
+
+  const expiry = jwtExpiry(accessToken, fallbackExpiresIn);
+  return {
     access_token: accessToken,
     token_type: "bearer",
-    expires_in: expiresIn,
-    expires_at: expiresAt,
-    token_id: tokenId,
-    programs,
+    expires_in: expiry.expiresIn,
+    expires_at: expiry.expiresAt,
+    token_id: metadata.token_id,
+    programs: metadata.programs,
   };
 }
 
@@ -67,6 +380,7 @@ export async function exchangeAgentToken(
     throw new AgentTokenExchangeDeniedError("Invalid or expired agent token.");
   }
 
+  const authConfig = getAuthConfig(env);
   const supabase = getServiceRoleSupabaseClient(env);
   if (!supabase) {
     throw new AgentTokenExchangeConfigError(
@@ -88,5 +402,7 @@ export async function exchangeAgentToken(
     throw new Error(message);
   }
 
-  return parseExchangeResult(data);
+  const metadata = parseTokenMetadata(data);
+  const email = await ensureAgentAuthUser(authConfig, metadata);
+  return createAgentSession(authConfig, email, metadata);
 }

--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -191,10 +191,12 @@ describe("createApp", () => {
     });
   });
 
-  it("exchanges opaque agent tokens through the service-role RPC", async () => {
+  it("exchanges opaque agent tokens through service-role validation and Supabase Auth", async () => {
     process.env.VITE_SUPABASE_URL = "https://utvmqjssbkzpumsdpgdy.supabase.co";
     process.env.VITE_SUPABASE_ANON_KEY = "sb_publishable_test";
     process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+    const tokenId = "00000000-0000-0000-0000-000000000042";
+    const agentEmail = `agent-${tokenId}@aeolus.earth`;
     globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
       const request = input instanceof Request ? input : new Request(input, init);
       const url = new URL(request.url);
@@ -205,12 +207,72 @@ describe("createApp", () => {
         assert.equal(request.headers.get("authorization"), "Bearer service-role-key");
         return new Response(
           JSON.stringify({
+            token_id: tokenId,
+            name: "hosted-cli-audit",
+            programs: ["weather-intervention", "shared"],
+            expires_at: "2026-07-17T02:00:00Z",
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+
+      if (url.pathname === "/auth/v1/admin/users" && request.method === "GET") {
+        assert.equal(request.headers.get("authorization"), "Bearer service-role-key");
+        return new Response(JSON.stringify({ users: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (url.pathname === "/auth/v1/admin/users" && request.method === "POST") {
+        assert.equal(request.headers.get("authorization"), "Bearer service-role-key");
+        const body = (await request.json()) as {
+          email: string;
+          email_confirm: boolean;
+          app_metadata: {
+            agent: boolean;
+            programs: string[];
+            token_id: string;
+            token_name: string;
+          };
+        };
+        assert.equal(body.email, agentEmail);
+        assert.equal(body.email_confirm, true);
+        assert.deepEqual(body.app_metadata, {
+          agent: true,
+          programs: ["weather-intervention", "shared"],
+          token_id: tokenId,
+          token_name: "hosted-cli-audit",
+          agent_name: "hosted-cli-audit",
+        });
+        return new Response(JSON.stringify({ id: "auth-user-id", email: agentEmail }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (url.pathname === "/auth/v1/admin/generate_link") {
+        assert.equal(request.headers.get("authorization"), "Bearer service-role-key");
+        const body = (await request.json()) as { type: string; email: string };
+        assert.deepEqual(body, { type: "magiclink", email: agentEmail });
+        return new Response(JSON.stringify({ hashed_token: "magic-link-hash" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (url.pathname === "/auth/v1/verify") {
+        assert.equal(request.headers.get("authorization"), "Bearer sb_publishable_test");
+        const body = (await request.json()) as { type: string; token_hash: string };
+        assert.deepEqual(body, { type: "magiclink", token_hash: "magic-link-hash" });
+        return new Response(
+          JSON.stringify({
             access_token: "agent-access-jwt",
             token_type: "bearer",
-            expires_in: 900,
-            expires_at: "2026-04-17T02:00:00Z",
-            token_id: "00000000-0000-0000-0000-000000000042",
-            programs: ["shared"],
+            expires_in: 3600,
           }),
           {
             status: 200,
@@ -241,7 +303,7 @@ describe("createApp", () => {
     };
     assert.equal(body.access_token, "agent-access-jwt");
     assert.equal(body.token_type, "bearer");
-    assert.deepEqual(body.programs, ["shared"]);
+    assert.deepEqual(body.programs, ["weather-intervention", "shared"]);
   });
 
   it("rejects legacy password-bundle tokens at the exchange endpoint", async () => {

--- a/server/src/supabase.ts
+++ b/server/src/supabase.ts
@@ -10,7 +10,7 @@ export function telemetryRequiresServiceRole(
   return getRuntimeEnvironment(env) === "production";
 }
 
-function getSupabaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+export function getSupabaseUrl(env: NodeJS.ProcessEnv = process.env): string {
   const value = env.VITE_SUPABASE_URL?.trim() || env.SUPABASE_URL?.trim();
   if (!value) {
     throw new Error("Missing SUPABASE_URL / VITE_SUPABASE_URL.");
@@ -18,7 +18,7 @@ function getSupabaseUrl(env: NodeJS.ProcessEnv = process.env): string {
   return value;
 }
 
-function getSupabaseAnonKey(env: NodeJS.ProcessEnv = process.env): string {
+export function getSupabaseAnonKey(env: NodeJS.ProcessEnv = process.env): string {
   const value =
     env.VITE_SUPABASE_ANON_KEY?.trim() || env.SUPABASE_ANON_KEY?.trim();
   if (!value) {
@@ -27,13 +27,19 @@ function getSupabaseAnonKey(env: NodeJS.ProcessEnv = process.env): string {
   return value;
 }
 
-function getSupabaseServiceRoleKey(env: NodeJS.ProcessEnv = process.env): string | null {
+export function getSupabaseServiceRoleKey(
+  env: NodeJS.ProcessEnv = process.env
+): string | null {
   const value = env.SUPABASE_SERVICE_ROLE_KEY?.trim();
   return value || null;
 }
 
-function createServerSupabaseClient(key: string, accessToken?: string): SupabaseClient {
-  return createClient(getSupabaseUrl(), key, {
+function createServerSupabaseClient(
+  key: string,
+  accessToken?: string,
+  env: NodeJS.ProcessEnv = process.env
+): SupabaseClient {
+  return createClient(getSupabaseUrl(env), key, {
     auth: { persistSession: false, autoRefreshToken: false },
     global: accessToken
       ? {
@@ -45,8 +51,11 @@ function createServerSupabaseClient(key: string, accessToken?: string): Supabase
   });
 }
 
-export function createUserSupabaseClient(accessToken: string): SupabaseClient {
-  return createServerSupabaseClient(getSupabaseAnonKey(), accessToken);
+export function createUserSupabaseClient(
+  accessToken: string,
+  env: NodeJS.ProcessEnv = process.env
+): SupabaseClient {
+  return createServerSupabaseClient(getSupabaseAnonKey(env), accessToken, env);
 }
 
 export function getServiceRoleSupabaseClient(
@@ -54,7 +63,7 @@ export function getServiceRoleSupabaseClient(
 ): SupabaseClient | null {
   const key = getSupabaseServiceRoleKey(env);
   if (!key) return null;
-  return createServerSupabaseClient(key);
+  return createServerSupabaseClient(key, undefined, env);
 }
 
 export function createTelemetrySupabaseClient(

--- a/supabase/migrations/20260417000002_hosted_agent_exchange_session.sql
+++ b/supabase/migrations/20260417000002_hosted_agent_exchange_session.sql
@@ -1,0 +1,173 @@
+-- Hosted-compatible opaque agent exchange.
+--
+-- Hosted Supabase projects do not expose app.settings.jwt_secret to SQL, so
+-- the exchange RPC cannot sign a first-party JWT itself. Keep the database as
+-- the revocation/expiry source of truth, but have the hosted server mint a
+-- Supabase Auth session after this RPC validates the opaque token.
+
+CREATE OR REPLACE FUNCTION public.exchange_agent_token(
+    p_token_hash text,
+    p_cli_version text DEFAULT NULL,
+    p_host_label text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    token_row public.agent_tokens%rowtype;
+BEGIN
+    IF p_token_hash IS NULL OR p_token_hash !~ '^[0-9a-f]{64}$' THEN
+        RAISE EXCEPTION 'Invalid or expired agent token' USING ERRCODE = '42501';
+    END IF;
+
+    SELECT *
+    INTO token_row
+    FROM public.agent_tokens
+    WHERE token_hash = p_token_hash
+      AND revoked_at IS NULL
+      AND expires_at > now()
+    LIMIT 1;
+
+    IF token_row.id IS NULL THEN
+        RAISE EXCEPTION 'Invalid or expired agent token' USING ERRCODE = '42501';
+    END IF;
+
+    UPDATE public.agent_tokens
+    SET last_exchanged_at = now(),
+        exchange_count = exchange_count + 1
+    WHERE id = token_row.id;
+
+    RETURN jsonb_build_object(
+        'token_id', token_row.id,
+        'name', token_row.name,
+        'programs', to_jsonb(token_row.programs),
+        'expires_at', token_row.expires_at
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.exchange_agent_token(text, text, text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.exchange_agent_token(text, text, text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    claims jsonb;
+    app_meta jsonb;
+    user_email text;
+    user_programs_arr text[];
+    agent_programs text[];
+    is_admin boolean;
+    is_agent boolean;
+    token_id_text text;
+    token_id uuid;
+    token_name text;
+BEGIN
+    claims := event -> 'claims';
+    app_meta := coalesce(claims -> 'app_metadata', '{}'::jsonb);
+    user_email := claims ->> 'email';
+    is_agent := coalesce((app_meta ->> 'agent')::boolean, false);
+
+    -- Reject non-aeolus.earth emails (defense in depth — Google hd param is UI-only).
+    IF user_email IS NOT NULL AND user_email NOT LIKE '%@aeolus.earth' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'http_code', 403,
+                'message', 'Only @aeolus.earth accounts are allowed'
+            )
+        );
+    END IF;
+
+    IF is_agent THEN
+        token_id_text := app_meta ->> 'token_id';
+        IF token_id_text IS NULL
+           OR token_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'http_code', 403,
+                    'message', 'Invalid or expired agent token'
+                )
+            );
+        END IF;
+
+        token_id := token_id_text::uuid;
+        SELECT token.programs, token.name
+        INTO agent_programs, token_name
+        FROM public.agent_tokens token
+        WHERE token.id = token_id
+          AND token.revoked_at IS NULL
+          AND token.expires_at > now();
+
+        IF NOT FOUND THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'http_code', 403,
+                    'message', 'Invalid or expired agent token'
+                )
+            );
+        END IF;
+
+        claims := jsonb_set(
+            claims,
+            '{app_metadata}',
+            app_meta ||
+            jsonb_build_object(
+                'agent', true,
+                'programs', to_jsonb(agent_programs),
+                'is_admin', false,
+                'token_id', token_id,
+                'token_name', token_name,
+                'agent_name', token_name
+            )
+        );
+
+        event := jsonb_set(event, '{claims}', claims);
+        RETURN event;
+    END IF;
+
+    -- Look up human user's live program assignments.
+    SELECT
+        coalesce(array_agg(up.program), ARRAY['shared']),
+        coalesce(bool_or(up.role = 'admin'), false)
+    INTO user_programs_arr, is_admin
+    FROM public.user_programs up
+    WHERE up.user_id = (claims ->> 'sub')::uuid;
+
+    -- New humans with no assignments get 'shared' by default.
+    IF user_programs_arr IS NULL OR user_programs_arr = '{}' THEN
+        user_programs_arr := ARRAY['shared'];
+        is_admin := false;
+    END IF;
+
+    claims := jsonb_set(
+        claims,
+        '{app_metadata}',
+        app_meta ||
+        jsonb_build_object(
+            'programs', to_jsonb(user_programs_arr),
+            'is_admin', is_admin
+        )
+    );
+
+    event := jsonb_set(event, '{claims}', claims);
+    RETURN event;
+END;
+$$;
+
+GRANT USAGE ON SCHEMA public TO supabase_auth_admin;
+GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb) TO supabase_auth_admin;
+GRANT SELECT ON TABLE public.user_programs TO supabase_auth_admin;
+GRANT SELECT ON TABLE public.agent_tokens TO supabase_auth_admin;
+REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb) FROM authenticated, anon, public;
+
+UPDATE public.schema_version
+SET version = GREATEST(version, 5),
+    updated_at = now()
+WHERE singleton = TRUE;


### PR DESCRIPTION
## What changed

This fixes the hosted opaque agent-token exchange path so it no longer depends on `app.settings.jwt_secret` being available inside hosted Supabase SQL.

The database RPC now validates the opaque token hash, enforces revocation/expiry, records exchange telemetry, and returns token metadata only. The hosted server then creates or refreshes a dedicated Supabase Auth user for that token, generates a one-time magic-link hash through the service-role Auth API, verifies it with the publishable key, and returns the resulting short-lived Supabase Auth access token to the CLI. No bot password is created or returned.

I also updated the custom access-token hook so agent Auth sessions preserve `agent`, `token_id`, and token-scoped programs from `agent_tokens` instead of being overwritten by human `user_programs` defaults. RLS continues to use `agent_tokens` as the live source of truth for revocation and expiry.

## Root cause

The previous hosted exchange RPC attempted to sign JWTs in SQL with `current_setting('app.settings.jwt_secret')`. That works only when the JWT secret is exposed as a Postgres setting. Hosted staging does not expose that setting, so the CLI hosted audit failed with:

`Agent token exchange failed: unrecognized configuration parameter "app.settings.jwt_secret"`

## Impact

After this lands and staging deploys, the existing rotated staging `sonde_ak_...` audit token should exchange successfully without storing or exposing a plaintext password. Staging promotion can then rerun the hosted CLI audit and proceed toward the guarded staging to main PR flow.

## Validation

- `bash scripts/ci/core.sh server`
- `bash scripts/ci/data.sh`
- `bash scripts/ci/auth.sh`
- `node server/scripts/hosted-env-contract.mjs check-parity && bash scripts/ci/check-hosted-workflow-action.sh`
- `bash scripts/ci/browser.sh smoke`
- `bash scripts/ci/browser.sh regression`
- `bash scripts/ci/core.sh cli`
- `git diff --check`