### PR TITLE
[codex] Bump CLI schema requirement to 5

### DIFF
--- a/cli/src/sonde/db/compat.py
+++ b/cli/src/sonde/db/compat.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 # Bump this when a migration adds features the CLI requires.
 # The corresponding migration should run:
 #   UPDATE schema_version SET version = <N>, updated_at = now();
-MINIMUM_SCHEMA_VERSION = 4
+MINIMUM_SCHEMA_VERSION = 5
 
 # Cached per-process after the first successful check.
 _checked: bool = False


### PR DESCRIPTION
## What changed

Bumps `MINIMUM_SCHEMA_VERSION` from `4` to `5` so hosted staging runtime parity expects the schema version introduced by `20260417000002_hosted_agent_exchange_session.sql`.

## Why

After PR #190 landed, staging deployed correctly and the agent reported the new commit with `schemaVersion: "5"`. The staging config/smoke workflows still read expected schema `4` from `cli/src/sonde/db/compat.py`, so they timed out on runtime parity despite the deployed agent being current.

## Validation

- `cd cli && uv run ruff check src/sonde/db/compat.py tests/test_compat.py`
- `cd cli && uv run ruff format --check src/sonde/db/compat.py tests/test_compat.py`
- `cd cli && uv run ty check src/sonde/db/compat.py`
- `cd cli && uv run pytest tests/test_compat.py --tb=short`
- workflow schema extraction now returns `5`
- `git diff --check`