### PR TITLE
[codex] Harden hosted CLI audit checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
             SOURCE_SUPABASE_ANON_KEY: "sb_publishable_stage_test",
             SOURCE_SMOKE_USER_EMAIL: "stage-smoke@example.com",
             SOURCE_SMOKE_USER_PASSWORD: "not-a-real-password",
-            SOURCE_CLI_AUDIT_TOKEN: "stage-cli-token",
+            SOURCE_CLI_AUDIT_TOKEN: "sonde_ak_stage-cli-token",
             SOURCE_RUNTIME_AUDIT_TOKEN: "stage-runtime-token",
             SOURCE_GOOGLE_CLIENT_ID: "google-client-id",
             SOURCE_GOOGLE_CLIENT_SECRET: "google-client-secret",

--- a/.github/workflows/cli-hosted-audit.yml
+++ b/.github/workflows/cli-hosted-audit.yml
@@ -66,6 +66,35 @@ jobs:
           google-client-id: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
           google-client-secret: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
 
+      - name: Resolve expected staging schema version
+        id: schema
+        run: |
+          VERSION="$(node - <<'NODE'
+          const fs = require("node:fs");
+          const text = fs.readFileSync("cli/src/sonde/db/compat.py", "utf8");
+          const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
+          if (!match) {
+            console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");
+            process.exit(1);
+          }
+          process.stdout.write(match[1]);
+          NODE
+          )"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for staging agent runtime parity
+        working-directory: server
+        env:
+          PARITY_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
+          PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
+          PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
+          PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_REQUIRED_KEYS: ${{ steps.contract.outputs.audit_required_runtime_keys_csv }}
+          PARITY_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
+          PARITY_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
+        run: node scripts/wait-for-runtime-parity.mjs
+
       - name: Install Sonde CLI
         run: |
           uv tool install --force ./cli
@@ -151,6 +180,35 @@ jobs:
           require-shared-rate-limit: ${{ vars.SONDE_REQUIRE_SHARED_RATE_LIMIT }}
           google-client-id: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
           google-client-secret: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
+
+      - name: Resolve expected production schema version
+        id: schema
+        run: |
+          VERSION="$(node - <<'NODE'
+          const fs = require("node:fs");
+          const text = fs.readFileSync("cli/src/sonde/db/compat.py", "utf8");
+          const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
+          if (!match) {
+            console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");
+            process.exit(1);
+          }
+          process.stdout.write(match[1]);
+          NODE
+          )"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for production agent runtime parity
+        working-directory: server
+        env:
+          PARITY_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
+          PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
+          PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
+          PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_REQUIRED_KEYS: ${{ steps.contract.outputs.audit_required_runtime_keys_csv }}
+          PARITY_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
+          PARITY_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
+        run: node scripts/wait-for-runtime-parity.mjs
 
       - name: Install Sonde CLI
         run: |

--- a/cli/src/sonde/cli.py
+++ b/cli/src/sonde/cli.py
@@ -205,11 +205,16 @@ def cli(ctx: click.Context, use_json: bool, quiet: bool, verbose: bool, no_color
     # Enforce auth for commands that require it
     sub = ctx.invoked_subcommand
     if sub and sub not in _NO_AUTH and not _is_help_request():
-        from sonde.auth import is_authenticated
+        from sonde.auth import NotAuthenticatedError, get_token, is_authenticated
 
         if not is_authenticated():
+            message = "Not logged in."
+            try:
+                get_token()
+            except NotAuthenticatedError as exc:
+                message = str(exc) or message
             raise SystemExit(
-                "Error: Not logged in.\n"
+                f"Error: {message}\n"
                 "  Run: sonde login\n\n"
                 "  For agents, set the SONDE_TOKEN environment variable."
             )

--- a/cli/tests/test_auth_commands.py
+++ b/cli/tests/test_auth_commands.py
@@ -695,6 +695,16 @@ def test_list_rejects_unauthenticated(runner: CliRunner, monkeypatch):
     assert "sonde login" in result.output
 
 
+def test_auth_guard_preserves_legacy_bot_token_message(runner: CliRunner, monkeypatch):
+    monkeypatch.setenv("SONDE_TOKEN", "sonde_bt_password-envelope")
+
+    result = runner.invoke(cli, ["program", "list", "--json"])
+
+    assert result.exit_code != 0
+    assert "Legacy password-bundle agent tokens" in result.output
+    assert "sonde admin create-token" in result.output
+
+
 def test_show_rejects_unauthenticated(runner: CliRunner, monkeypatch):
     result = _invoke_unauthenticated(runner, monkeypatch, "show", "EXP-0001")
     assert result.exit_code != 0

--- a/server/scripts/lib/hosted-env-contract.mjs
+++ b/server/scripts/lib/hosted-env-contract.mjs
@@ -49,6 +49,14 @@ function chooseSource(primary, fallback = "") {
   return trim(primary) || trim(fallback);
 }
 
+function classifyCliAuditToken(value) {
+  const token = trim(value);
+  if (!token) return "missing";
+  if (token.startsWith("sonde_ak_")) return "opaque";
+  if (token.startsWith("sonde_bt_")) return "legacy-password-bundle";
+  return "unsupported";
+}
+
 const VALIDATION_PROFILES = new Set([
   "full",
   "deploy-db",
@@ -130,7 +138,7 @@ function profileFlags(profile) {
         requireSupabaseAnonKey: true,
         requireSmokeUser: true,
         requireCliAuditToken: true,
-        requireRuntimeAuditToken: false,
+        requireRuntimeAuditToken: true,
         requireGoogleOAuth: false,
         requireSharedRateLimit: false,
         requireExpectedProgram: true,
@@ -309,6 +317,7 @@ export function resolveHostedEnvironment(
   if (!environment) {
     throw new Error(`Unknown hosted environment '${name}'.`);
   }
+  const cliAuditToken = trim(env.HOSTED_CLI_AUDIT_TOKEN);
 
   return {
     schemaVersion: contract.schemaVersion,
@@ -322,7 +331,8 @@ export function resolveHostedEnvironment(
     supabaseAnonKey: trim(env.HOSTED_SUPABASE_ANON_KEY),
     smokeUserEmailConfigured: Boolean(trim(env.HOSTED_SMOKE_USER_EMAIL)),
     smokeUserPasswordConfigured: Boolean(trim(env.HOSTED_SMOKE_USER_PASSWORD)),
-    cliAuditTokenConfigured: Boolean(trim(env.HOSTED_CLI_AUDIT_TOKEN)),
+    cliAuditTokenConfigured: Boolean(cliAuditToken),
+    cliAuditTokenKind: classifyCliAuditToken(cliAuditToken),
     runtimeAuditTokenConfigured: Boolean(trim(env.HOSTED_RUNTIME_AUDIT_TOKEN)),
     redisUrlConfigured: Boolean(trim(env.HOSTED_REDIS_URL)),
     redisTokenConfigured: Boolean(trim(env.HOSTED_REDIS_TOKEN)),
@@ -445,7 +455,8 @@ export function resolveHostedGithubEnvironmentEnv(env = process.env) {
 
 export function validateResolvedHostedEnvironment(resolved, profile = "full") {
   const errors = [];
-  const flags = profileFlags(profile);
+  const validationProfile = getValidationProfile(profile);
+  const flags = profileFlags(validationProfile);
   const requireAgentUrl =
     typeof flags.requireAgentUrl === "function"
       ? flags.requireAgentUrl(resolved.requirements.agentUrlRequired)
@@ -516,8 +527,24 @@ export function validateResolvedHostedEnvironment(resolved, profile = "full") {
     }
   }
 
-  if (requireCliAuditToken && !resolved.cliAuditTokenConfigured) {
-    errors.push("HOSTED_CLI_AUDIT_TOKEN is required.");
+  if (requireCliAuditToken) {
+    if (!resolved.cliAuditTokenConfigured) {
+      errors.push("HOSTED_CLI_AUDIT_TOKEN is required.");
+    } else if (
+      validationProfile === "cli-audit" &&
+      resolved.cliAuditTokenKind === "legacy-password-bundle"
+    ) {
+      errors.push(
+        "HOSTED_CLI_AUDIT_TOKEN uses legacy password-bundle agent token format (sonde_bt_); create a new opaque token with: sonde admin create-token.",
+      );
+    } else if (
+      validationProfile === "cli-audit" &&
+      resolved.cliAuditTokenKind !== "opaque"
+    ) {
+      errors.push(
+        "HOSTED_CLI_AUDIT_TOKEN must be an opaque agent token that starts with sonde_ak_.",
+      );
+    }
   }
 
   if (requireRuntimeAuditToken && !resolved.runtimeAuditTokenConfigured) {

--- a/server/scripts/run-cli-hosted-audit.mjs
+++ b/server/scripts/run-cli-hosted-audit.mjs
@@ -2,6 +2,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync, spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const OPAQUE_AGENT_TOKEN_PREFIX = "sonde_ak_";
+const LEGACY_BOT_TOKEN_PREFIX = "sonde_bt_";
 
 function requiredEnv(name) {
   const value = process.env[name]?.trim();
@@ -31,6 +35,23 @@ async function requestJson(url, init) {
 function parsePositiveInt(value, fallback) {
   const parsed = Number.parseInt(value ?? "", 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function validateAgentAuditToken(token) {
+  const value = token?.trim() ?? "";
+  if (!value) {
+    throw new Error("CLI_AUDIT_AUTH_MODE=token requires CLI_AUDIT_SONDE_TOKEN.");
+  }
+  if (value.startsWith(LEGACY_BOT_TOKEN_PREFIX)) {
+    throw new Error(
+      "CLI_AUDIT_SONDE_TOKEN uses legacy password-bundle agent token format (sonde_bt_); create a new opaque token with: sonde admin create-token.",
+    );
+  }
+  if (!value.startsWith(OPAQUE_AGENT_TOKEN_PREFIX)) {
+    throw new Error(
+      "CLI_AUDIT_SONDE_TOKEN must be an opaque agent token that starts with sonde_ak_.",
+    );
+  }
 }
 
 function sleep(ms) {
@@ -258,9 +279,7 @@ async function main() {
   }
 
   if (authMode === "token") {
-    if (!sondeToken) {
-      throw new Error("CLI_AUDIT_AUTH_MODE=token requires CLI_AUDIT_SONDE_TOKEN.");
-    }
+    validateAgentAuditToken(sondeToken);
     cliEnv.SONDE_TOKEN = sondeToken;
     if (agentBase) {
       cliEnv.SONDE_AGENT_HTTP_BASE = agentBase;
@@ -408,7 +427,9 @@ async function main() {
   console.log(JSON.stringify(summary));
 }
 
-main().catch((error) => {
-  console.error("[run-cli-hosted-audit] Failed:", error.message);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error("[run-cli-hosted-audit] Failed:", error.message);
+    process.exit(1);
+  });
+}

--- a/server/scripts/run-cli-hosted-audit.test.mjs
+++ b/server/scripts/run-cli-hosted-audit.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { validateAgentAuditToken } from "./run-cli-hosted-audit.mjs";
+
+describe("run-cli-hosted-audit", () => {
+  it("accepts opaque agent audit tokens", () => {
+    assert.doesNotThrow(() => validateAgentAuditToken("sonde_ak_secret"));
+  });
+
+  it("rejects legacy password-bundle audit tokens", () => {
+    assert.throws(
+      () => validateAgentAuditToken("sonde_bt_password-envelope"),
+      /legacy password-bundle agent token format/,
+    );
+  });
+
+  it("rejects non-opaque audit tokens", () => {
+    assert.throws(
+      () => validateAgentAuditToken("plain-token"),
+      /must be an opaque agent token/,
+    );
+  });
+});

--- a/server/scripts/test-sequential.mjs
+++ b/server/scripts/test-sequential.mjs
@@ -5,24 +5,28 @@ import { fileURLToPath } from "node:url";
 
 const serverRoot = fileURLToPath(new URL("..", import.meta.url));
 const sourceRoot = join(serverRoot, "src");
+const scriptsRoot = join(serverRoot, "scripts");
 
-function collectTestFiles(directory) {
+function collectTestFiles(directory, suffix) {
   const entries = readdirSync(directory, { withFileTypes: true });
   const files = [];
   for (const entry of entries) {
     const entryPath = join(directory, entry.name);
     if (entry.isDirectory()) {
-      files.push(...collectTestFiles(entryPath));
+      files.push(...collectTestFiles(entryPath, suffix));
       continue;
     }
-    if (entry.isFile() && entry.name.endsWith(".test.ts")) {
+    if (entry.isFile() && entry.name.endsWith(suffix)) {
       files.push(entryPath);
     }
   }
   return files;
 }
 
-const testFiles = collectTestFiles(sourceRoot)
+const testFiles = [
+  ...collectTestFiles(sourceRoot, ".test.ts"),
+  ...collectTestFiles(scriptsRoot, ".test.mjs"),
+]
   .sort((left, right) => left.localeCompare(right))
   .map((file) => relative(serverRoot, file));
 

--- a/server/src/hosted-env-contract.test.ts
+++ b/server/src/hosted-env-contract.test.ts
@@ -21,7 +21,7 @@ describe("hosted environment contract", () => {
       HOSTED_SUPABASE_ANON_KEY: "sb_publishable_stage",
       HOSTED_SMOKE_USER_EMAIL: "smoke@aeolus.earth",
       HOSTED_SMOKE_USER_PASSWORD: "secret",
-      HOSTED_CLI_AUDIT_TOKEN: "cli-audit",
+      HOSTED_CLI_AUDIT_TOKEN: "sonde_ak_cli-audit",
       HOSTED_RUNTIME_AUDIT_TOKEN: "runtime-audit",
       HOSTED_GOOGLE_CLIENT_ID: "google-id",
       HOSTED_GOOGLE_CLIENT_SECRET: "google-secret",
@@ -74,7 +74,7 @@ describe("hosted environment contract", () => {
       HOSTED_SUPABASE_ANON_KEY: "sb_publishable_prod",
       HOSTED_SMOKE_USER_EMAIL: "smoke@aeolus.earth",
       HOSTED_SMOKE_USER_PASSWORD: "secret",
-      HOSTED_CLI_AUDIT_TOKEN: "cli-audit",
+      HOSTED_CLI_AUDIT_TOKEN: "sonde_ak_cli-audit",
       HOSTED_RUNTIME_AUDIT_TOKEN: "runtime-audit",
       HOSTED_GOOGLE_CLIENT_ID: "google-id",
       HOSTED_GOOGLE_CLIENT_SECRET: "google-secret",
@@ -94,12 +94,61 @@ describe("hosted environment contract", () => {
       HOSTED_SUPABASE_ANON_KEY: "sb_publishable_stage",
       HOSTED_SMOKE_USER_EMAIL: "smoke@aeolus.earth",
       HOSTED_SMOKE_USER_PASSWORD: "secret",
-      HOSTED_CLI_AUDIT_TOKEN: "cli-audit",
+      HOSTED_CLI_AUDIT_TOKEN: "sonde_ak_cli-audit",
+      HOSTED_RUNTIME_AUDIT_TOKEN: "runtime-audit",
     });
 
     assert.deepEqual(validateResolvedHostedEnvironment(resolved, "cli-audit"), [
       "HOSTED_AGENT_URL is required.",
     ]);
+  });
+
+  it("rejects legacy password-bundle tokens for CLI token audits", () => {
+    const resolved = resolveHostedEnvironment("production", {
+      HOSTED_AGENT_URL: "https://agent.example.com",
+      HOSTED_SUPABASE_PROJECT_REF: "prodproj",
+      HOSTED_SUPABASE_ANON_KEY: "sb_publishable_prod",
+      HOSTED_SMOKE_USER_EMAIL: "smoke@aeolus.earth",
+      HOSTED_SMOKE_USER_PASSWORD: "secret",
+      HOSTED_CLI_AUDIT_TOKEN: "sonde_bt_password-envelope",
+      HOSTED_RUNTIME_AUDIT_TOKEN: "runtime-audit",
+    });
+
+    assert.deepEqual(validateResolvedHostedEnvironment(resolved, "cli-audit"), [
+      "HOSTED_CLI_AUDIT_TOKEN uses legacy password-bundle agent token format (sonde_bt_); create a new opaque token with: sonde admin create-token.",
+    ]);
+  });
+
+  it("rejects non-opaque CLI audit tokens for CLI token audits", () => {
+    const resolved = resolveHostedEnvironment("production", {
+      HOSTED_AGENT_URL: "https://agent.example.com",
+      HOSTED_SUPABASE_PROJECT_REF: "prodproj",
+      HOSTED_SUPABASE_ANON_KEY: "sb_publishable_prod",
+      HOSTED_SMOKE_USER_EMAIL: "smoke@aeolus.earth",
+      HOSTED_SMOKE_USER_PASSWORD: "secret",
+      HOSTED_CLI_AUDIT_TOKEN: "plain-token",
+      HOSTED_RUNTIME_AUDIT_TOKEN: "runtime-audit",
+    });
+
+    assert.deepEqual(validateResolvedHostedEnvironment(resolved, "cli-audit"), [
+      "HOSTED_CLI_AUDIT_TOKEN must be an opaque agent token that starts with sonde_ak_.",
+    ]);
+  });
+
+  it("does not validate CLI audit token shape outside CLI token audits", () => {
+    const resolved = resolveHostedEnvironment("production", {
+      HOSTED_AGENT_URL: "https://agent.example.com",
+      HOSTED_SUPABASE_PROJECT_REF: "prodproj",
+      HOSTED_SUPABASE_ANON_KEY: "sb_publishable_prod",
+      HOSTED_SMOKE_USER_EMAIL: "smoke@aeolus.earth",
+      HOSTED_SMOKE_USER_PASSWORD: "secret",
+      HOSTED_CLI_AUDIT_TOKEN: "sonde_bt_password-envelope",
+      HOSTED_RUNTIME_AUDIT_TOKEN: "runtime-audit",
+      HOSTED_GOOGLE_CLIENT_ID: "google-id",
+      HOSTED_GOOGLE_CLIENT_SECRET: "google-secret",
+    });
+
+    assert.deepEqual(validateResolvedHostedEnvironment(resolved, "config-audit"), []);
   });
 
   it("formats GitHub outputs with the contract-derived smoke expectations", () => {


### PR DESCRIPTION
## Summary

This hardens the hosted CLI audit path that caught the production failure on `main`.

Root cause verified before this branch: the `CLI Hosted Audit` failure on `main` was `sonde program list --json failed: Error: Not logged in.` The production audit secret was much older than staging and was consistent with a stale legacy password-bundle token. This branch makes that failure mode explicit and adds deploy/runtime parity waiting before the hosted CLI reads from the environment.

## Changes

- Reject legacy `sonde_bt_` password-bundle tokens in hosted CLI audit validation with a specific remediation message.
- Require the runtime audit token for the `cli-audit` hosted contract profile so parity checks can run before CLI reads.
- Wait for hosted agent runtime parity in both staging and production CLI audit jobs before installing/running the CLI.
- Preserve detailed agent-token auth errors in the CLI auth guard instead of flattening them to generic `Not logged in`.
- Include script-level Node tests in the server sequential test runner so hosted audit script tests run in `npm test`.

## Local verification

- `bash scripts/ci/core.sh guard`
- `bash scripts/ci/core.sh cli`
- `bash scripts/ci/core.sh server`
- Targeted CLI auth tests for legacy token messaging
- Targeted hosted contract and hosted audit script tests
- `git diff --check`

## Operational note

The production hosted audit secret still needs rotation to a fresh opaque `sonde_ak_` token. I attempted to rotate locally, but the local Sonde admin session is expired and this shell has no `SONDE_TOKEN` or service-role credential available. The code now makes that exact stale-secret failure obvious in CI instead of disguising it as a generic login failure.