### PR TITLE
[codex] Operationalize agent token hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,3 +631,11 @@ jobs:
       - if: steps.gate.outputs.run == 'true'
         name: Run data integration
         run: bash scripts/ci/data.sh
+
+      - if: failure() && steps.gate.outputs.run == 'true'
+        name: Upload RLS snapshot on failure
+        uses: actions/upload-artifact@v7
+        with:
+          name: rls-snapshot
+          path: /tmp/sonde-rls-snapshot.txt
+          if-no-files-found: ignore

--- a/cli/src/sonde/auth.py
+++ b/cli/src/sonde/auth.py
@@ -718,7 +718,8 @@ def _agent_token_fingerprint(token: str) -> str:
 def _legacy_bot_token_message() -> str:
     return (
         "Legacy password-bundle agent tokens (sonde_bt_) are no longer supported. "
-        "Ask an admin to create a new opaque token with: sonde admin create-token"
+        "Rotate this credential by asking a program admin to create a new opaque "
+        "token with: sonde admin create-token"
     )
 
 

--- a/cli/src/sonde/commands/admin.py
+++ b/cli/src/sonde/commands/admin.py
@@ -82,14 +82,21 @@ def create_token(ctx: click.Context, name: str, programs: str, expires: int) -> 
     else:
         expires_str = str(token_data.get("expires_at", ""))[:10]
         token_str = str(token_data.get("token", ""))
+        token_preview = str(token_data.get("token_preview", ""))
         print_success(f"Token created: {name}")
         err.print(f"  Programs: {', '.join(program_list)}")
         err.print(f"  Expires:  {expires_str}")
+        if token_preview:
+            err.print(f"  Preview:  {token_preview}")
         err.print()
         err.print(f"  [bold]Token: {token_str}[/bold]")
         err.print()
         err.print("  [yellow]Save this token now — it cannot be retrieved later.[/yellow]")
-        err.print("  Set it as an environment variable for your agent:")
+        err.print(
+            "  This opaque token is exchanged for short-lived sessions; "
+            "revocation and expiry are enforced server-side."
+        )
+        err.print("  Set it as an environment variable for your agent or CI job:")
         err.print(f'    export SONDE_TOKEN="{token_str}"')
 
 

--- a/cli/src/sonde/diagnostics.py
+++ b/cli/src/sonde/diagnostics.py
@@ -313,7 +313,14 @@ def build_local_section(*, deep: bool = False) -> DoctorSection:
 
 def build_auth_section(*, deep: bool = False) -> DoctorSection:
     """Inspect current auth state."""
-    checks = [check_auth_session(), check_device_login_base(), check_device_login_health()]
+    checks = [
+        check_auth_token_source(),
+        check_auth_session(),
+        check_opaque_agent_exchange_cache(),
+        check_auth_environment_overrides(),
+        check_device_login_base(),
+        check_device_login_health(),
+    ]
     return build_section("auth", checks, required=True)
 
 
@@ -598,6 +605,250 @@ def check_auth_session() -> DoctorCheck:
         }
 
     return _timed_check("auth-session", "Current session", build, required=True)
+
+
+def check_auth_token_source() -> DoctorCheck:
+    """Classify the configured auth source without exposing credential material."""
+
+    def build() -> dict[str, Any]:
+        token = os.environ.get("SONDE_TOKEN", "").strip()
+        if not token:
+            session = auth.load_session()
+            if session and isinstance(session.get("access_token"), str):
+                return {
+                    "status": "info",
+                    "summary": "No SONDE_TOKEN set; using stored human session.",
+                    "details": [f"Session store: {auth.SESSION_FILE}"],
+                    "metadata": {"kind": "human-session", "has_session": True},
+                }
+            return {
+                "status": "info",
+                "summary": "No SONDE_TOKEN set and no stored session detected.",
+                "details": [f"Session store: {auth.SESSION_FILE}"],
+                "metadata": {"kind": "none", "has_session": False},
+            }
+
+        if token.startswith(auth.BOT_TOKEN_PREFIX):
+            return {
+                "status": "error",
+                "summary": "Legacy password-bundle SONDE_TOKEN is unsupported.",
+                "details": [
+                    "Tokens that start with sonde_bt_ contained a bot password "
+                    "and must be rotated.",
+                    "New agent credentials must start with sonde_ak_ and exchange "
+                    "through the hosted server.",
+                ],
+                "fix": "Ask a program admin to create a fresh token: sonde admin create-token",
+                "metadata": {"kind": "legacy-password-bundle"},
+            }
+
+        if token.startswith(auth.OPAQUE_AGENT_TOKEN_PREFIX):
+            origin, source = _resolved_agent_exchange_origin()
+            details = [
+                "Credential kind: opaque agent token (sonde_ak_).",
+                "The CLI exchanges this token for a short-lived Supabase session.",
+            ]
+            if origin:
+                details.append(f"Exchange origin: {origin} ({source})")
+            return {
+                "status": "ok",
+                "summary": "SONDE_TOKEN is an opaque exchange-backed agent token.",
+                "details": details,
+                "metadata": {
+                    "kind": "opaque-agent-token",
+                    "exchange_origin": origin,
+                    "exchange_origin_source": source,
+                },
+            }
+
+        if token.startswith(auth.AGENT_TOKEN_PREFIX):
+            return {
+                "status": "warn",
+                "summary": "SONDE_TOKEN uses the old signed agent-token format.",
+                "details": [
+                    "Old sonde_at_ tokens are not exchange-backed, so revocation and expiry "
+                    "diagnostics are weaker than with sonde_ak_ tokens.",
+                    "Rotate this credential to the opaque token model.",
+                ],
+                "fix": "Ask a program admin to create a fresh token: sonde admin create-token",
+                "metadata": {"kind": "signed-agent-token"},
+            }
+
+        claims = _safe_token_claims(token)
+        if _looks_like_access_token(claims):
+            return {
+                "status": "warn",
+                "summary": "SONDE_TOKEN looks like a raw Supabase access token.",
+                "details": [
+                    "Raw access tokens are bearer credentials and are not revocable through "
+                    "Sonde agent-token management.",
+                    "Use human login for people or sonde_ak_ tokens for agents.",
+                ],
+                "fix": "For agents, rotate to: sonde admin create-token",
+                "metadata": {"kind": "raw-access-token", "programs": _claim_programs(claims)},
+            }
+
+        return {
+            "status": "warn",
+            "summary": "SONDE_TOKEN has an unrecognized format.",
+            "details": [
+                "Expected an opaque agent token that starts with sonde_ak_, or a valid "
+                "Supabase access token for advanced workflows."
+            ],
+            "fix": "Unset SONDE_TOKEN and run sonde login, or create a fresh agent token.",
+            "metadata": {"kind": "unknown"},
+        }
+
+    return _timed_check("auth-token-source", "Auth source", build, required=True)
+
+
+def check_opaque_agent_exchange_cache() -> DoctorCheck:
+    """Report the cached short-lived session for opaque agent tokens."""
+
+    def build() -> dict[str, Any]:
+        token = os.environ.get("SONDE_TOKEN", "").strip()
+        if not token.startswith(auth.OPAQUE_AGENT_TOKEN_PREFIX):
+            return {
+                "status": "skipped",
+                "summary": "Opaque agent exchange cache not applicable.",
+            }
+
+        session = auth._agent_cached_session(token)
+        if not session:
+            return {
+                "status": "info",
+                "summary": "No cached agent exchange session found yet.",
+                "details": [
+                    "The next authenticated command will exchange SONDE_TOKEN through "
+                    "/auth/agent/exchange."
+                ],
+                "metadata": {"has_cached_session": False},
+            }
+
+        access_token = session.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            return {
+                "status": "warn",
+                "summary": "Cached agent exchange session is incomplete.",
+                "details": [f"Cache file: {auth.AGENT_SESSION_FILE}"],
+                "fix": "Delete the cache and retry: rm ~/.config/sonde/agent-session.json",
+                "metadata": {"has_cached_session": True, "valid": False},
+            }
+
+        claims = _safe_token_claims(access_token)
+        expires_at = _claim_expiry(claims)
+        expired = auth._is_expired(access_token)
+        programs = _claim_programs(claims)
+        seconds_left = (
+            int((expires_at - datetime.now(UTC)).total_seconds())
+            if expires_at is not None
+            else None
+        )
+        details = [f"Cache file: {auth.AGENT_SESSION_FILE}"]
+        if expires_at is not None:
+            details.append(f"Cached session expires: {expires_at.isoformat()}")
+        if programs:
+            details.append(f"Programs in cached claims: {', '.join(programs)}")
+
+        metadata: dict[str, Any] = {
+            "has_cached_session": True,
+            "valid": not expired,
+            "expires_at": expires_at.isoformat() if expires_at is not None else None,
+            "seconds_left": seconds_left,
+            "programs": programs or [],
+            "token_id": claims.get("app_metadata", {}).get("token_id")
+            if isinstance(claims.get("app_metadata"), dict)
+            else None,
+        }
+
+        if expired:
+            return {
+                "status": "info",
+                "summary": "Cached agent session is expired and will be re-exchanged.",
+                "details": details,
+                "metadata": metadata,
+            }
+
+        if seconds_left is not None and seconds_left <= 300:
+            return {
+                "status": "info",
+                "summary": "Cached agent session is valid but near expiry.",
+                "details": [
+                    *details,
+                    "Sonde will automatically exchange the opaque token again when needed.",
+                ],
+                "metadata": metadata,
+            }
+
+        return {
+            "status": "ok",
+            "summary": "Cached agent exchange session is valid.",
+            "details": details,
+            "metadata": metadata,
+        }
+
+    return _timed_check("auth-agent-exchange-cache", "Agent exchange cache", build)
+
+
+def check_auth_environment_overrides() -> DoctorCheck:
+    """Explain env vars that change auth, config, or hosted-target precedence."""
+
+    def build() -> dict[str, Any]:
+        details: list[str] = []
+        metadata: dict[str, Any] = {}
+        token = os.environ.get("SONDE_TOKEN", "").strip()
+        session = auth.load_session()
+
+        if token:
+            kind = auth_source()
+            details.append(f"SONDE_TOKEN is set; credential kind: {kind}.")
+            metadata["sonde_token_kind"] = kind
+            if session and isinstance(session.get("access_token"), str):
+                details.append("SONDE_TOKEN overrides the stored human session for this shell.")
+                metadata["token_shadows_session"] = True
+
+        if os.environ.get("SONDE_AGENT_HTTP_BASE"):
+            details.append("SONDE_AGENT_HTTP_BASE is set and takes precedence for hosted auth/API.")
+            metadata["sonde_agent_http_base_set"] = True
+            if os.environ.get("SONDE_UI_URL"):
+                details.append("SONDE_UI_URL is also set, but SONDE_AGENT_HTTP_BASE wins for auth.")
+                metadata["agent_base_shadows_ui_url"] = True
+        elif os.environ.get("SONDE_UI_URL"):
+            details.append("SONDE_UI_URL is set and will be used for hosted activation.")
+            metadata["sonde_ui_url_set"] = True
+
+        if os.environ.get("AEOLUS_SUPABASE_URL"):
+            details.append("AEOLUS_SUPABASE_URL is set and overrides the default Supabase project.")
+            metadata["aeolus_supabase_url_set"] = True
+        if os.environ.get("AEOLUS_SUPABASE_ANON_KEY"):
+            details.append("AEOLUS_SUPABASE_ANON_KEY is set; value is intentionally not displayed.")
+            metadata["aeolus_supabase_anon_key_set"] = True
+        if os.environ.get("SONDE_CONFIG_DIR"):
+            details.append(f"SONDE_CONFIG_DIR is set; config/session path: {auth.CONFIG_DIR}")
+            metadata["sonde_config_dir"] = str(auth.CONFIG_DIR)
+
+        if not details:
+            return {
+                "status": "ok",
+                "summary": "No auth-related environment overrides detected.",
+                "metadata": metadata,
+            }
+
+        status: DoctorStatus = "warn" if metadata.get("token_shadows_session") else "info"
+        summary = "Auth environment overrides detected."
+        if metadata.get("token_shadows_session"):
+            summary = "SONDE_TOKEN is shadowing a stored human session."
+        return {
+            "status": status,
+            "summary": summary,
+            "details": details,
+            "fix": "Unset SONDE_TOKEN to use your stored human login."
+            if metadata.get("token_shadows_session")
+            else None,
+            "metadata": metadata,
+        }
+
+    return _timed_check("auth-env-overrides", "Auth environment", build)
 
 
 def check_device_login_base() -> DoctorCheck:
@@ -1243,6 +1494,43 @@ def auth_source() -> str:
     if token.startswith(auth.AGENT_TOKEN_PREFIX):
         return "signed-agent-token"
     return "token"
+
+
+def _resolved_agent_exchange_origin() -> tuple[str, str]:
+    """Return the normalized hosted exchange origin and its precedence source."""
+    resolved, source = auth._resolve_hosted_login_origin()
+    normalized = auth._normalize_hosted_login_origin(resolved)
+    return normalized, source
+
+
+def _safe_token_claims(token: str) -> dict[str, Any]:
+    try:
+        return auth._token_claims(token)
+    except Exception:
+        return {}
+
+
+def _claim_programs(claims: dict[str, Any]) -> list[str]:
+    programs = auth._claim_programs(claims)
+    return programs or []
+
+
+def _claim_expiry(claims: dict[str, Any]) -> datetime | None:
+    exp = claims.get("exp")
+    if isinstance(exp, (int, float)):
+        return datetime.fromtimestamp(exp, UTC)
+    return None
+
+
+def _looks_like_access_token(claims: dict[str, Any]) -> bool:
+    if not claims:
+        return False
+    sub = claims.get("sub")
+    if not isinstance(sub, str) or not sub.strip():
+        return False
+    role = claims.get("role")
+    aud = claims.get("aud")
+    return role == "authenticated" or aud == "authenticated"
 
 
 def detect_s3_credentials() -> str | None:

--- a/cli/tests/test_admin_commands.py
+++ b/cli/tests/test_admin_commands.py
@@ -29,6 +29,9 @@ class TestCreateToken:
             )
         assert result.exit_code == 0
         assert "test-bot" in result.output
+        assert "Preview:" in result.output
+        assert "short-lived sessions" in result.output
+        assert "export SONDE_TOKEN=" in result.output
 
     def test_create_token_json(self, runner: CliRunner, patched_db: MagicMock):
         with patch(

--- a/cli/tests/test_doctor.py
+++ b/cli/tests/test_doctor.py
@@ -2,19 +2,25 @@
 
 from __future__ import annotations
 
+import base64
+import json
 import sys
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from urllib.error import HTTPError, URLError
 
+from sonde import auth
 from sonde.cli import cli
 from sonde.commands.upgrade import UpgradeCheckResult
 from sonde.diagnostics import (
     GIT_TOOL_INSTALL_COMMAND,
+    check_auth_environment_overrides,
+    check_auth_token_source,
     check_cli_update,
     check_device_login_base,
     check_device_login_health,
     check_install_shadows,
+    check_opaque_agent_exchange_cache,
     check_s3_settings,
     check_stac_settings,
     run_doctor,
@@ -27,6 +33,14 @@ from sonde.models.doctor import (
     DoctorStatus,
     DoctorSummary,
 )
+
+
+def _jwt(payload: dict[str, object]) -> str:
+    def encode(value: dict[str, object]) -> str:
+        raw = json.dumps(value, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+    return f"{encode({'alg': 'none', 'typ': 'JWT'})}.{encode(payload)}.signature"
 
 
 def _check(
@@ -273,6 +287,91 @@ def test_check_device_login_health_warns_on_404(monkeypatch) -> None:
 
     assert check.status == "warn"
     assert "returned 404" in check.summary.lower()
+
+
+def test_check_auth_token_source_rejects_legacy_bot_token(monkeypatch):
+    monkeypatch.setenv("SONDE_TOKEN", "sonde_bt_password-envelope")
+
+    check = check_auth_token_source()
+
+    assert check.id == "auth-token-source"
+    assert check.status == "error"
+    assert "Legacy password-bundle" in check.summary
+    assert check.metadata["kind"] == "legacy-password-bundle"
+    assert "sonde admin create-token" in (check.fix or "")
+
+
+def test_check_auth_token_source_reports_opaque_agent_token(monkeypatch):
+    monkeypatch.setenv("SONDE_TOKEN", "sonde_ak_secret")
+    monkeypatch.setattr(
+        "sonde.diagnostics.auth._resolve_hosted_login_origin",
+        lambda: ("https://agent.example.com/", "agent-http-base"),
+    )
+    monkeypatch.setattr(
+        "sonde.diagnostics.auth._normalize_hosted_login_origin",
+        lambda value: value.rstrip("/"),
+    )
+
+    check = check_auth_token_source()
+
+    assert check.status == "ok"
+    assert check.metadata["kind"] == "opaque-agent-token"
+    assert check.metadata["exchange_origin"] == "https://agent.example.com"
+    assert "short-lived" in "\n".join(check.details)
+
+
+def test_check_opaque_agent_exchange_cache_reports_cached_programs(monkeypatch, tmp_path):
+    token = "sonde_ak_secret"
+    expires_at = datetime.now(UTC) + timedelta(minutes=20)
+    cached_access_token = _jwt(
+        {
+            "sub": "token-1",
+            "role": "authenticated",
+            "aud": "authenticated",
+            "exp": int(expires_at.timestamp()),
+            "app_metadata": {
+                "agent": True,
+                "token_id": "tok-001",
+                "programs": ["shared", "weather-intervention"],
+            },
+        }
+    )
+    cache_path = tmp_path / "agent-session.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "access_token": cached_access_token,
+                "agent_token_fingerprint": auth._agent_token_fingerprint(token),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SONDE_TOKEN", token)
+    monkeypatch.setattr(auth, "AGENT_SESSION_FILE", cache_path)
+
+    check = check_opaque_agent_exchange_cache()
+
+    assert check.status == "ok"
+    assert check.metadata["valid"] is True
+    assert check.metadata["programs"] == ["shared", "weather-intervention"]
+    assert check.metadata["token_id"] == "tok-001"
+
+
+def test_check_auth_environment_overrides_warns_when_token_shadows_session(monkeypatch):
+    monkeypatch.setenv("SONDE_TOKEN", "sonde_ak_secret")
+    monkeypatch.setenv("SONDE_AGENT_HTTP_BASE", "https://agent.example.com")
+    monkeypatch.setenv("SONDE_UI_URL", "https://ui.example.com")
+    monkeypatch.setattr(
+        "sonde.diagnostics.auth.load_session",
+        lambda: {"access_token": "stored-human-token"},
+    )
+
+    check = check_auth_environment_overrides()
+
+    assert check.status == "warn"
+    assert check.metadata["token_shadows_session"] is True
+    assert check.metadata["agent_base_shadows_ui_url"] is True
+    assert "Unset SONDE_TOKEN" in (check.fix or "")
 
 
 def test_check_install_shadows_reports_shadowed_binary(monkeypatch):

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -8,7 +8,7 @@ An admin creates a scoped token for the agent:
 sonde admin create-token -n "my-agent" -p weather-intervention,shared
 ```
 
-This prints a `sonde_bt_...` token. **Save it immediately** — it cannot be retrieved later.
+This prints a `sonde_ak_...` opaque token. **Save it immediately** — it cannot be retrieved later. Older `sonde_bt_...` password-bundle tokens are no longer supported and must be rotated.
 
 Options:
 - `-n` — agent name (used in activity logs as `agent/my-agent`)
@@ -31,7 +31,7 @@ Or add manually:
       "args": ["tsx", "src/index.ts"],
       "cwd": "/path/to/sonde/server",
       "env": {
-        "SONDE_TOKEN": "sonde_bt_..."
+        "SONDE_TOKEN": "sonde_ak_..."
       }
     }
   }
@@ -45,7 +45,7 @@ Same config in `.cursor/mcp.json`.
 ### CLI only (no MCP)
 
 ```bash
-export SONDE_TOKEN="sonde_bt_..."
+export SONDE_TOKEN="sonde_ak_..."
 sonde list          # verify access
 sonde brief         # see research state
 ```
@@ -53,7 +53,7 @@ sonde brief         # see research state
 ## 3. Verify
 
 ```bash
-SONDE_TOKEN="sonde_bt_..." sonde whoami
+SONDE_TOKEN="sonde_ak_..." sonde whoami
 # Should show: agent/my-agent
 ```
 
@@ -61,17 +61,18 @@ SONDE_TOKEN="sonde_bt_..." sonde whoami
 
 ```bash
 sonde admin list-tokens        # see all tokens + expiry
-sonde admin revoke-token <id>  # revoke a token
+sonde admin revoke-token <name>  # revoke a token by name
 ```
 
-Tokens expire after 365 days by default. Create a new one when expired.
+Opaque tokens expire after 365 days by default. The CLI exchanges them through the hosted Sonde server for short-lived Supabase sessions, so revocation and expiry are enforced by the `agent_tokens` row instead of by a password embedded in the token.
 
 ## Troubleshooting
 
 | Problem | Fix |
 |---------|-----|
 | "Not authenticated" | Check `SONDE_TOKEN` is set in the agent's environment |
-| "Bot token authentication failed" | Token may be expired — create a new one |
+| "Legacy password-bundle agent tokens" | Rotate the old `sonde_bt_...` token with `sonde admin create-token` |
+| "Invalid or expired agent token" | Token may be expired or revoked — create a new one |
 | MCP tools not appearing | Check `cwd` points to the `server/` directory with `package.json` |
 | "uv not found" | Install [uv](https://docs.astral.sh/uv/) — the MCP server spawns CLI via `uv run sonde` |
 | "Permission denied" on programs | Token was scoped to specific programs — create a new token with the right `-p` flag |

--- a/scripts/ci/data.sh
+++ b/scripts/ci/data.sh
@@ -83,6 +83,8 @@ if [[ "$file_count" != "$applied_count" ]]; then
   exit 1
 fi
 
+SONDE_SECURITY_ASSUME_READY=1 bash scripts/ci/security.sh
+
 (
   cd cli
   uv sync

--- a/scripts/ci/security.sh
+++ b/scripts/ci/security.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+printf '\n==> Security regression harness\n'
+
+SNAPSHOT_OUT="${SONDE_SECURITY_SNAPSHOT_OUT:-${RUNNER_TEMP:-/tmp}/sonde-rls-snapshot.txt}"
+ASSUME_READY="${SONDE_SECURITY_ASSUME_READY:-0}"
+
+psql_file() {
+  local file="$1"
+
+  if command -v psql >/dev/null 2>&1; then
+    PGPASSWORD=postgres psql \
+      -h 127.0.0.1 \
+      -p 54322 \
+      -U postgres \
+      -d postgres \
+      -v ON_ERROR_STOP=1 \
+      -f "$file"
+    return 0
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    local container
+    container="$(
+      docker ps --format '{{.Names}}' | awk '/^supabase_db_/ { print; exit }'
+    )"
+    if [[ -n "$container" ]]; then
+      docker exec -i "$container" psql \
+        -U postgres \
+        -d postgres \
+        -v ON_ERROR_STOP=1 \
+        -f /dev/stdin <"$file"
+      return 0
+    fi
+  fi
+
+  echo "::error::Unable to query the local Supabase Postgres instance. Install psql or ensure Docker can see the supabase_db_* container."
+  exit 1
+}
+
+cleanup() {
+  if [[ "$ASSUME_READY" != "1" ]]; then
+    supabase stop >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+capture_snapshot() {
+  mkdir -p "$(dirname "$SNAPSHOT_OUT")"
+  if psql_file scripts/security/rls-snapshot.sql >"$SNAPSHOT_OUT"; then
+    echo "RLS snapshot written to $SNAPSHOT_OUT"
+  else
+    echo "::warning::Could not capture RLS snapshot at $SNAPSHOT_OUT"
+  fi
+}
+
+if [[ "$ASSUME_READY" != "1" ]]; then
+  supabase start
+  bash scripts/ci/question-graph-migration.sh
+  supabase db reset --local --yes
+fi
+
+if ! psql_file scripts/security/rls-exploit-tests.sql; then
+  capture_snapshot
+  exit 1
+fi
+
+capture_snapshot

--- a/server/scripts/run-cli-hosted-audit.mjs
+++ b/server/scripts/run-cli-hosted-audit.mjs
@@ -54,6 +54,49 @@ export function validateAgentAuditToken(token) {
   }
 }
 
+export async function assertAgentExchangeRejectsInvalidTokens(agentBase) {
+  const base = agentBase?.trim().replace(/\/+$/, "") ?? "";
+  if (!base) {
+    throw new Error("Agent exchange negative probes require CLI_AUDIT_AGENT_BASE.");
+  }
+
+  const cases = [
+    {
+      label: "legacy password-bundle",
+      token: "sonde_bt_password-envelope-audit-probe",
+    },
+    {
+      label: "malformed opaque",
+      token: "sonde_ak_malformed-audit-probe",
+    },
+  ];
+
+  for (const testCase of cases) {
+    const response = await fetch(`${base}/auth/agent/exchange`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        token: testCase.token,
+        cli_version: "hosted-audit",
+        host_label: "hosted-audit-negative-probe",
+      }),
+    });
+
+    if (response.ok) {
+      throw new Error(
+        `Agent exchange unexpectedly accepted ${testCase.label} token probe.`
+      );
+    }
+
+    if (response.status < 400 || response.status >= 500) {
+      const body = await response.text();
+      throw new Error(
+        `Agent exchange rejected ${testCase.label} token with unexpected HTTP ${response.status}: ${body}`
+      );
+    }
+  }
+}
+
 function sleep(ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -278,6 +321,10 @@ async function main() {
     throw new Error("CLI_AUDIT_AUTH_MODE must be one of: auto, token, session.");
   }
 
+  if (agentBase) {
+    await assertAgentExchangeRejectsInvalidTokens(agentBase);
+  }
+
   if (authMode === "token") {
     validateAgentAuditToken(sondeToken);
     cliEnv.SONDE_TOKEN = sondeToken;
@@ -359,6 +406,7 @@ async function main() {
     allowWrite,
     briefKeys: Object.keys(brief),
     authMode,
+    agentExchangeNegativeProbes: Boolean(agentBase),
   };
 
   if (expectedExperimentId) {

--- a/server/scripts/run-cli-hosted-audit.test.mjs
+++ b/server/scripts/run-cli-hosted-audit.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
+import http from "node:http";
 import { describe, it } from "node:test";
-import { validateAgentAuditToken } from "./run-cli-hosted-audit.mjs";
+import {
+  assertAgentExchangeRejectsInvalidTokens,
+  validateAgentAuditToken,
+} from "./run-cli-hosted-audit.mjs";
 
 describe("run-cli-hosted-audit", () => {
   it("accepts opaque agent audit tokens", () => {
@@ -19,5 +23,65 @@ describe("run-cli-hosted-audit", () => {
       () => validateAgentAuditToken("plain-token"),
       /must be an opaque agent token/,
     );
+  });
+
+  it("passes when deployed exchange rejects invalid token probes", async () => {
+    const seen = [];
+    const server = http.createServer((request, response) => {
+      if (request.method !== "POST" || request.url !== "/auth/agent/exchange") {
+        response.writeHead(404).end();
+        return;
+      }
+
+      let raw = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        raw += chunk;
+      });
+      request.on("end", () => {
+        seen.push(JSON.parse(raw).token);
+        response
+          .writeHead(403, { "content-type": "application/json" })
+          .end(JSON.stringify({ error: { message: "Invalid or expired agent token." } }));
+      });
+    });
+
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+
+    try {
+      await assertAgentExchangeRejectsInvalidTokens(
+        `http://127.0.0.1:${address.port}`
+      );
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+
+    assert.deepEqual(seen, [
+      "sonde_bt_password-envelope-audit-probe",
+      "sonde_ak_malformed-audit-probe",
+    ]);
+  });
+
+  it("fails when deployed exchange accepts an invalid token probe", async () => {
+    const server = http.createServer((_request, response) => {
+      response
+        .writeHead(200, { "content-type": "application/json" })
+        .end(JSON.stringify({ access_token: "bad" }));
+    });
+
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+
+    try {
+      await assert.rejects(
+        assertAgentExchangeRejectsInvalidTokens(`http://127.0.0.1:${address.port}`),
+        /unexpectedly accepted/,
+      );
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
   });
 });


### PR DESCRIPTION
## Summary

This PR operationalizes the agent-token hardening work so the secure path is easier to use and harder to regress.

It tightens `sonde doctor` into the main support surface for auth issues by classifying token formats, detecting legacy `sonde_bt_` password-bundle tokens, reporting opaque `sonde_ak_` exchange cache state, showing JWT program claims when safely available, and calling out environment overrides that can shadow stored human sessions.

It also makes the RLS/security regression scripts first-class CI coverage by adding a reusable `scripts/ci/security.sh` harness and running it from the existing `data-integration` lane after migrations are applied. If that lane fails, CI now uploads an RLS snapshot artifact to make policy drift easier to inspect.

Finally, it improves the operational UX for agent admins and hosted audits: token creation output now shows a preview plus explicit short-lived-session/revocation guidance, agent setup docs describe the opaque-token model and rotation path, and the hosted CLI audit probes `/auth/agent/exchange` with synthetic invalid legacy/malformed tokens to prove deployed environments reject them.

## Validation

- `uv run ruff check src/ tests/` from `cli/`
- `uv run ruff format --check src/ tests/` from `cli/`
- `uv run ty check src/` from `cli/`
- `uv run pytest tests/test_doctor.py tests/test_admin_commands.py tests/test_auth_commands.py -q` from `cli/`
- `bash scripts/ci/core.sh cli`
- `bash scripts/ci/core.sh server`
- `bash scripts/ci/core.sh ui`
- `npm run lint && npm run build` from `server/`
- `npm test -- run-cli-hosted-audit.test.mjs` from `server/`
- `bash scripts/ci/core.sh guard`
- `bash scripts/ci/data.sh`
- `bash -n scripts/ci/security.sh scripts/ci/data.sh`
- YAML parse check for `.github/workflows/ci.yml`
- `git diff --check`

## Notes

The new security harness ran locally inside `scripts/ci/data.sh` and confirmed the auth-events, cross-program admin, opaque-token, expiry, and direct-exchange regression checks still pass after a full Supabase reset.