### PR TITLE
[codex] Add contractor program RBAC

### DIFF
--- a/cli/src/sonde/commands/admin.py
+++ b/cli/src/sonde/commands/admin.py
@@ -9,6 +9,7 @@ import click
 from postgrest.exceptions import APIError
 
 from sonde.cli_options import pass_output_options
+from sonde.db import admin_access as access_db
 from sonde.db import admin_tokens as db
 from sonde.db import artifacts as artifact_db
 from sonde.db.client import get_client, has_service_role_key
@@ -176,6 +177,152 @@ def revoke_token(ctx: click.Context, token_name: str, force: bool) -> None:
         print_success(f'Token "{token_name}" revoked')
 
 
+@admin.command("grant-user")
+@click.argument("email")
+@click.option("--program", "-p", required=True, help="Program id to grant")
+@click.option(
+    "--role",
+    "-r",
+    type=click.Choice(["contributor", "admin"]),
+    default="contributor",
+    show_default=True,
+    help="Program role to grant",
+)
+@pass_output_options
+@click.pass_context
+def grant_user(ctx: click.Context, email: str, program: str, role: str) -> None:
+    """Grant an Aeolus-managed user access to a program.
+
+    \b
+    Examples:
+      sonde admin grant-user contractor@aeolus.earth -p weather-intervention
+      sonde admin grant-user lead@aeolus.earth -p shared --role admin
+    """
+    try:
+        grant = access_db.grant_user(email=email, program=program, role=role)
+    except APIError as e:
+        _print_access_api_error(e, program=program, action="grant access")
+        raise SystemExit(1) from None
+    except Exception as e:
+        print_error("Failed to grant access", str(e), "Check your admin permissions and retry.")
+        raise SystemExit(1) from None
+
+    if ctx.obj.get("json"):
+        print_json(grant)
+        return
+
+    status = str(grant.get("status", "active"))
+    print_success(f"Granted {grant['role']} access to {grant['email']}")
+    err.print(f"  Program: {grant['program']}")
+    err.print(f"  Status:  {status}")
+    if status == "pending":
+        err.print("  The grant will apply automatically when this Aeolus account first signs in.")
+
+
+@admin.command("revoke-user")
+@click.argument("email")
+@click.option("--program", "-p", required=True, help="Program id to revoke")
+@click.option("--force", "-f", is_flag=True, help="Skip confirmation")
+@pass_output_options
+@click.pass_context
+def revoke_user(ctx: click.Context, email: str, program: str, force: bool) -> None:
+    """Revoke a user's active or pending program access.
+
+    \b
+    Examples:
+      sonde admin revoke-user contractor@aeolus.earth -p weather-intervention
+    """
+    if not force:
+        click.confirm(f"Revoke {email}'s access to {program}?", abort=True)
+
+    try:
+        revoked = access_db.revoke_user(email=email, program=program)
+    except APIError as e:
+        _print_access_api_error(e, program=program, action="revoke access")
+        raise SystemExit(1) from None
+    except Exception as e:
+        print_error("Failed to revoke access", str(e), "Check your admin permissions and retry.")
+        raise SystemExit(1) from None
+
+    if ctx.obj.get("json"):
+        print_json(revoked)
+        return
+
+    if revoked.get("revoked_active") or revoked.get("revoked_pending"):
+        print_success(f"Revoked access for {revoked['email']}")
+        err.print(f"  Program: {revoked['program']}")
+    else:
+        err.print(f"[yellow]No active or pending access found for {email} on {program}.[/yellow]")
+
+
+@admin.command("list-users")
+@click.option("--program", "-p", required=True, help="Program id to inspect")
+@pass_output_options
+@click.pass_context
+def list_users(ctx: click.Context, program: str) -> None:
+    """List users with active or pending access to a program.
+
+    \b
+    Examples:
+      sonde admin list-users -p weather-intervention
+    """
+    try:
+        rows = access_db.list_users(program)
+    except APIError as e:
+        _print_access_api_error(e, program=program, action="list access")
+        raise SystemExit(1) from None
+    except Exception as e:
+        print_error("Failed to list access", str(e), "Check your admin permissions and retry.")
+        raise SystemExit(1) from None
+
+    if ctx.obj.get("json"):
+        print_json(rows)
+        return
+
+    if not rows:
+        err.print(f"[dim]No active or pending users found for {program}.[/dim]")
+        return
+
+    print_table(
+        ["email", "program", "role", "status", "granted"],
+        [_format_access_table_row(row) for row in rows],
+    )
+
+
+@admin.command("user-access")
+@click.argument("email")
+@pass_output_options
+@click.pass_context
+def user_access(ctx: click.Context, email: str) -> None:
+    """Show manageable program access for a user.
+
+    \b
+    Examples:
+      sonde admin user-access contractor@aeolus.earth
+    """
+    try:
+        rows = access_db.user_access(email)
+    except APIError as e:
+        _print_access_api_error(e, action="show user access")
+        raise SystemExit(1) from None
+    except Exception as e:
+        print_error("Failed to show user access", str(e), "Check your admin permissions and retry.")
+        raise SystemExit(1) from None
+
+    if ctx.obj.get("json"):
+        print_json(rows)
+        return
+
+    if not rows:
+        err.print(f"[dim]No manageable program access found for {email}.[/dim]")
+        return
+
+    print_table(
+        ["email", "program", "role", "status", "granted"],
+        [_format_access_table_row(row) for row in rows],
+    )
+
+
 @admin.command("reconcile-artifacts")
 @click.option(
     "--limit",
@@ -317,3 +464,53 @@ def _print_audit_table(title: str, columns_csv: str, rows: list[dict[str, Any]])
     if not rows:
         return
     print_table(columns_csv.split(","), rows, title=title)
+
+
+def _format_access_table_row(row: dict[str, Any]) -> dict[str, Any]:
+    granted_at = str(row.get("granted_at") or "")
+    return {
+        "email": row.get("email", ""),
+        "program": row.get("program", ""),
+        "role": row.get("role", ""),
+        "status": row.get("status", ""),
+        "granted": granted_at[:10],
+    }
+
+
+def _print_access_api_error(
+    error: APIError,
+    *,
+    action: str,
+    program: str | None = None,
+) -> None:
+    msg = error.message or ""
+    if error.code == "42501":
+        if "last shared admin" in msg:
+            print_error(
+                "Cannot change access",
+                msg,
+                "Grant another trusted user shared admin first, then retry.",
+            )
+        else:
+            print_error(
+                "Permission denied",
+                f"You are not an admin for {program or 'the requested program'}.",
+                "Ask a shared admin or that program's admin to make this change.",
+            )
+    elif error.code == "22023" or "@aeolus.earth" in msg:
+        print_error(
+            "Invalid user",
+            msg or "Only Aeolus-managed Google accounts can receive Sonde access.",
+            "Use an @aeolus.earth Google account.",
+        )
+    elif error.code == "P0001" or "Program does not exist" in msg:
+        print_error(
+            "Invalid program",
+            f"{program or 'The requested program'} does not exist or is not visible to you.",
+            "List accessible programs in the UI or ask a shared admin to confirm the program id.",
+        )
+    else:
+        from sonde.db import classify_api_error
+
+        what, why, fix = classify_api_error(error, table="user_programs", action=action)
+        print_error(what, why, fix)

--- a/cli/src/sonde/db/admin_access.py
+++ b/cli/src/sonde/db/admin_access.py
@@ -1,0 +1,91 @@
+"""Admin user-access database operations."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from sonde.db import client as db_client
+from sonde.db import rows as to_rows
+
+PUBLIC_ROLE = "contributor"
+DB_ROLE = "member"
+
+
+def grant_user(email: str, program: str, role: str = PUBLIC_ROLE) -> dict[str, Any]:
+    """Grant a human user access to one program.
+
+    Existing Aeolus-managed Google users are updated immediately; users who
+    have not signed in yet receive a pending grant that applies on first login.
+    """
+    data = (
+        db_client.get_client()
+        .rpc(
+            "grant_program_access",
+            {
+                "p_email": email,
+                "p_program": program,
+                "p_role": _to_db_role(role),
+            },
+        )
+        .execute()
+        .data
+    )
+    return _normalize_row(_result_dict(data))
+
+
+def revoke_user(email: str, program: str) -> dict[str, Any]:
+    """Revoke a human user's active or pending access to one program."""
+    data = (
+        db_client.get_client()
+        .rpc(
+            "revoke_program_access",
+            {
+                "p_email": email,
+                "p_program": program,
+            },
+        )
+        .execute()
+        .data
+    )
+    return _result_dict(data)
+
+
+def list_users(program: str) -> list[dict[str, Any]]:
+    """List active and pending user access for one program."""
+    data = db_client.get_client().rpc("list_program_access", {"p_program": program}).execute().data
+    return [_normalize_row(row) for row in to_rows(data)]
+
+
+def user_access(email: str) -> list[dict[str, Any]]:
+    """List manageable access rows for a single user."""
+    data = db_client.get_client().rpc("get_user_program_access", {"p_email": email}).execute().data
+    return [_normalize_row(row) for row in to_rows(data)]
+
+
+def _result_dict(data: object) -> dict[str, Any]:
+    if isinstance(data, dict):
+        return cast(dict[str, Any], data)
+
+    rows = to_rows(data)
+    if not rows:
+        raise ValueError("Expected a result row from admin access operation.")
+    return rows[0]
+
+
+def _normalize_row(row: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(row)
+    normalized["role"] = _from_db_role(str(normalized.get("role", "")))
+    return normalized
+
+
+def _to_db_role(role: str) -> str:
+    normalized = role.strip().lower()
+    if normalized == PUBLIC_ROLE:
+        return DB_ROLE
+    return normalized
+
+
+def _from_db_role(role: str) -> str:
+    if role == DB_ROLE:
+        return PUBLIC_ROLE
+    return role

--- a/cli/src/sonde/db/admin_tokens.py
+++ b/cli/src/sonde/db/admin_tokens.py
@@ -34,8 +34,8 @@ def create_token(name: str, programs: list[str], expires_days: int) -> dict[str,
         raise ValueError("Expected an authenticated admin user.")
 
     _validate_expires_days(expires_days)
-    _ensure_programs_exist(client, programs)
     _ensure_admin_for_programs(client, current_user.user_id, programs)
+    _ensure_programs_exist(client, programs)
 
     expires_at = datetime.now(UTC) + timedelta(days=expires_days)
     token = _generate_opaque_token()
@@ -108,10 +108,12 @@ def _ensure_admin_for_programs(client: Any, user_id: str, programs: list[str]) -
         .select("program")
         .eq("user_id", user_id)
         .eq("role", "admin")
-        .in_("program", programs)
         .execute()
     )
     admin_programs = {str(row["program"]) for row in to_rows(result.data)}
+    if "shared" in admin_programs:
+        return
+
     missing = sorted(set(programs) - admin_programs)
     if missing:
         raise APIError(

--- a/cli/tests/test_admin_commands.py
+++ b/cli/tests/test_admin_commands.py
@@ -117,10 +117,17 @@ class TestCreateToken:
     def test_admin_check_requires_every_requested_program(self):
         client = MagicMock()
         query = client.table.return_value.select.return_value.eq.return_value.eq.return_value
-        query.in_.return_value.execute.return_value = MagicMock(data=[{"program": "alpha"}])
+        query.execute.return_value = MagicMock(data=[{"program": "alpha"}])
 
         with pytest.raises(APIError, match="beta"):
             admin_tokens._ensure_admin_for_programs(client, "user-1", ["alpha", "beta"])
+
+    def test_admin_check_allows_shared_admin_global_scope(self):
+        client = MagicMock()
+        query = client.table.return_value.select.return_value.eq.return_value.eq.return_value
+        query.execute.return_value = MagicMock(data=[{"program": "shared"}])
+
+        admin_tokens._ensure_admin_for_programs(client, "user-1", ["alpha", "beta"])
 
     def test_create_token_stores_only_opaque_token_hash(self, monkeypatch: pytest.MonkeyPatch):
         client = MagicMock()
@@ -207,6 +214,170 @@ class TestRevokeToken:
         result = runner.invoke(cli, ["admin", "revoke-token", "nonexistent", "--force"])
         assert result.exit_code == 1
         assert "No active token" in result.output
+
+
+class TestUserAccessAdmin:
+    def test_grant_user_active_success(self, runner: CliRunner, patched_db: MagicMock):
+        with patch(
+            "sonde.commands.admin.access_db.grant_user",
+            return_value={
+                "email": "contractor@aeolus.earth",
+                "program": "weather-intervention",
+                "role": "contributor",
+                "status": "active",
+                "user_id": "user-1",
+            },
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "admin",
+                    "grant-user",
+                    "contractor@aeolus.earth",
+                    "-p",
+                    "weather-intervention",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "Granted contributor access" in result.output
+        assert "weather-intervention" in result.output
+
+    def test_grant_user_pending_json(self, runner: CliRunner, patched_db: MagicMock):
+        with patch(
+            "sonde.commands.admin.access_db.grant_user",
+            return_value={
+                "email": "new.contractor@aeolus.earth",
+                "program": "nwp-development",
+                "role": "contributor",
+                "status": "pending",
+                "user_id": None,
+            },
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--json",
+                    "admin",
+                    "grant-user",
+                    "new.contractor@aeolus.earth",
+                    "-p",
+                    "nwp-development",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert '"status": "pending"' in result.output
+        assert '"role": "contributor"' in result.output
+
+    def test_grant_user_rejects_non_aeolus_email(self, runner: CliRunner, patched_db: MagicMock):
+        with patch(
+            "sonde.commands.admin.access_db.grant_user",
+            side_effect=APIError(
+                {
+                    "message": "Only @aeolus.earth accounts can receive Sonde access",
+                    "code": "22023",
+                    "hint": None,
+                    "details": None,
+                }
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["admin", "grant-user", "contractor@example.com", "-p", "shared"],
+            )
+
+        assert result.exit_code == 1
+        assert "Invalid user" in result.output
+        assert "@aeolus.earth" in result.output
+
+    def test_revoke_user_force(self, runner: CliRunner, patched_db: MagicMock):
+        with patch(
+            "sonde.commands.admin.access_db.revoke_user",
+            return_value={
+                "email": "contractor@aeolus.earth",
+                "program": "weather-intervention",
+                "revoked_active": True,
+                "revoked_pending": False,
+            },
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "admin",
+                    "revoke-user",
+                    "contractor@aeolus.earth",
+                    "-p",
+                    "weather-intervention",
+                    "--force",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "Revoked access" in result.output
+
+    def test_list_users_table(self, runner: CliRunner, patched_db: MagicMock):
+        with patch(
+            "sonde.commands.admin.access_db.list_users",
+            return_value=[
+                {
+                    "email": "contractor@aeolus.earth",
+                    "program": "weather-intervention",
+                    "role": "contributor",
+                    "status": "active",
+                    "granted_at": "2026-04-17T12:00:00+00:00",
+                }
+            ],
+        ):
+            result = runner.invoke(cli, ["admin", "list-users", "-p", "weather-intervention"])
+
+        assert result.exit_code == 0
+        assert "contractor" in result.output
+        assert "contributor" in result.output
+
+    def test_user_access_json(self, runner: CliRunner, patched_db: MagicMock):
+        with patch(
+            "sonde.commands.admin.access_db.user_access",
+            return_value=[
+                {
+                    "email": "contractor@aeolus.earth",
+                    "program": "weather-intervention",
+                    "role": "contributor",
+                    "status": "active",
+                    "granted_at": "2026-04-17T12:00:00+00:00",
+                }
+            ],
+        ):
+            result = runner.invoke(
+                cli,
+                ["--json", "admin", "user-access", "contractor@aeolus.earth"],
+            )
+
+        assert result.exit_code == 0
+        assert '"program": "weather-intervention"' in result.output
+
+    def test_last_shared_admin_error_has_safe_next_step(
+        self, runner: CliRunner, patched_db: MagicMock
+    ):
+        with patch(
+            "sonde.commands.admin.access_db.revoke_user",
+            side_effect=APIError(
+                {
+                    "message": "Cannot revoke the last shared admin",
+                    "code": "42501",
+                    "hint": None,
+                    "details": None,
+                }
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["admin", "revoke-user", "admin@aeolus.earth", "-p", "shared", "--force"],
+            )
+
+        assert result.exit_code == 1
+        assert "Cannot change access" in result.output
+        assert "Grant another trusted user shared admin" in result.output
 
 
 class TestArtifactAdmin:

--- a/scripts/security/rls-exploit-tests.sql
+++ b/scripts/security/rls-exploit-tests.sql
@@ -331,6 +331,179 @@ ROLLBACK;
 
 \echo ''
 \echo '============================================================'
+\echo 'TEST E6: shared admins can list all access-dashboard programs and grants'
+\echo '============================================================'
+BEGIN;
+RESET ROLE;
+INSERT INTO programs (id, name, description) VALUES
+    ('shared', 'Shared', 'Default shared knowledge'),
+    ('alpha', 'Alpha', 'A'),
+    ('beta', 'Beta', 'B')
+ON CONFLICT DO NOTHING;
+INSERT INTO auth.users (id, email, email_confirmed_at, aud, role, instance_id)
+VALUES
+    ('00000000-0000-0000-0000-000000000002', 'root@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+    ('00000000-0000-0000-0000-000000000003', 'alpha.user@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+    ('00000000-0000-0000-0000-000000000004', 'beta.user@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;
+INSERT INTO user_programs (user_id, program, role)
+VALUES
+    ('00000000-0000-0000-0000-000000000002', 'shared', 'admin'),
+    ('00000000-0000-0000-0000-000000000003', 'alpha', 'member'),
+    ('00000000-0000-0000-0000-000000000004', 'beta', 'member')
+ON CONFLICT DO NOTHING;
+SET LOCAL role authenticated;
+SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000002", "role": "authenticated", "email": "root@aeolus.earth", "app_metadata": {"programs": ["shared"], "is_admin": true}}';
+DO $$
+DECLARE
+    visible_programs integer;
+    visible_grants integer;
+BEGIN
+    SELECT count(*) INTO visible_programs
+    FROM list_manageable_programs()
+    WHERE id IN ('shared', 'alpha', 'beta');
+
+    SELECT count(*) INTO visible_grants
+    FROM list_manageable_program_access()
+    WHERE email IN ('alpha.user@aeolus.earth', 'beta.user@aeolus.earth');
+
+    IF visible_programs <> 3 THEN
+        RAISE EXCEPTION 'shared admin dashboard saw % programs, expected 3', visible_programs;
+    END IF;
+
+    IF visible_grants <> 2 THEN
+        RAISE EXCEPTION 'shared admin dashboard saw % grants, expected 2', visible_grants;
+    END IF;
+END;
+$$;
+ROLLBACK;
+
+\echo ''
+\echo '============================================================'
+\echo 'TEST E7: program admins list only their administered program access'
+\echo '============================================================'
+BEGIN;
+RESET ROLE;
+INSERT INTO programs (id, name, description) VALUES
+    ('alpha', 'Alpha', 'A'),
+    ('beta', 'Beta', 'B')
+ON CONFLICT DO NOTHING;
+INSERT INTO auth.users (id, email, email_confirmed_at, aud, role, instance_id)
+VALUES
+    ('00000000-0000-0000-0000-000000000001', 'alice@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+    ('00000000-0000-0000-0000-000000000003', 'alpha.user@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+    ('00000000-0000-0000-0000-000000000004', 'beta.user@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;
+INSERT INTO user_programs (user_id, program, role)
+VALUES
+    ('00000000-0000-0000-0000-000000000001', 'alpha', 'admin'),
+    ('00000000-0000-0000-0000-000000000003', 'alpha', 'member'),
+    ('00000000-0000-0000-0000-000000000004', 'beta', 'member')
+ON CONFLICT DO NOTHING;
+SET LOCAL role authenticated;
+SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000001", "role": "authenticated", "email": "alice@aeolus.earth", "app_metadata": {"programs": ["alpha"], "is_admin": true}}';
+DO $$
+DECLARE
+    alpha_programs integer;
+    beta_programs integer;
+    alpha_grants integer;
+    beta_grants integer;
+BEGIN
+    SELECT count(*) INTO alpha_programs FROM list_manageable_programs() WHERE id = 'alpha';
+    SELECT count(*) INTO beta_programs FROM list_manageable_programs() WHERE id = 'beta';
+    SELECT count(*) INTO alpha_grants
+    FROM list_manageable_program_access()
+    WHERE email = 'alpha.user@aeolus.earth';
+    SELECT count(*) INTO beta_grants
+    FROM list_manageable_program_access()
+    WHERE email = 'beta.user@aeolus.earth';
+
+    IF alpha_programs <> 1 OR beta_programs <> 0 THEN
+        RAISE EXCEPTION 'program admin dashboard scope leaked programs alpha=%, beta=%', alpha_programs, beta_programs;
+    END IF;
+
+    IF alpha_grants <> 1 OR beta_grants <> 0 THEN
+        RAISE EXCEPTION 'program admin dashboard scope leaked grants alpha=%, beta=%', alpha_grants, beta_grants;
+    END IF;
+END;
+$$;
+ROLLBACK;
+
+\echo ''
+\echo '============================================================'
+\echo 'TEST E8: contributors cannot call access-dashboard RPCs'
+\echo '============================================================'
+BEGIN;
+RESET ROLE;
+INSERT INTO programs (id, name, description) VALUES ('alpha', 'Alpha', 'A')
+ON CONFLICT DO NOTHING;
+INSERT INTO auth.users (id, email, email_confirmed_at, aud, role, instance_id)
+VALUES ('00000000-0000-0000-0000-000000000001', 'alice@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;
+INSERT INTO user_programs (user_id, program, role)
+VALUES ('00000000-0000-0000-0000-000000000001', 'alpha', 'member')
+ON CONFLICT DO NOTHING;
+SET LOCAL role authenticated;
+SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000001", "role": "authenticated", "email": "alice@aeolus.earth", "app_metadata": {"programs": ["alpha"]}}';
+DO $$
+BEGIN
+    PERFORM list_manageable_programs();
+    RAISE EXCEPTION 'contributor list_manageable_programs unexpectedly succeeded';
+EXCEPTION
+    WHEN insufficient_privilege THEN
+        NULL;
+END;
+$$;
+DO $$
+BEGIN
+    PERFORM list_manageable_program_access();
+    RAISE EXCEPTION 'contributor list_manageable_program_access unexpectedly succeeded';
+EXCEPTION
+    WHEN insufficient_privilege THEN
+        NULL;
+END;
+$$;
+ROLLBACK;
+
+\echo ''
+\echo '============================================================'
+\echo 'TEST E9: dashboard access RPC includes pending FTE grants'
+\echo '============================================================'
+BEGIN;
+RESET ROLE;
+INSERT INTO programs (id, name, description) VALUES
+    ('shared', 'Shared', 'Default shared knowledge'),
+    ('alpha', 'Alpha', 'A')
+ON CONFLICT DO NOTHING;
+INSERT INTO auth.users (id, email, email_confirmed_at, aud, role, instance_id)
+VALUES ('00000000-0000-0000-0000-000000000002', 'root@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;
+INSERT INTO user_programs (user_id, program, role)
+VALUES ('00000000-0000-0000-0000-000000000002', 'shared', 'admin')
+ON CONFLICT DO NOTHING;
+SET LOCAL role authenticated;
+SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000002", "role": "authenticated", "email": "root@aeolus.earth", "app_metadata": {"programs": ["shared"], "is_admin": true}}';
+SELECT grant_program_access('fte.pending@aeolus.earth', 'alpha', 'contributor');
+DO $$
+DECLARE
+    pending_rows integer;
+BEGIN
+    SELECT count(*) INTO pending_rows
+    FROM list_manageable_program_access()
+    WHERE email = 'fte.pending@aeolus.earth'
+      AND program = 'alpha'
+      AND role = 'member'
+      AND status = 'pending';
+
+    IF pending_rows <> 1 THEN
+        RAISE EXCEPTION 'dashboard access RPC did not expose the pending FTE grant';
+    END IF;
+END;
+$$;
+ROLLBACK;
+
+\echo ''
+\echo '============================================================'
 \echo 'TEST F: opaque token rows require admin of every requested program'
 \echo '============================================================'
 BEGIN;

--- a/scripts/security/rls-exploit-tests.sql
+++ b/scripts/security/rls-exploit-tests.sql
@@ -196,7 +196,142 @@ ROLLBACK;
 
 \echo ''
 \echo '============================================================'
-\echo 'TEST F: create_agent_token requires admin of every requested program'
+\echo 'TEST E2: shared admin can grant access to any program'
+\echo '============================================================'
+BEGIN;
+RESET ROLE;
+INSERT INTO programs (id, name, description) VALUES
+    ('shared', 'Shared', 'Default shared knowledge'),
+    ('beta', 'Beta', 'B')
+ON CONFLICT DO NOTHING;
+INSERT INTO auth.users (id, email, email_confirmed_at, aud, role, instance_id)
+VALUES
+    ('00000000-0000-0000-0000-000000000002', 'root@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+    ('00000000-0000-0000-0000-000000000003', 'bob@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;
+INSERT INTO user_programs (user_id, program, role)
+VALUES ('00000000-0000-0000-0000-000000000002', 'shared', 'admin')
+ON CONFLICT DO NOTHING;
+SET LOCAL role authenticated;
+SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000002", "role": "authenticated", "email": "root@aeolus.earth", "app_metadata": {"programs": ["shared"], "is_admin": true}}';
+SELECT grant_program_access('bob@aeolus.earth', 'beta', 'contributor');
+RESET ROLE;
+DO $$
+DECLARE
+    granted_role text;
+BEGIN
+    SELECT role INTO granted_role
+    FROM user_programs
+    WHERE user_id = '00000000-0000-0000-0000-000000000003'
+      AND program = 'beta';
+
+    IF granted_role <> 'member' THEN
+        RAISE EXCEPTION 'shared admin grant did not create beta member access';
+    END IF;
+END;
+$$;
+ROLLBACK;
+
+\echo ''
+\echo '============================================================'
+\echo 'TEST E3: contributors cannot grant program access'
+\echo '============================================================'
+BEGIN;
+RESET ROLE;
+INSERT INTO programs (id, name, description) VALUES ('alpha', 'Alpha', 'A')
+ON CONFLICT DO NOTHING;
+INSERT INTO auth.users (id, email, email_confirmed_at, aud, role, instance_id)
+VALUES
+    ('00000000-0000-0000-0000-000000000001', 'alice@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+    ('00000000-0000-0000-0000-000000000002', 'bob@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;
+INSERT INTO user_programs (user_id, program, role)
+VALUES ('00000000-0000-0000-0000-000000000001', 'alpha', 'member')
+ON CONFLICT DO NOTHING;
+SET LOCAL role authenticated;
+SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000001", "role": "authenticated", "email": "alice@aeolus.earth", "app_metadata": {"programs": ["alpha"]}}';
+DO $$
+BEGIN
+    PERFORM grant_program_access('bob@aeolus.earth', 'alpha', 'contributor');
+    RAISE EXCEPTION 'contributor grant_program_access unexpectedly succeeded';
+EXCEPTION
+    WHEN insufficient_privilege THEN
+        NULL;
+END;
+$$;
+ROLLBACK;
+
+\echo ''
+\echo '============================================================'
+\echo 'TEST E4: pending grants apply when the Aeolus account first signs in'
+\echo '============================================================'
+BEGIN;
+RESET ROLE;
+INSERT INTO programs (id, name, description) VALUES
+    ('shared', 'Shared', 'Default shared knowledge'),
+    ('beta', 'Beta', 'B')
+ON CONFLICT DO NOTHING;
+INSERT INTO auth.users (id, email, email_confirmed_at, aud, role, instance_id)
+VALUES ('00000000-0000-0000-0000-000000000002', 'root@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;
+INSERT INTO user_programs (user_id, program, role)
+VALUES ('00000000-0000-0000-0000-000000000002', 'shared', 'admin')
+ON CONFLICT DO NOTHING;
+SET LOCAL role authenticated;
+SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000002", "role": "authenticated", "email": "root@aeolus.earth", "app_metadata": {"programs": ["shared"], "is_admin": true}}';
+SELECT grant_program_access('new.contractor@aeolus.earth', 'beta', 'contributor');
+RESET ROLE;
+INSERT INTO auth.users (id, email, email_confirmed_at, aud, role, instance_id)
+VALUES ('00000000-0000-0000-0000-000000000004', 'new.contractor@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000');
+DO $$
+DECLARE
+    granted_role text;
+BEGIN
+    SELECT role INTO granted_role
+    FROM user_programs
+    WHERE user_id = '00000000-0000-0000-0000-000000000004'
+      AND program = 'beta';
+
+    IF granted_role <> 'member' THEN
+        RAISE EXCEPTION 'pending grant did not apply to newly created auth user';
+    END IF;
+END;
+$$;
+ROLLBACK;
+
+\echo ''
+\echo '============================================================'
+\echo 'TEST E5: the last shared admin cannot be revoked'
+\echo '============================================================'
+BEGIN;
+RESET ROLE;
+INSERT INTO programs (id, name, description) VALUES ('shared', 'Shared', 'Default shared knowledge')
+ON CONFLICT DO NOTHING;
+INSERT INTO auth.users (id, email, email_confirmed_at, aud, role, instance_id)
+VALUES ('00000000-0000-0000-0000-000000000002', 'root@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;
+INSERT INTO user_programs (user_id, program, role)
+VALUES ('00000000-0000-0000-0000-000000000002', 'shared', 'admin')
+ON CONFLICT DO NOTHING;
+DELETE FROM user_programs
+WHERE program = 'shared'
+  AND user_id <> '00000000-0000-0000-0000-000000000002';
+SET LOCAL role authenticated;
+SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000002", "role": "authenticated", "email": "root@aeolus.earth", "app_metadata": {"programs": ["shared"], "is_admin": true}}';
+DO $$
+BEGIN
+    PERFORM revoke_program_access('root@aeolus.earth', 'shared');
+    RAISE EXCEPTION 'last shared admin revoke unexpectedly succeeded';
+EXCEPTION
+    WHEN insufficient_privilege THEN
+        NULL;
+END;
+$$;
+ROLLBACK;
+
+\echo ''
+\echo '============================================================'
+\echo 'TEST F: opaque token rows require admin of every requested program'
 \echo '============================================================'
 BEGIN;
 RESET ROLE;
@@ -213,8 +348,21 @@ SET LOCAL role authenticated;
 SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000001", "role": "authenticated", "email": "alice@aeolus.earth", "app_metadata": {"programs": ["alpha"], "is_admin": true}}';
 DO $$
 BEGIN
-    PERFORM create_agent_token('alice-evil-token', ARRAY['beta'], 1);
-    RAISE EXCEPTION 'cross-program create_agent_token unexpectedly succeeded';
+    INSERT INTO agent_tokens (
+        id, name, programs, created_by, expires_at,
+        token_hash, token_prefix, token_preview
+    )
+    VALUES (
+        '11111111-1111-1111-1111-111111111114',
+        'alice-evil-token',
+        ARRAY['beta'],
+        '00000000-0000-0000-0000-000000000001',
+        now() + interval '1 day',
+        repeat('c', 64),
+        'sonde_ak_',
+        'sonde_ak_test...secret'
+    );
+    RAISE EXCEPTION 'cross-program agent_tokens insert unexpectedly succeeded';
 EXCEPTION
     WHEN insufficient_privilege THEN
         NULL;
@@ -362,8 +510,45 @@ $$;
 SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000001", "role": "authenticated", "email": "alice@aeolus.earth", "app_metadata": {"programs": ["alpha", "shared"]}}';
 DO $$
 BEGIN
-    IF user_programs() <> ARRAY['shared']::text[] THEN
-        RAISE EXCEPTION 'removed human did not collapse stale JWT access to shared only';
+    IF user_programs() <> ARRAY[]::text[] THEN
+        RAISE EXCEPTION 'removed human unexpectedly retained stale shared JWT access';
+    END IF;
+END;
+$$;
+ROLLBACK;
+
+\echo ''
+\echo '============================================================'
+\echo 'TEST I2: users with no grants cannot enumerate programs or protected records'
+\echo '============================================================'
+BEGIN;
+RESET ROLE;
+INSERT INTO programs (id, name, description) VALUES
+    ('alpha', 'Alpha', 'A'), ('shared', 'Shared', 'Default shared knowledge')
+ON CONFLICT DO NOTHING;
+INSERT INTO auth.users (id, email, email_confirmed_at, aud, role, instance_id)
+VALUES ('00000000-0000-0000-0000-000000000001', 'alice@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;
+DELETE FROM user_programs WHERE user_id = '00000000-0000-0000-0000-000000000001';
+INSERT INTO experiments (id, program, status, source, hypothesis)
+VALUES ('EXP-RLS-NOACCESS', 'alpha', 'open', 'audit/test', 'hidden')
+ON CONFLICT DO NOTHING;
+SET LOCAL role authenticated;
+SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000001", "role": "authenticated", "email": "alice@aeolus.earth", "app_metadata": {"programs": ["alpha", "shared"]}}';
+DO $$
+DECLARE
+    visible_programs integer;
+    visible_experiments integer;
+BEGIN
+    SELECT count(*) INTO visible_programs FROM programs;
+    SELECT count(*) INTO visible_experiments FROM experiments WHERE id = 'EXP-RLS-NOACCESS';
+
+    IF visible_programs <> 0 THEN
+        RAISE EXCEPTION 'ungranted user unexpectedly saw % programs', visible_programs;
+    END IF;
+
+    IF visible_experiments <> 0 THEN
+        RAISE EXCEPTION 'ungranted user unexpectedly saw protected experiment';
     END IF;
 END;
 $$;

--- a/scripts/security/rls-exploit-tests.sql
+++ b/scripts/security/rls-exploit-tests.sql
@@ -504,6 +504,133 @@ ROLLBACK;
 
 \echo ''
 \echo '============================================================'
+\echo 'TEST E10: shared admins can read all access audit events'
+\echo '============================================================'
+BEGIN;
+RESET ROLE;
+INSERT INTO programs (id, name, description) VALUES
+    ('shared', 'Shared', 'Default shared knowledge'),
+    ('alpha', 'Alpha', 'A'),
+    ('beta', 'Beta', 'B')
+ON CONFLICT DO NOTHING;
+INSERT INTO auth.users (id, email, email_confirmed_at, aud, role, instance_id)
+VALUES ('00000000-0000-0000-0000-000000000002', 'root@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;
+INSERT INTO user_programs (user_id, program, role)
+VALUES ('00000000-0000-0000-0000-000000000002', 'shared', 'admin')
+ON CONFLICT DO NOTHING;
+INSERT INTO program_access_events (
+    action,
+    actor_user_id,
+    actor_email,
+    target_email,
+    program,
+    new_role
+)
+VALUES
+    ('grant', '00000000-0000-0000-0000-000000000002', 'root@aeolus.earth', 'alpha.user@aeolus.earth', 'alpha', 'member'),
+    ('grant', '00000000-0000-0000-0000-000000000002', 'root@aeolus.earth', 'beta.user@aeolus.earth', 'beta', 'member');
+SET LOCAL role authenticated;
+SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000002", "role": "authenticated", "email": "root@aeolus.earth", "app_metadata": {"programs": ["shared"], "is_admin": true}}';
+DO $$
+DECLARE
+    visible_events integer;
+BEGIN
+    SELECT count(*) INTO visible_events
+    FROM program_access_events
+    WHERE program IN ('alpha', 'beta');
+
+    IF visible_events <> 2 THEN
+        RAISE EXCEPTION 'shared admin saw % access audit events, expected 2', visible_events;
+    END IF;
+END;
+$$;
+ROLLBACK;
+
+\echo ''
+\echo '============================================================'
+\echo 'TEST E11: program admins read only their program access audit events'
+\echo '============================================================'
+BEGIN;
+RESET ROLE;
+INSERT INTO programs (id, name, description) VALUES
+    ('alpha', 'Alpha', 'A'),
+    ('beta', 'Beta', 'B')
+ON CONFLICT DO NOTHING;
+INSERT INTO auth.users (id, email, email_confirmed_at, aud, role, instance_id)
+VALUES ('00000000-0000-0000-0000-000000000001', 'alice@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;
+INSERT INTO user_programs (user_id, program, role)
+VALUES ('00000000-0000-0000-0000-000000000001', 'alpha', 'admin')
+ON CONFLICT DO NOTHING;
+INSERT INTO program_access_events (
+    action,
+    actor_user_id,
+    actor_email,
+    target_email,
+    program,
+    new_role
+)
+VALUES
+    ('grant', '00000000-0000-0000-0000-000000000001', 'alice@aeolus.earth', 'alpha.user@aeolus.earth', 'alpha', 'member'),
+    ('grant', '00000000-0000-0000-0000-000000000001', 'alice@aeolus.earth', 'beta.user@aeolus.earth', 'beta', 'member');
+SET LOCAL role authenticated;
+SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000001", "role": "authenticated", "email": "alice@aeolus.earth", "app_metadata": {"programs": ["alpha"], "is_admin": true}}';
+DO $$
+DECLARE
+    alpha_events integer;
+    beta_events integer;
+BEGIN
+    SELECT count(*) INTO alpha_events FROM program_access_events WHERE program = 'alpha';
+    SELECT count(*) INTO beta_events FROM program_access_events WHERE program = 'beta';
+
+    IF alpha_events <> 1 OR beta_events <> 0 THEN
+        RAISE EXCEPTION 'program admin access audit scope leaked events alpha=%, beta=%', alpha_events, beta_events;
+    END IF;
+END;
+$$;
+ROLLBACK;
+
+\echo ''
+\echo '============================================================'
+\echo 'TEST E12: contributors cannot read program access audit events'
+\echo '============================================================'
+BEGIN;
+RESET ROLE;
+INSERT INTO programs (id, name, description) VALUES ('alpha', 'Alpha', 'A')
+ON CONFLICT DO NOTHING;
+INSERT INTO auth.users (id, email, email_confirmed_at, aud, role, instance_id)
+VALUES ('00000000-0000-0000-0000-000000000001', 'alice@aeolus.earth', now(), 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;
+INSERT INTO user_programs (user_id, program, role)
+VALUES ('00000000-0000-0000-0000-000000000001', 'alpha', 'member')
+ON CONFLICT DO NOTHING;
+INSERT INTO program_access_events (
+    action,
+    actor_user_id,
+    actor_email,
+    target_email,
+    program,
+    new_role
+)
+VALUES ('grant', '00000000-0000-0000-0000-000000000001', 'alice@aeolus.earth', 'alpha.user@aeolus.earth', 'alpha', 'member');
+SET LOCAL role authenticated;
+SET LOCAL request.jwt.claims TO '{"sub": "00000000-0000-0000-0000-000000000001", "role": "authenticated", "email": "alice@aeolus.earth", "app_metadata": {"programs": ["alpha"]}}';
+DO $$
+DECLARE
+    visible_events integer;
+BEGIN
+    SELECT count(*) INTO visible_events FROM program_access_events WHERE program = 'alpha';
+
+    IF visible_events <> 0 THEN
+        RAISE EXCEPTION 'contributor read % program access audit events, expected 0', visible_events;
+    END IF;
+END;
+$$;
+ROLLBACK;
+
+\echo ''
+\echo '============================================================'
 \echo 'TEST F: opaque token rows require admin of every requested program'
 \echo '============================================================'
 BEGIN;

--- a/supabase/migrations/20260417000003_contractor_program_rbac.sql
+++ b/supabase/migrations/20260417000003_contractor_program_rbac.sql
@@ -1,0 +1,858 @@
+-- Contractor RBAC: explicit program grants, scoped program discovery, and
+-- shared-program admins as the global access managers.
+
+-- ---------------------------------------------------------------------------
+-- 1. Admin helpers: shared admin is the explicit org-admin role
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.can_manage_program(target_program text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT public.is_sonde_admin() OR public.is_program_admin(target_program);
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_admin_programs(target_programs text[])
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    requested text[];
+BEGIN
+    SELECT coalesce(array_agg(trimmed ORDER BY trimmed), ARRAY[]::text[])
+    INTO requested
+    FROM (
+        SELECT DISTINCT btrim(program) AS trimmed
+        FROM unnest(coalesce(target_programs, ARRAY[]::text[])) AS program
+    ) normalized;
+
+    IF requested = ARRAY[]::text[] THEN
+        RETURN false;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM unnest(coalesce(target_programs, ARRAY[]::text[])) AS program
+        WHERE program IS NULL OR btrim(program) = ''
+    ) THEN
+        RETURN false;
+    END IF;
+
+    IF public.is_sonde_admin() THEN
+        RETURN true;
+    END IF;
+
+    RETURN requested <@ public.admin_programs();
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Program grants + audit trail
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.program_access_grants (
+    email text NOT NULL,
+    program text NOT NULL REFERENCES public.programs(id) ON DELETE CASCADE,
+    role text NOT NULL DEFAULT 'member' CHECK (role IN ('member', 'admin')),
+    granted_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    applied_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+    applied_at timestamptz,
+    PRIMARY KEY (email, program),
+    CHECK (email = lower(email)),
+    CHECK (email LIKE '%@aeolus.earth')
+);
+
+ALTER TABLE public.program_access_grants ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "program_access_grants_select_manager" ON public.program_access_grants;
+DROP POLICY IF EXISTS "program_access_grants_insert_manager" ON public.program_access_grants;
+DROP POLICY IF EXISTS "program_access_grants_update_manager" ON public.program_access_grants;
+DROP POLICY IF EXISTS "program_access_grants_delete_manager" ON public.program_access_grants;
+
+CREATE POLICY "program_access_grants_select_manager" ON public.program_access_grants
+    FOR SELECT TO authenticated
+    USING (public.can_manage_program(program));
+
+CREATE POLICY "program_access_grants_insert_manager" ON public.program_access_grants
+    FOR INSERT TO authenticated
+    WITH CHECK (public.can_manage_program(program));
+
+CREATE POLICY "program_access_grants_update_manager" ON public.program_access_grants
+    FOR UPDATE TO authenticated
+    USING (public.can_manage_program(program))
+    WITH CHECK (public.can_manage_program(program));
+
+CREATE POLICY "program_access_grants_delete_manager" ON public.program_access_grants
+    FOR DELETE TO authenticated
+    USING (public.can_manage_program(program));
+
+CREATE TABLE IF NOT EXISTS public.program_access_events (
+    id bigserial PRIMARY KEY,
+    action text NOT NULL CHECK (action IN ('grant', 'revoke', 'apply_pending')),
+    actor_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+    actor_email text,
+    target_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+    target_email text NOT NULL,
+    program text NOT NULL REFERENCES public.programs(id) ON DELETE CASCADE,
+    old_role text CHECK (old_role IS NULL OR old_role IN ('member', 'admin')),
+    new_role text CHECK (new_role IS NULL OR new_role IN ('member', 'admin')),
+    details jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.program_access_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "program_access_events_select_manager" ON public.program_access_events;
+CREATE POLICY "program_access_events_select_manager" ON public.program_access_events
+    FOR SELECT TO authenticated
+    USING (public.can_manage_program(program));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.program_access_grants TO authenticated;
+GRANT SELECT ON public.program_access_events TO authenticated;
+GRANT USAGE, SELECT ON SEQUENCE public.program_access_events_id_seq TO authenticated;
+
+-- Keep existing users usable when removing the implicit shared fallback. Future
+-- users must be granted explicitly or arrive through a pending grant.
+INSERT INTO public.user_programs (user_id, program, role)
+SELECT u.id, 'shared', 'member'
+FROM auth.users u
+WHERE lower(coalesce(u.email, '')) LIKE '%@aeolus.earth'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM public.user_programs up
+      WHERE up.user_id = u.id
+  )
+ON CONFLICT (user_id, program) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- 3. Guard against deleting or downgrading the last shared admin
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.prevent_last_shared_admin_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    shared_admin_count integer;
+BEGIN
+    IF TG_OP = 'DELETE'
+       AND OLD.program = 'shared'
+       AND OLD.role = 'admin' THEN
+        SELECT count(*)
+        INTO shared_admin_count
+        FROM public.user_programs
+        WHERE program = 'shared'
+          AND role = 'admin';
+
+        IF shared_admin_count <= 1 THEN
+            RAISE EXCEPTION 'Cannot remove the last shared admin'
+                USING ERRCODE = '42501';
+        END IF;
+
+        RETURN OLD;
+    END IF;
+
+    IF TG_OP = 'UPDATE'
+       AND OLD.program = 'shared'
+       AND OLD.role = 'admin'
+       AND (NEW.program <> 'shared' OR NEW.role <> 'admin') THEN
+        SELECT count(*)
+        INTO shared_admin_count
+        FROM public.user_programs
+        WHERE program = 'shared'
+          AND role = 'admin';
+
+        IF shared_admin_count <= 1 THEN
+            RAISE EXCEPTION 'Cannot downgrade the last shared admin'
+                USING ERRCODE = '42501';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS prevent_last_shared_admin_change ON public.user_programs;
+CREATE TRIGGER prevent_last_shared_admin_change
+BEFORE UPDATE OR DELETE ON public.user_programs
+FOR EACH ROW
+EXECUTE FUNCTION public.prevent_last_shared_admin_change();
+
+-- ---------------------------------------------------------------------------
+-- 4. Program-access RPCs used by the admin CLI
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.normalize_program_access_email(p_email text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public
+AS $$
+DECLARE
+    normalized text := lower(btrim(coalesce(p_email, '')));
+BEGIN
+    IF normalized !~ '^[^[:space:]@]+@aeolus[.]earth$' THEN
+        RAISE EXCEPTION 'Only @aeolus.earth accounts can receive Sonde access'
+            USING ERRCODE = '22023';
+    END IF;
+
+    RETURN normalized;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.normalize_program_access_role(p_role text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public
+AS $$
+DECLARE
+    normalized text := lower(btrim(coalesce(p_role, 'member')));
+BEGIN
+    IF normalized = 'contributor' THEN
+        RETURN 'member';
+    END IF;
+
+    IF normalized NOT IN ('member', 'admin') THEN
+        RAISE EXCEPTION 'Role must be contributor or admin'
+            USING ERRCODE = '22023';
+    END IF;
+
+    RETURN normalized;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.grant_program_access(
+    p_email text,
+    p_program text,
+    p_role text DEFAULT 'member'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    target_email text := public.normalize_program_access_email(p_email);
+    target_program text := btrim(coalesce(p_program, ''));
+    target_role text := public.normalize_program_access_role(p_role);
+    target_user_id uuid;
+    old_role text;
+    result_status text;
+    shared_admin_count integer;
+BEGIN
+    IF target_program = '' OR NOT EXISTS (SELECT 1 FROM public.programs WHERE id = target_program) THEN
+        RAISE EXCEPTION 'Program does not exist: %', target_program
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    IF NOT public.can_manage_program(target_program) THEN
+        RAISE EXCEPTION 'Only admins of % can grant program access', target_program
+            USING ERRCODE = '42501';
+    END IF;
+
+    SELECT u.id
+    INTO target_user_id
+    FROM auth.users u
+    WHERE lower(u.email) = target_email
+    ORDER BY u.created_at DESC
+    LIMIT 1;
+
+    IF target_user_id IS NOT NULL THEN
+        SELECT role
+        INTO old_role
+        FROM public.user_programs
+        WHERE user_id = target_user_id
+          AND program = target_program;
+
+        IF target_program = 'shared'
+           AND old_role = 'admin'
+           AND target_role <> 'admin' THEN
+            SELECT count(*)
+            INTO shared_admin_count
+            FROM public.user_programs
+            WHERE program = 'shared'
+              AND role = 'admin';
+
+            IF shared_admin_count <= 1 THEN
+                RAISE EXCEPTION 'Cannot downgrade the last shared admin'
+                    USING ERRCODE = '42501';
+            END IF;
+        END IF;
+
+        INSERT INTO public.user_programs (user_id, program, role)
+        VALUES (target_user_id, target_program, target_role)
+        ON CONFLICT (user_id, program) DO UPDATE
+        SET role = EXCLUDED.role;
+
+        result_status := 'active';
+    ELSE
+        result_status := 'pending';
+    END IF;
+
+    INSERT INTO public.program_access_grants (
+        email,
+        program,
+        role,
+        granted_by,
+        created_at,
+        applied_user_id,
+        applied_at
+    )
+    VALUES (
+        target_email,
+        target_program,
+        target_role,
+        auth.uid(),
+        now(),
+        target_user_id,
+        CASE WHEN target_user_id IS NULL THEN NULL ELSE now() END
+    )
+    ON CONFLICT (email, program) DO UPDATE
+    SET role = EXCLUDED.role,
+        granted_by = EXCLUDED.granted_by,
+        created_at = EXCLUDED.created_at,
+        applied_user_id = EXCLUDED.applied_user_id,
+        applied_at = EXCLUDED.applied_at;
+
+    INSERT INTO public.program_access_events (
+        action,
+        actor_user_id,
+        actor_email,
+        target_user_id,
+        target_email,
+        program,
+        old_role,
+        new_role,
+        details
+    )
+    VALUES (
+        'grant',
+        auth.uid(),
+        auth.jwt() ->> 'email',
+        target_user_id,
+        target_email,
+        target_program,
+        old_role,
+        target_role,
+        jsonb_build_object('status', result_status)
+    );
+
+    RETURN jsonb_build_object(
+        'email', target_email,
+        'program', target_program,
+        'role', target_role,
+        'status', result_status,
+        'user_id', target_user_id
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.revoke_program_access(
+    p_email text,
+    p_program text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    target_email text := public.normalize_program_access_email(p_email);
+    target_program text := btrim(coalesce(p_program, ''));
+    target_user_id uuid;
+    old_role text;
+    deleted_grants integer := 0;
+    deleted_active integer := 0;
+    shared_admin_count integer;
+BEGIN
+    IF target_program = '' OR NOT EXISTS (SELECT 1 FROM public.programs WHERE id = target_program) THEN
+        RAISE EXCEPTION 'Program does not exist: %', target_program
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    IF NOT public.can_manage_program(target_program) THEN
+        RAISE EXCEPTION 'Only admins of % can revoke program access', target_program
+            USING ERRCODE = '42501';
+    END IF;
+
+    SELECT u.id
+    INTO target_user_id
+    FROM auth.users u
+    WHERE lower(u.email) = target_email
+    ORDER BY u.created_at DESC
+    LIMIT 1;
+
+    IF target_user_id IS NOT NULL THEN
+        SELECT role
+        INTO old_role
+        FROM public.user_programs
+        WHERE user_id = target_user_id
+          AND program = target_program;
+
+        IF target_program = 'shared' AND old_role = 'admin' THEN
+            SELECT count(*)
+            INTO shared_admin_count
+            FROM public.user_programs
+            WHERE program = 'shared'
+              AND role = 'admin';
+
+            IF shared_admin_count <= 1 THEN
+                RAISE EXCEPTION 'Cannot revoke the last shared admin'
+                    USING ERRCODE = '42501';
+            END IF;
+        END IF;
+
+        DELETE FROM public.user_programs
+        WHERE user_id = target_user_id
+          AND program = target_program;
+        GET DIAGNOSTICS deleted_active = ROW_COUNT;
+    END IF;
+
+    DELETE FROM public.program_access_grants
+    WHERE email = target_email
+      AND program = target_program;
+    GET DIAGNOSTICS deleted_grants = ROW_COUNT;
+
+    INSERT INTO public.program_access_events (
+        action,
+        actor_user_id,
+        actor_email,
+        target_user_id,
+        target_email,
+        program,
+        old_role,
+        new_role,
+        details
+    )
+    VALUES (
+        'revoke',
+        auth.uid(),
+        auth.jwt() ->> 'email',
+        target_user_id,
+        target_email,
+        target_program,
+        old_role,
+        NULL,
+        jsonb_build_object(
+            'revoked_active', deleted_active > 0,
+            'revoked_pending', deleted_grants > 0
+        )
+    );
+
+    RETURN jsonb_build_object(
+        'email', target_email,
+        'program', target_program,
+        'revoked_active', deleted_active > 0,
+        'revoked_pending', deleted_grants > 0
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_program_access(p_program text)
+RETURNS TABLE (
+    email text,
+    user_id uuid,
+    program text,
+    role text,
+    status text,
+    granted_at timestamptz,
+    applied_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    target_program text := btrim(coalesce(p_program, ''));
+BEGIN
+    IF target_program = '' OR NOT EXISTS (SELECT 1 FROM public.programs WHERE id = target_program) THEN
+        RAISE EXCEPTION 'Program does not exist: %', target_program
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    IF NOT public.can_manage_program(target_program) THEN
+        RAISE EXCEPTION 'Only admins of % can list program access', target_program
+            USING ERRCODE = '42501';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        lower(u.email)::text AS email,
+        up.user_id,
+        up.program,
+        up.role,
+        'active'::text AS status,
+        coalesce(g.created_at, up.created_at) AS granted_at,
+        g.applied_at
+    FROM public.user_programs up
+    JOIN auth.users u ON u.id = up.user_id
+    LEFT JOIN public.program_access_grants g
+      ON g.email = lower(u.email)
+     AND g.program = up.program
+    WHERE up.program = target_program
+
+    UNION ALL
+
+    SELECT
+        g.email,
+        NULL::uuid AS user_id,
+        g.program,
+        g.role,
+        'pending'::text AS status,
+        g.created_at AS granted_at,
+        NULL::timestamptz AS applied_at
+    FROM public.program_access_grants g
+    LEFT JOIN auth.users u ON lower(u.email) = g.email
+    LEFT JOIN public.user_programs up
+      ON up.user_id = u.id
+     AND up.program = g.program
+    WHERE g.program = target_program
+      AND u.id IS NULL
+    ORDER BY status, email;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_user_program_access(p_email text)
+RETURNS TABLE (
+    email text,
+    user_id uuid,
+    program text,
+    role text,
+    status text,
+    granted_at timestamptz,
+    applied_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    target_email text := public.normalize_program_access_email(p_email);
+BEGIN
+    RETURN QUERY
+    SELECT
+        lower(u.email)::text AS email,
+        up.user_id,
+        up.program,
+        up.role,
+        'active'::text AS status,
+        coalesce(g.created_at, up.created_at) AS granted_at,
+        g.applied_at
+    FROM public.user_programs up
+    JOIN auth.users u ON u.id = up.user_id
+    LEFT JOIN public.program_access_grants g
+      ON g.email = lower(u.email)
+     AND g.program = up.program
+    WHERE lower(u.email) = target_email
+      AND public.can_manage_program(up.program)
+
+    UNION ALL
+
+    SELECT
+        g.email,
+        NULL::uuid AS user_id,
+        g.program,
+        g.role,
+        'pending'::text AS status,
+        g.created_at AS granted_at,
+        NULL::timestamptz AS applied_at
+    FROM public.program_access_grants g
+    LEFT JOIN auth.users u ON lower(u.email) = g.email
+    LEFT JOIN public.user_programs up
+      ON up.user_id = u.id
+     AND up.program = g.program
+    WHERE g.email = target_email
+      AND u.id IS NULL
+      AND public.can_manage_program(g.program)
+    ORDER BY status, program;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.normalize_program_access_email(text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.normalize_program_access_role(text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.grant_program_access(text, text, text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.revoke_program_access(text, text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.list_program_access(text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.get_user_program_access(text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.grant_program_access(text, text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.revoke_program_access(text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_program_access(text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_user_program_access(text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 5. Apply pending grants when an Aeolus-managed Google account first appears
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.apply_pending_program_access_grants()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    normalized_email text;
+    grant_row public.program_access_grants%rowtype;
+BEGIN
+    normalized_email := lower(coalesce(NEW.email, ''));
+
+    IF normalized_email NOT LIKE '%@aeolus.earth' THEN
+        RETURN NEW;
+    END IF;
+
+    FOR grant_row IN
+        SELECT *
+        FROM public.program_access_grants
+        WHERE email = normalized_email
+    LOOP
+        INSERT INTO public.user_programs (user_id, program, role)
+        VALUES (NEW.id, grant_row.program, grant_row.role)
+        ON CONFLICT (user_id, program) DO UPDATE
+        SET role = EXCLUDED.role;
+
+        UPDATE public.program_access_grants
+        SET applied_user_id = NEW.id,
+            applied_at = now()
+        WHERE email = grant_row.email
+          AND program = grant_row.program;
+
+        INSERT INTO public.program_access_events (
+            action,
+            actor_user_id,
+            target_user_id,
+            target_email,
+            program,
+            old_role,
+            new_role,
+            details
+        )
+        VALUES (
+            'apply_pending',
+            grant_row.granted_by,
+            NEW.id,
+            normalized_email,
+            grant_row.program,
+            NULL,
+            grant_row.role,
+            jsonb_build_object('source', 'auth.users trigger')
+        );
+    END LOOP;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS apply_pending_program_access_grants ON auth.users;
+CREATE TRIGGER apply_pending_program_access_grants
+AFTER INSERT ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION public.apply_pending_program_access_grants();
+
+-- ---------------------------------------------------------------------------
+-- 6. RLS: explicit grants only, and programs are not world-readable metadata
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "user_programs_select_own_or_program_admin" ON public.user_programs;
+DROP POLICY IF EXISTS "user_programs_insert_program_admin" ON public.user_programs;
+DROP POLICY IF EXISTS "user_programs_update_program_admin" ON public.user_programs;
+DROP POLICY IF EXISTS "user_programs_delete_program_admin" ON public.user_programs;
+
+CREATE POLICY "user_programs_select_own_or_program_admin" ON public.user_programs
+    FOR SELECT TO authenticated
+    USING (user_id = auth.uid() OR public.can_manage_program(program));
+
+CREATE POLICY "user_programs_insert_program_admin" ON public.user_programs
+    FOR INSERT TO authenticated
+    WITH CHECK (public.can_manage_program(program));
+
+CREATE POLICY "user_programs_update_program_admin" ON public.user_programs
+    FOR UPDATE TO authenticated
+    USING (public.can_manage_program(program))
+    WITH CHECK (public.can_manage_program(program));
+
+CREATE POLICY "user_programs_delete_program_admin" ON public.user_programs
+    FOR DELETE TO authenticated
+    USING (public.can_manage_program(program));
+
+DROP POLICY IF EXISTS "programs_read" ON public.programs;
+DROP POLICY IF EXISTS "programs_select_scoped" ON public.programs;
+
+CREATE POLICY "programs_select_scoped" ON public.programs
+    FOR SELECT TO authenticated
+    USING (id = ANY(public.user_programs()) OR public.is_sonde_admin());
+
+CREATE OR REPLACE FUNCTION public.user_programs()
+RETURNS text[]
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    jwt_programs text[];
+    live_programs text[];
+    is_agent boolean := coalesce((auth.jwt() -> 'app_metadata' ->> 'agent')::boolean, false);
+    token_id_text text;
+    token_id uuid;
+    token_is_active boolean;
+BEGIN
+    jwt_programs := coalesce(
+        array(
+            SELECT jsonb_array_elements_text(auth.jwt() -> 'app_metadata' -> 'programs')
+        ),
+        ARRAY[]::text[]
+    );
+
+    IF is_agent THEN
+        token_id_text := auth.jwt() -> 'app_metadata' ->> 'token_id';
+        IF token_id_text IS NULL OR token_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+            RETURN ARRAY[]::text[];
+        END IF;
+
+        token_id := token_id_text::uuid;
+        SELECT EXISTS (
+            SELECT 1
+            FROM public.agent_tokens token
+            WHERE token.id = token_id
+              AND token.revoked_at IS NULL
+              AND token.expires_at > now()
+              AND jwt_programs <@ token.programs
+        )
+        INTO token_is_active;
+
+        IF NOT token_is_active THEN
+            RETURN ARRAY[]::text[];
+        END IF;
+
+        RETURN jwt_programs;
+    END IF;
+
+    SELECT coalesce(array_agg(up.program ORDER BY up.program), ARRAY[]::text[])
+    INTO live_programs
+    FROM public.user_programs up
+    WHERE up.user_id = auth.uid();
+
+    RETURN live_programs;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    claims jsonb;
+    app_meta jsonb;
+    user_email text;
+    user_programs_arr text[];
+    agent_programs text[];
+    is_admin boolean;
+    is_agent boolean;
+    token_id_text text;
+    token_id uuid;
+    token_name text;
+BEGIN
+    claims := event -> 'claims';
+    app_meta := coalesce(claims -> 'app_metadata', '{}'::jsonb);
+    user_email := claims ->> 'email';
+    is_agent := coalesce((app_meta ->> 'agent')::boolean, false);
+
+    IF user_email IS NOT NULL AND user_email NOT LIKE '%@aeolus.earth' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'http_code', 403,
+                'message', 'Only @aeolus.earth accounts are allowed'
+            )
+        );
+    END IF;
+
+    IF is_agent THEN
+        token_id_text := app_meta ->> 'token_id';
+        IF token_id_text IS NULL
+           OR token_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'http_code', 403,
+                    'message', 'Invalid or expired agent token'
+                )
+            );
+        END IF;
+
+        token_id := token_id_text::uuid;
+        SELECT token.programs, token.name
+        INTO agent_programs, token_name
+        FROM public.agent_tokens token
+        WHERE token.id = token_id
+          AND token.revoked_at IS NULL
+          AND token.expires_at > now();
+
+        IF NOT FOUND THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'http_code', 403,
+                    'message', 'Invalid or expired agent token'
+                )
+            );
+        END IF;
+
+        claims := jsonb_set(
+            claims,
+            '{app_metadata}',
+            app_meta ||
+            jsonb_build_object(
+                'agent', true,
+                'programs', to_jsonb(agent_programs),
+                'is_admin', false,
+                'token_id', token_id,
+                'token_name', token_name,
+                'agent_name', token_name
+            )
+        );
+
+        event := jsonb_set(event, '{claims}', claims);
+        RETURN event;
+    END IF;
+
+    SELECT
+        coalesce(array_agg(up.program ORDER BY up.program), ARRAY[]::text[]),
+        coalesce(bool_or(up.role = 'admin'), false)
+    INTO user_programs_arr, is_admin
+    FROM public.user_programs up
+    WHERE up.user_id = (claims ->> 'sub')::uuid;
+
+    claims := jsonb_set(
+        claims,
+        '{app_metadata}',
+        app_meta ||
+        jsonb_build_object(
+            'programs', to_jsonb(coalesce(user_programs_arr, ARRAY[]::text[])),
+            'is_admin', coalesce(is_admin, false)
+        )
+    );
+
+    event := jsonb_set(event, '{claims}', claims);
+    RETURN event;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb) TO supabase_auth_admin;
+GRANT SELECT ON TABLE public.user_programs TO supabase_auth_admin;
+GRANT SELECT ON TABLE public.agent_tokens TO supabase_auth_admin;
+REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb) FROM authenticated, anon, public;
+
+UPDATE public.schema_version
+SET version = GREATEST(version, 6),
+    updated_at = now()
+WHERE singleton = TRUE;

--- a/supabase/migrations/20260417000004_admin_access_dashboard.sql
+++ b/supabase/migrations/20260417000004_admin_access_dashboard.sql
@@ -1,0 +1,119 @@
+-- Admin access dashboard helpers. These RPCs expose only the programs and
+-- access rows the caller can manage, so the UI can remain a thin operator
+-- console over the existing Postgres-enforced RBAC model.
+
+CREATE OR REPLACE FUNCTION public.require_program_access_manager()
+RETURNS void
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF NOT public.is_sonde_admin()
+       AND coalesce(array_length(public.admin_programs(), 1), 0) = 0 THEN
+        RAISE EXCEPTION 'Program admin access required'
+            USING ERRCODE = '42501';
+    END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_manageable_programs()
+RETURNS TABLE (
+    id text,
+    name text,
+    description text,
+    created_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    PERFORM public.require_program_access_manager();
+
+    RETURN QUERY
+    SELECT p.id, p.name, p.description, p.created_at
+    FROM public.programs p
+    WHERE public.can_manage_program(p.id)
+    ORDER BY p.name, p.id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_manageable_program_access()
+RETURNS TABLE (
+    email text,
+    user_id uuid,
+    program text,
+    role text,
+    status text,
+    granted_at timestamptz,
+    applied_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    PERFORM public.require_program_access_manager();
+
+    RETURN QUERY
+    WITH manageable_programs AS (
+        SELECT p.id
+        FROM public.programs p
+        WHERE public.can_manage_program(p.id)
+    ),
+    active_access AS (
+        SELECT
+            lower(u.email)::text AS email,
+            up.user_id,
+            up.program,
+            up.role,
+            'active'::text AS status,
+            coalesce(g.created_at, up.created_at) AS granted_at,
+            g.applied_at
+        FROM public.user_programs up
+        JOIN manageable_programs mp ON mp.id = up.program
+        JOIN auth.users u ON u.id = up.user_id
+        LEFT JOIN public.program_access_grants g
+          ON g.email = lower(u.email)
+         AND g.program = up.program
+    ),
+    pending_access AS (
+        SELECT
+            g.email,
+            NULL::uuid AS user_id,
+            g.program,
+            g.role,
+            'pending'::text AS status,
+            g.created_at AS granted_at,
+            NULL::timestamptz AS applied_at
+        FROM public.program_access_grants g
+        JOIN manageable_programs mp ON mp.id = g.program
+        LEFT JOIN auth.users u ON lower(u.email) = g.email
+        LEFT JOIN public.user_programs up
+          ON up.user_id = u.id
+         AND up.program = g.program
+        WHERE u.id IS NULL
+    )
+    SELECT *
+    FROM active_access
+    UNION ALL
+    SELECT *
+    FROM pending_access
+    ORDER BY program, status, email;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.require_program_access_manager() FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.list_manageable_programs() FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.list_manageable_program_access() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.list_manageable_programs() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_manageable_program_access() TO authenticated;
+
+UPDATE public.schema_version
+SET version = GREATEST(version, 7),
+    updated_at = now()
+WHERE singleton = TRUE;

--- a/ui/src/components/admin/access-management.test.ts
+++ b/ui/src/components/admin/access-management.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import { createElement } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AdminAccessManagement } from "./access-management";
+
+const useManageableProgramsMock = vi.fn();
+const useManageableProgramAccessMock = vi.fn();
+const useGrantProgramAccessMock = vi.fn();
+const useRevokeProgramAccessMock = vi.fn();
+const useBulkGrantProgramAccessMock = vi.fn();
+
+vi.mock("@/hooks/use-admin-access", () => ({
+  useManageablePrograms: () => useManageableProgramsMock(),
+  useManageableProgramAccess: () => useManageableProgramAccessMock(),
+  useGrantProgramAccess: () => useGrantProgramAccessMock(),
+  useRevokeProgramAccess: () => useRevokeProgramAccessMock(),
+  useBulkGrantProgramAccess: () => useBulkGrantProgramAccessMock(),
+}));
+
+const programs = [
+  {
+    id: "alpha",
+    name: "Alpha Library",
+    description: null,
+    created_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: "beta",
+    name: "Beta Library",
+    description: null,
+    created_at: "2026-04-01T00:00:00Z",
+  },
+];
+
+describe("AdminAccessManagement", () => {
+  const grantMutate = vi.fn();
+  const revokeMutate = vi.fn();
+  const bulkMutate = vi.fn();
+
+  beforeEach(() => {
+    grantMutate.mockReset();
+    revokeMutate.mockReset();
+    bulkMutate.mockReset();
+    useManageableProgramsMock.mockReturnValue({
+      data: programs,
+      isLoading: false,
+      error: null,
+    });
+    useManageableProgramAccessMock.mockReturnValue({
+      data: [
+        {
+          email: "alice@aeolus.earth",
+          user_id: "user-1",
+          program: "alpha",
+          role: "admin",
+          status: "active",
+          granted_at: "2026-04-01T00:00:00Z",
+          applied_at: "2026-04-01T00:01:00Z",
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    useGrantProgramAccessMock.mockReturnValue({
+      mutate: grantMutate,
+      isPending: false,
+    });
+    useRevokeProgramAccessMock.mockReturnValue({
+      mutate: revokeMutate,
+      isPending: false,
+    });
+    useBulkGrantProgramAccessMock.mockReturnValue({
+      mutate: bulkMutate,
+      isPending: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the user/program access matrix", () => {
+    render(createElement(AdminAccessManagement));
+
+    expect(screen.getByText("Access management")).toBeVisible();
+    expect(screen.getByText("alice@aeolus.earth")).toBeVisible();
+    expect(screen.getAllByText("Alpha Library").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Beta Library").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Grant" })).toBeVisible();
+  });
+
+  it("previews and applies bulk FTE contributor grants", () => {
+    render(createElement(AdminAccessManagement));
+
+    fireEvent.change(screen.getByPlaceholderText(/alice@aeolus/i), {
+      target: {
+        value: "alice@aeolus.earth bob@aeolus.earth",
+      },
+    });
+
+    expect(screen.getByText("2 valid emails")).toBeVisible();
+    expect(screen.getByText("3 grants to add")).toBeVisible();
+    expect(screen.getByText("1 already covered")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply FTE grants" }));
+
+    expect(bulkMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emails: ["alice@aeolus.earth", "bob@aeolus.earth"],
+        programs,
+        role: "contributor",
+      }),
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+      }),
+    );
+  });
+
+  it("blocks invalid non-Aeolus emails before bulk writes", () => {
+    render(createElement(AdminAccessManagement));
+
+    fireEvent.change(screen.getByPlaceholderText(/alice@aeolus/i), {
+      target: {
+        value: "contractor@example.com",
+      },
+    });
+
+    expect(screen.getByText("Invalid entries: contractor@example.com")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Apply FTE grants" })).toBeDisabled();
+  });
+});

--- a/ui/src/components/admin/access-management.test.ts
+++ b/ui/src/components/admin/access-management.test.ts
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
 import { createElement } from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AdminAccessManagement } from "./access-management";
 
 const useManageableProgramsMock = vi.fn();
 const useManageableProgramAccessMock = vi.fn();
+const useProgramAccessEventsMock = vi.fn();
 const useGrantProgramAccessMock = vi.fn();
 const useRevokeProgramAccessMock = vi.fn();
 const useBulkGrantProgramAccessMock = vi.fn();
@@ -14,6 +15,7 @@ const useBulkGrantProgramAccessMock = vi.fn();
 vi.mock("@/hooks/use-admin-access", () => ({
   useManageablePrograms: () => useManageableProgramsMock(),
   useManageableProgramAccess: () => useManageableProgramAccessMock(),
+  useProgramAccessEvents: (filters: unknown) => useProgramAccessEventsMock(filters),
   useGrantProgramAccess: () => useGrantProgramAccessMock(),
   useRevokeProgramAccess: () => useRevokeProgramAccessMock(),
   useBulkGrantProgramAccess: () => useBulkGrantProgramAccessMock(),
@@ -34,15 +36,53 @@ const programs = [
   },
 ];
 
+const accessEvents = [
+  {
+    id: 1,
+    action: "grant",
+    actor_email: "root@aeolus.earth",
+    target_email: "alice@aeolus.earth",
+    program: "alpha",
+    old_role: null,
+    new_role: "admin",
+    details: { status: "active" },
+    created_at: "2026-04-03T00:00:00Z",
+  },
+  {
+    id: 2,
+    action: "revoke",
+    actor_email: "root@aeolus.earth",
+    target_email: "bob@aeolus.earth",
+    program: "beta",
+    old_role: "contributor",
+    new_role: null,
+    details: {},
+    created_at: "2026-04-02T00:00:00Z",
+  },
+  {
+    id: 3,
+    action: "apply_pending",
+    actor_email: null,
+    target_email: "carol@aeolus.earth",
+    program: "alpha",
+    old_role: null,
+    new_role: "contributor",
+    details: { source: "auth.users trigger" },
+    created_at: "2026-04-01T00:00:00Z",
+  },
+];
+
 describe("AdminAccessManagement", () => {
   const grantMutate = vi.fn();
   const revokeMutate = vi.fn();
   const bulkMutate = vi.fn();
+  let confirmMock: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     grantMutate.mockReset();
     revokeMutate.mockReset();
     bulkMutate.mockReset();
+    confirmMock = vi.spyOn(window, "confirm").mockReturnValue(true);
     useManageableProgramsMock.mockReturnValue({
       data: programs,
       isLoading: false,
@@ -63,6 +103,23 @@ describe("AdminAccessManagement", () => {
       isLoading: false,
       error: null,
     });
+    useProgramAccessEventsMock.mockImplementation(
+      ({
+        action,
+        program,
+      }: {
+        action?: string;
+        program?: string;
+      } = {}) => ({
+        data: accessEvents.filter(
+          (event) =>
+            (!action || event.action === action) &&
+            (!program || event.program === program),
+        ),
+        isLoading: false,
+        error: null,
+      }),
+    );
     useGrantProgramAccessMock.mockReturnValue({
       mutate: grantMutate,
       isPending: false,
@@ -79,19 +136,26 @@ describe("AdminAccessManagement", () => {
 
   afterEach(() => {
     cleanup();
+    confirmMock.mockRestore();
   });
 
   it("renders the user/program access matrix", () => {
     render(createElement(AdminAccessManagement));
 
     expect(screen.getByText("Access management")).toBeVisible();
-    expect(screen.getByText("alice@aeolus.earth")).toBeVisible();
+    const matrixPanel = screen.getByRole("heading", { name: "User access matrix" })
+      .parentElement?.parentElement?.parentElement;
+
+    expect(matrixPanel).toBeTruthy();
+    expect(within(matrixPanel!).getByText("alice@aeolus.earth")).toBeVisible();
     expect(screen.getAllByText("Alpha Library").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Beta Library").length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Grant" })).toBeVisible();
+    expect(screen.getByText("Recent access changes")).toBeVisible();
+    expect(screen.getByText("bob@aeolus.earth")).toBeVisible();
   });
 
-  it("previews and applies bulk FTE contributor grants", () => {
+  it("previews, confirms, and applies bulk FTE contributor grants", () => {
     render(createElement(AdminAccessManagement));
 
     fireEvent.change(screen.getByPlaceholderText(/alice@aeolus/i), {
@@ -106,6 +170,9 @@ describe("AdminAccessManagement", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Apply FTE grants" }));
 
+    expect(confirmMock).toHaveBeenCalledWith(
+      expect.stringContaining("add 3 contributor grants"),
+    );
     expect(bulkMutate).toHaveBeenCalledWith(
       expect.objectContaining({
         emails: ["alice@aeolus.earth", "bob@aeolus.earth"],
@@ -116,6 +183,21 @@ describe("AdminAccessManagement", () => {
         onSuccess: expect.any(Function),
       }),
     );
+  });
+
+  it("does not apply bulk FTE grants when confirmation is cancelled", () => {
+    confirmMock.mockReturnValue(false);
+    render(createElement(AdminAccessManagement));
+
+    fireEvent.change(screen.getByPlaceholderText(/alice@aeolus/i), {
+      target: {
+        value: "alice@aeolus.earth bob@aeolus.earth",
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply FTE grants" }));
+
+    expect(confirmMock).toHaveBeenCalled();
+    expect(bulkMutate).not.toHaveBeenCalled();
   });
 
   it("blocks invalid non-Aeolus emails before bulk writes", () => {
@@ -129,5 +211,63 @@ describe("AdminAccessManagement", () => {
 
     expect(screen.getByText("Invalid entries: contractor@example.com")).toBeVisible();
     expect(screen.getByRole("button", { name: "Apply FTE grants" })).toBeDisabled();
+  });
+
+  it("filters users by pending access", () => {
+    useManageableProgramAccessMock.mockReturnValue({
+      data: [
+        {
+          email: "alice@aeolus.earth",
+          user_id: "user-1",
+          program: "alpha",
+          role: "admin",
+          status: "active",
+          granted_at: "2026-04-01T00:00:00Z",
+          applied_at: "2026-04-01T00:01:00Z",
+        },
+        {
+          email: "carol@aeolus.earth",
+          user_id: null,
+          program: "beta",
+          role: "contributor",
+          status: "pending",
+          granted_at: "2026-04-02T00:00:00Z",
+          applied_at: null,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    render(createElement(AdminAccessManagement));
+
+    fireEvent.change(screen.getByLabelText("Filter users by access status"), {
+      target: { value: "pending" },
+    });
+
+    const matrixPanel = screen.getByRole("heading", { name: "User access matrix" })
+      .parentElement?.parentElement?.parentElement;
+
+    expect(matrixPanel).toBeTruthy();
+    expect(within(matrixPanel!).queryByText("alice@aeolus.earth")).not.toBeInTheDocument();
+    expect(within(matrixPanel!).getByText("carol@aeolus.earth")).toBeVisible();
+  });
+
+  it("filters recent access changes by action and program", () => {
+    render(createElement(AdminAccessManagement));
+
+    fireEvent.change(screen.getByLabelText("Filter access changes by action"), {
+      target: { value: "revoke" },
+    });
+    fireEvent.change(screen.getByLabelText("Filter access changes by program"), {
+      target: { value: "beta" },
+    });
+
+    const auditPanel = screen.getByRole("heading", { name: "Recent access changes" })
+      .parentElement?.parentElement?.parentElement;
+
+    expect(auditPanel).toBeTruthy();
+    expect(within(auditPanel!).getByText("bob@aeolus.earth")).toBeVisible();
+    expect(within(auditPanel!).queryByText("alice@aeolus.earth")).not.toBeInTheDocument();
+    expect(within(auditPanel!).queryByText("carol@aeolus.earth")).not.toBeInTheDocument();
   });
 });

--- a/ui/src/components/admin/access-management.tsx
+++ b/ui/src/components/admin/access-management.tsx
@@ -4,8 +4,11 @@ import {
   useGrantProgramAccess,
   useManageableProgramAccess,
   useManageablePrograms,
+  useProgramAccessEvents,
   useRevokeProgramAccess,
   type BulkGrantProgramAccessResult,
+  type ProgramAccessEventAction,
+  type ProgramAccessEventRow,
 } from "@/hooks/use-admin-access";
 import {
   buildBulkGrantPreview,
@@ -24,6 +27,19 @@ import type { Program } from "@/types/sonde";
 const cardClass = "rounded-[8px] border border-border bg-surface p-3";
 const controlClass =
   "rounded-[6px] border border-border bg-surface px-2 py-1 text-[12px] text-text placeholder:text-text-quaternary";
+
+type AccessMatrixStatusFilter = "all" | "active" | "pending";
+type ProgramAccessEventActionFilter = "all" | ProgramAccessEventAction;
+
+const accessEventActionOptions: Array<{
+  value: ProgramAccessEventActionFilter;
+  label: string;
+}> = [
+  { value: "all", label: "All changes" },
+  { value: "grant", label: "Grants" },
+  { value: "revoke", label: "Revokes" },
+  { value: "apply_pending", label: "Pending activations" },
+];
 
 function AccessStatCard({
   label,
@@ -57,6 +73,10 @@ function roleLabel(role: ProgramAccessRole): string {
   return role === "admin" ? "admin" : "contributor";
 }
 
+function optionalRoleLabel(role: ProgramAccessRole | null): string {
+  return role ? roleLabel(role) : "access";
+}
+
 function statusVariant(cell: ProgramAccessCell): "complete" | "open" | "running" {
   if (cell.status === "pending") {
     return "open";
@@ -72,6 +92,38 @@ function currentCellTitle(cell: ProgramAccessCell): string {
 
 function normalizeSearch(value: string): string {
   return value.trim().toLowerCase();
+}
+
+function eventActionLabel(action: ProgramAccessEventAction): string {
+  if (action === "revoke") {
+    return "Revoked";
+  }
+  if (action === "apply_pending") {
+    return "Activated";
+  }
+  return "Granted";
+}
+
+function eventVariant(
+  action: ProgramAccessEventAction,
+): "complete" | "open" | "superseded" {
+  if (action === "apply_pending") {
+    return "open";
+  }
+  return action === "revoke" ? "superseded" : "complete";
+}
+
+function eventRoleSummary(event: ProgramAccessEventRow): string {
+  if (event.action === "revoke") {
+    return `${optionalRoleLabel(event.old_role)} removed`;
+  }
+  if (event.old_role && event.new_role && event.old_role !== event.new_role) {
+    return `${roleLabel(event.old_role)} -> ${roleLabel(event.new_role)}`;
+  }
+  if (event.new_role) {
+    return roleLabel(event.new_role);
+  }
+  return "access updated";
 }
 
 function grantableProgramsForBulk({
@@ -91,10 +143,15 @@ function grantableProgramsForBulk({
 
 export function AdminAccessManagement() {
   const [userFilter, setUserFilter] = useState("");
+  const [accessStatusFilter, setAccessStatusFilter] =
+    useState<AccessMatrixStatusFilter>("all");
   const [grantEmail, setGrantEmail] = useState("");
   const [grantProgram, setGrantProgram] = useState("");
   const [grantRole, setGrantRole] = useState<ProgramAccessRole>("contributor");
   const [bulkInput, setBulkInput] = useState("");
+  const [eventActionFilter, setEventActionFilter] =
+    useState<ProgramAccessEventActionFilter>("all");
+  const [eventProgramFilter, setEventProgramFilter] = useState("");
   const [lastBulkResult, setLastBulkResult] =
     useState<BulkGrantProgramAccessResult | null>(null);
 
@@ -108,22 +165,42 @@ export function AdminAccessManagement() {
     isLoading: accessLoading,
     error: accessError,
   } = useManageableProgramAccess();
+  const {
+    data: accessEvents = [],
+    isLoading: accessEventsLoading,
+    error: accessEventsError,
+  } = useProgramAccessEvents({
+    action: eventActionFilter === "all" ? undefined : eventActionFilter,
+    program: eventProgramFilter || undefined,
+  });
   const grantAccess = useGrantProgramAccess();
   const revokeAccess = useRevokeProgramAccess();
   const bulkGrantAccess = useBulkGrantProgramAccess();
 
   const selectedGrantProgram = grantProgram || programs[0]?.id || "";
+  const programsById = useMemo(
+    () => new Map(programs.map((program) => [program.id, program])),
+    [programs],
+  );
   const matrix = useMemo(
     () => buildProgramAccessMatrix(programs, accessRows),
     [accessRows, programs],
   );
   const filteredMatrix = useMemo(() => {
     const filter = normalizeSearch(userFilter);
-    if (!filter) {
-      return matrix;
-    }
-    return matrix.filter((row) => row.email.includes(filter));
-  }, [matrix, userFilter]);
+    return matrix.filter((row) => {
+      if (filter && !row.email.includes(filter)) {
+        return false;
+      }
+      if (accessStatusFilter === "active" && row.activeCount === 0) {
+        return false;
+      }
+      if (accessStatusFilter === "pending" && row.pendingCount === 0) {
+        return false;
+      }
+      return true;
+    });
+  }, [accessStatusFilter, matrix, userFilter]);
   const bulkPreview = useMemo(
     () =>
       buildBulkGrantPreview({
@@ -175,6 +252,13 @@ export function AdminAccessManagement() {
     if (!canBulkGrant) {
       return;
     }
+    if (
+      !window.confirm(
+        `Apply FTE grants for ${bulkPreview.validEmails.length} emails across ${bulkGrantablePrograms.length} programs? This will add ${bulkPreview.grantCount} contributor grants and skip ${bulkPreview.alreadyGrantedCount} existing grants. Existing admins will not be downgraded.`,
+      )
+    ) {
+      return;
+    }
     bulkGrantAccess.mutate(
       {
         emails: bulkPreview.validEmails,
@@ -212,12 +296,12 @@ export function AdminAccessManagement() {
             Access management
           </h2>
           <p className="mt-0.5 max-w-[720px] text-[11px] leading-relaxed text-text-quaternary">
-            Manage who can see each Sonde program / library. FTE bulk grants add
-            contributor access only where it is missing, so existing admin grants are
-            preserved instead of silently downgraded.
+            Manage users with active or pending Sonde program / library access. FTE
+            bulk grants add contributor access only where it is missing, so existing
+            admin grants are preserved instead of silently downgraded.
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
           <input
             type="search"
             value={userFilter}
@@ -225,6 +309,18 @@ export function AdminAccessManagement() {
             placeholder="Filter users"
             className={cn(controlClass, "w-full sm:w-[220px]")}
           />
+          <select
+            value={accessStatusFilter}
+            onChange={(event) =>
+              setAccessStatusFilter(event.target.value as AccessMatrixStatusFilter)
+            }
+            className={cn(controlClass, "w-full sm:w-[130px]")}
+            aria-label="Filter users by access status"
+          >
+            <option value="all">All access</option>
+            <option value="active">Active</option>
+            <option value="pending">Pending</option>
+          </select>
         </div>
       </div>
 
@@ -390,8 +486,8 @@ export function AdminAccessManagement() {
               User access matrix
             </h3>
             <p className="mt-0.5 text-[11px] text-text-quaternary">
-              Role changes here are explicit. Bulk FTE grants never downgrade existing
-              admins.
+              Showing users with active or pending program access. Role changes here
+              are explicit; bulk FTE grants never downgrade existing admins.
             </p>
           </div>
           <Badge variant="tag">{filteredMatrix.length} shown</Badge>
@@ -409,7 +505,7 @@ export function AdminAccessManagement() {
           </p>
         ) : filteredMatrix.length === 0 ? (
           <p className="px-3 py-4 text-[12px] text-text-quaternary">
-            No users match this filter yet.
+            No users match these access filters yet.
           </p>
         ) : (
           <div className="overflow-x-auto">
@@ -511,6 +607,107 @@ export function AdminAccessManagement() {
                 ))}
               </tbody>
             </table>
+          </div>
+        )}
+      </div>
+
+      <div className={cn(cardClass, "overflow-hidden p-0")}>
+        <div className="flex flex-col gap-3 border-b border-border px-3 py-2 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h3 className="text-[12px] font-medium text-text">
+              Recent access changes
+            </h3>
+            <p className="mt-0.5 text-[11px] leading-relaxed text-text-quaternary">
+              Audit trail for grants, revokes, and pending grants that became active
+              on first sign-in. Visibility is scoped by the same program-admin RLS.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <select
+              value={eventActionFilter}
+              onChange={(event) =>
+                setEventActionFilter(
+                  event.target.value as ProgramAccessEventActionFilter,
+                )
+              }
+              className={cn(controlClass, "w-full sm:w-[170px]")}
+              aria-label="Filter access changes by action"
+            >
+              {accessEventActionOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <select
+              value={eventProgramFilter}
+              onChange={(event) => setEventProgramFilter(event.target.value)}
+              className={cn(controlClass, "w-full sm:w-[180px]")}
+              aria-label="Filter access changes by program"
+            >
+              <option value="">All programs</option>
+              {programs.map((program) => (
+                <option key={program.id} value={program.id}>
+                  {program.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {accessEventsLoading ? (
+          <div className="space-y-2 px-3 py-3">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ) : accessEventsError instanceof Error ? (
+          <div className="px-3 py-4">
+            <p className="text-[12px] font-medium text-status-failed">
+              Access changes failed to load
+            </p>
+            <p className="mt-1 text-[11px] text-status-failed">
+              {accessEventsError.message}
+            </p>
+          </div>
+        ) : accessEvents.length === 0 ? (
+          <p className="px-3 py-4 text-[12px] text-text-quaternary">
+            No access changes match these filters yet.
+          </p>
+        ) : (
+          <div className="divide-y divide-border-subtle">
+            {accessEvents.map((event) => {
+              const program = programsById.get(event.program);
+              return (
+                <div
+                  key={event.id}
+                  className="grid gap-2 px-3 py-2 text-[12px] sm:grid-cols-[150px_1fr_170px]"
+                >
+                  <div className="flex items-center gap-2">
+                    <Badge variant={eventVariant(event.action)}>
+                      {eventActionLabel(event.action)}
+                    </Badge>
+                    <span className="text-[10px] text-text-quaternary">
+                      {formatDateTimeShort(event.created_at)}
+                    </span>
+                  </div>
+                  <div className="min-w-0">
+                    <p className="truncate font-medium text-text" title={event.target_email}>
+                      {event.target_email}
+                    </p>
+                    <p className="mt-0.5 truncate text-[11px] text-text-quaternary">
+                      {program?.name ?? event.program} · {eventRoleSummary(event)}
+                    </p>
+                  </div>
+                  <p
+                    className="truncate text-[11px] text-text-quaternary sm:text-right"
+                    title={event.actor_email ?? "system"}
+                  >
+                    by {event.actor_email ?? "system"}
+                  </p>
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/ui/src/components/admin/access-management.tsx
+++ b/ui/src/components/admin/access-management.tsx
@@ -1,0 +1,519 @@
+import { useMemo, useState } from "react";
+import {
+  useBulkGrantProgramAccess,
+  useGrantProgramAccess,
+  useManageableProgramAccess,
+  useManageablePrograms,
+  useRevokeProgramAccess,
+  type BulkGrantProgramAccessResult,
+} from "@/hooks/use-admin-access";
+import {
+  buildBulkGrantPreview,
+  buildProgramAccessMatrix,
+  parseAeolusEmailList,
+  type ProgramAccessCell,
+  type ProgramAccessRole,
+  type ProgramAccessUserRow,
+} from "@/lib/admin-access-matrix";
+import { formatDateTimeShort, cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { Program } from "@/types/sonde";
+
+const cardClass = "rounded-[8px] border border-border bg-surface p-3";
+const controlClass =
+  "rounded-[6px] border border-border bg-surface px-2 py-1 text-[12px] text-text placeholder:text-text-quaternary";
+
+function AccessStatCard({
+  label,
+  value,
+  loading,
+}: {
+  label: string;
+  value: number | string;
+  loading?: boolean;
+}) {
+  if (loading) {
+    return (
+      <div className="rounded-[8px] border border-border-subtle bg-surface-raised px-3 py-2">
+        <Skeleton className="mb-1 h-5 w-10" />
+        <Skeleton className="h-3 w-20" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-[8px] border border-border-subtle bg-surface-raised px-3 py-2">
+      <p className="text-[17px] font-semibold tracking-[-0.02em] text-text">
+        {value}
+      </p>
+      <p className="text-[11px] text-text-tertiary">{label}</p>
+    </div>
+  );
+}
+
+function roleLabel(role: ProgramAccessRole): string {
+  return role === "admin" ? "admin" : "contributor";
+}
+
+function statusVariant(cell: ProgramAccessCell): "complete" | "open" | "running" {
+  if (cell.status === "pending") {
+    return "open";
+  }
+  return cell.role === "admin" ? "running" : "complete";
+}
+
+function currentCellTitle(cell: ProgramAccessCell): string {
+  const when = cell.appliedAt ?? cell.grantedAt;
+  const status = cell.status === "pending" ? "pending grant" : "active grant";
+  return when ? `${status}, ${formatDateTimeShort(when)}` : status;
+}
+
+function normalizeSearch(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function grantableProgramsForBulk({
+  programs,
+  matrix,
+  emails,
+}: {
+  programs: Program[];
+  matrix: ProgramAccessUserRow[];
+  emails: string[];
+}): Program[] {
+  const rowsByEmail = new Map(matrix.map((row) => [row.email, row]));
+  return programs.filter((program) =>
+    emails.some((email) => !rowsByEmail.get(email)?.cells[program.id]),
+  );
+}
+
+export function AdminAccessManagement() {
+  const [userFilter, setUserFilter] = useState("");
+  const [grantEmail, setGrantEmail] = useState("");
+  const [grantProgram, setGrantProgram] = useState("");
+  const [grantRole, setGrantRole] = useState<ProgramAccessRole>("contributor");
+  const [bulkInput, setBulkInput] = useState("");
+  const [lastBulkResult, setLastBulkResult] =
+    useState<BulkGrantProgramAccessResult | null>(null);
+
+  const {
+    data: programs = [],
+    isLoading: programsLoading,
+    error: programsError,
+  } = useManageablePrograms();
+  const {
+    data: accessRows = [],
+    isLoading: accessLoading,
+    error: accessError,
+  } = useManageableProgramAccess();
+  const grantAccess = useGrantProgramAccess();
+  const revokeAccess = useRevokeProgramAccess();
+  const bulkGrantAccess = useBulkGrantProgramAccess();
+
+  const selectedGrantProgram = grantProgram || programs[0]?.id || "";
+  const matrix = useMemo(
+    () => buildProgramAccessMatrix(programs, accessRows),
+    [accessRows, programs],
+  );
+  const filteredMatrix = useMemo(() => {
+    const filter = normalizeSearch(userFilter);
+    if (!filter) {
+      return matrix;
+    }
+    return matrix.filter((row) => row.email.includes(filter));
+  }, [matrix, userFilter]);
+  const bulkPreview = useMemo(
+    () =>
+      buildBulkGrantPreview({
+        input: bulkInput,
+        programs,
+        matrix,
+      }),
+    [bulkInput, matrix, programs],
+  );
+  const bulkGrantablePrograms = useMemo(
+    () =>
+      grantableProgramsForBulk({
+        programs,
+        matrix,
+        emails: bulkPreview.validEmails,
+      }),
+    [bulkPreview.validEmails, matrix, programs],
+  );
+  const singleGrantParsed = useMemo(
+    () => parseAeolusEmailList(grantEmail),
+    [grantEmail],
+  );
+  const activeGrantCount = accessRows.filter((row) => row.status === "active").length;
+  const pendingGrantCount = accessRows.filter((row) => row.status === "pending").length;
+  const isLoading = programsLoading || accessLoading;
+  const loadError = programsError ?? accessError;
+  const canSingleGrant =
+    singleGrantParsed.validEmails.length === 1 &&
+    singleGrantParsed.invalidEntries.length === 0 &&
+    Boolean(selectedGrantProgram);
+  const canBulkGrant =
+    bulkPreview.validEmails.length > 0 &&
+    bulkPreview.invalidEntries.length === 0 &&
+    bulkPreview.grantCount > 0 &&
+    bulkGrantablePrograms.length > 0;
+
+  function handleSingleGrant() {
+    if (!canSingleGrant) {
+      return;
+    }
+    grantAccess.mutate({
+      email: singleGrantParsed.validEmails[0]!,
+      program: selectedGrantProgram,
+      role: grantRole,
+    });
+  }
+
+  function handleBulkGrant() {
+    if (!canBulkGrant) {
+      return;
+    }
+    bulkGrantAccess.mutate(
+      {
+        emails: bulkPreview.validEmails,
+        programs: bulkGrantablePrograms,
+        matrix,
+        role: "contributor",
+      },
+      {
+        onSuccess: (result) => {
+          setLastBulkResult(result);
+          if (result.failed === 0) {
+            setBulkInput("");
+          }
+        },
+      },
+    );
+  }
+
+  function handleRevoke(email: string, program: string) {
+    if (
+      !window.confirm(
+        `Revoke ${email}'s access to ${program}? This removes database access immediately; their UI may need to refresh.`,
+      )
+    ) {
+      return;
+    }
+    revokeAccess.mutate({ email, program });
+  }
+
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-[13px] font-medium text-text-secondary">
+            Access management
+          </h2>
+          <p className="mt-0.5 max-w-[720px] text-[11px] leading-relaxed text-text-quaternary">
+            Manage who can see each Sonde program / library. FTE bulk grants add
+            contributor access only where it is missing, so existing admin grants are
+            preserved instead of silently downgraded.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            type="search"
+            value={userFilter}
+            onChange={(event) => setUserFilter(event.target.value)}
+            placeholder="Filter users"
+            className={cn(controlClass, "w-full sm:w-[220px]")}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <AccessStatCard
+          value={programs.length}
+          label="Manageable programs"
+          loading={isLoading}
+        />
+        <AccessStatCard value={matrix.length} label="Users with access" loading={isLoading} />
+        <AccessStatCard
+          value={activeGrantCount}
+          label="Active grants"
+          loading={isLoading}
+        />
+        <AccessStatCard
+          value={pendingGrantCount}
+          label="Pending grants"
+          loading={isLoading}
+        />
+      </div>
+
+      {loadError instanceof Error && (
+        <div className="rounded-[8px] border border-status-failed/30 bg-status-failed/5 px-3 py-3">
+          <p className="text-[12px] font-medium text-status-failed">
+            Access management failed to load
+          </p>
+          <p className="mt-1 text-[11px] leading-relaxed text-status-failed">
+            {loadError.message}
+          </p>
+        </div>
+      )}
+
+      <div className="grid gap-3 lg:grid-cols-[1fr_1.4fr]">
+        <div className={cardClass}>
+          <h3 className="text-[12px] font-medium text-text">Grant one user</h3>
+          <p className="mt-1 text-[11px] leading-relaxed text-text-quaternary">
+            Use this for contractors or one-off changes. New users can be granted access
+            before they sign in; the grant becomes active on first login.
+          </p>
+          <div className="mt-3 grid gap-2">
+            <input
+              type="email"
+              value={grantEmail}
+              onChange={(event) => setGrantEmail(event.target.value)}
+              placeholder="person@aeolus.earth"
+              className={controlClass}
+            />
+            <div className="grid gap-2 sm:grid-cols-[1fr_150px]">
+              <select
+                value={selectedGrantProgram}
+                onChange={(event) => setGrantProgram(event.target.value)}
+                className={controlClass}
+                disabled={programs.length === 0}
+              >
+                {programs.map((program) => (
+                  <option key={program.id} value={program.id}>
+                    {program.name}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={grantRole}
+                onChange={(event) => setGrantRole(event.target.value as ProgramAccessRole)}
+                className={controlClass}
+              >
+                <option value="contributor">contributor</option>
+                <option value="admin">admin</option>
+              </select>
+            </div>
+            {singleGrantParsed.invalidEntries.length > 0 && (
+              <p className="text-[11px] text-status-failed">
+                Only @aeolus.earth emails can receive access.
+              </p>
+            )}
+            <Button
+              size="sm"
+              onClick={handleSingleGrant}
+              disabled={!canSingleGrant || grantAccess.isPending}
+            >
+              Grant access
+            </Button>
+          </div>
+        </div>
+
+        <div className={cardClass}>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h3 className="text-[12px] font-medium text-text">
+                Bulk grant FTE list
+              </h3>
+              <p className="mt-1 text-[11px] leading-relaxed text-text-quaternary">
+                Paste Aeolus FTE emails to give contributor access to every manageable
+                program / library. Existing grants are skipped.
+              </p>
+            </div>
+            <Badge variant="tag">contributor only</Badge>
+          </div>
+          <textarea
+            value={bulkInput}
+            onChange={(event) => {
+              setBulkInput(event.target.value);
+              setLastBulkResult(null);
+            }}
+            placeholder={"alice@aeolus.earth\nbob@aeolus.earth"}
+            className={cn(controlClass, "mt-3 min-h-[96px] w-full resize-y leading-relaxed")}
+          />
+          <div className="mt-3 grid gap-2 text-[11px] text-text-tertiary sm:grid-cols-4">
+            <span>{bulkPreview.validEmails.length} valid emails</span>
+            <span>{bulkPreview.programCount} programs</span>
+            <span>{bulkPreview.grantCount} grants to add</span>
+            <span>{bulkPreview.alreadyGrantedCount} already covered</span>
+          </div>
+          {(bulkPreview.invalidEntries.length > 0 || bulkPreview.duplicates.length > 0) && (
+            <div className="mt-3 rounded-[8px] border border-border-subtle bg-surface-raised px-3 py-2 text-[11px] leading-relaxed">
+              {bulkPreview.invalidEntries.length > 0 && (
+                <p className="text-status-failed">
+                  Invalid entries: {bulkPreview.invalidEntries.join(", ")}
+                </p>
+              )}
+              {bulkPreview.duplicates.length > 0 && (
+                <p className="text-text-quaternary">
+                  Duplicates skipped: {bulkPreview.duplicates.join(", ")}
+                </p>
+              )}
+            </div>
+          )}
+          {lastBulkResult && (
+            <div className="mt-3 rounded-[8px] border border-border-subtle bg-surface-raised px-3 py-2 text-[11px] leading-relaxed text-text-tertiary">
+              <p>
+                Last run: {lastBulkResult.granted} granted, {lastBulkResult.skipped} skipped,
+                {" "}
+                {lastBulkResult.failed} failed.
+              </p>
+              {lastBulkResult.failures.slice(0, 3).map((failure) => (
+                <p key={`${failure.email}-${failure.program}`} className="text-status-failed">
+                  {failure.email} / {failure.program}: {failure.message}
+                </p>
+              ))}
+            </div>
+          )}
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              onClick={handleBulkGrant}
+              disabled={!canBulkGrant || bulkGrantAccess.isPending}
+            >
+              Apply FTE grants
+            </Button>
+            {bulkPreview.grantCount === 0 && bulkPreview.validEmails.length > 0 && (
+              <span className="text-[11px] text-text-quaternary">
+                Everyone in this list already has access to all manageable programs.
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className={cn(cardClass, "overflow-hidden p-0")}>
+        <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2">
+          <div>
+            <h3 className="text-[12px] font-medium text-text">
+              User access matrix
+            </h3>
+            <p className="mt-0.5 text-[11px] text-text-quaternary">
+              Role changes here are explicit. Bulk FTE grants never downgrade existing
+              admins.
+            </p>
+          </div>
+          <Badge variant="tag">{filteredMatrix.length} shown</Badge>
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-2 px-3 py-3">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ) : programs.length === 0 ? (
+          <p className="px-3 py-4 text-[12px] text-text-quaternary">
+            No manageable programs are visible to this admin account.
+          </p>
+        ) : filteredMatrix.length === 0 ? (
+          <p className="px-3 py-4 text-[12px] text-text-quaternary">
+            No users match this filter yet.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-[860px] w-full border-collapse text-left text-[12px]">
+              <thead>
+                <tr className="border-b border-border bg-surface-raised text-[11px] text-text-tertiary">
+                  <th className="sticky left-0 z-10 w-[240px] bg-surface-raised px-3 py-2 font-medium">
+                    User
+                  </th>
+                  {programs.map((program) => (
+                    <th key={program.id} className="min-w-[170px] px-3 py-2 font-medium">
+                      <span className="block truncate" title={program.name}>
+                        {program.name}
+                      </span>
+                      <span className="block truncate text-[10px] text-text-quaternary">
+                        {program.id}
+                      </span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {filteredMatrix.map((row) => (
+                  <tr key={row.email} className="border-b border-border-subtle last:border-0">
+                    <td className="sticky left-0 z-10 bg-surface px-3 py-2 align-top">
+                      <p className="font-medium text-text">{row.email}</p>
+                      <p className="mt-1 text-[11px] text-text-quaternary">
+                        {row.activeCount} active, {row.pendingCount} pending
+                      </p>
+                    </td>
+                    {programs.map((program) => {
+                      const cell = row.cells[program.id];
+                      return (
+                        <td key={program.id} className="px-3 py-2 align-top">
+                          {cell ? (
+                            <div className="space-y-2">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <Badge variant={statusVariant(cell)}>
+                                  {cell.status === "pending"
+                                    ? "pending"
+                                    : roleLabel(cell.role)}
+                                </Badge>
+                                <span
+                                  className="text-[10px] text-text-quaternary"
+                                  title={currentCellTitle(cell)}
+                                >
+                                  {cell.status === "pending" ? "not signed in" : "active"}
+                                </span>
+                              </div>
+                              <div className="flex flex-wrap items-center gap-1.5">
+                                <select
+                                  value={cell.role}
+                                  onChange={(event) =>
+                                    grantAccess.mutate({
+                                      email: row.email,
+                                      program: program.id,
+                                      role: event.target.value as ProgramAccessRole,
+                                    })
+                                  }
+                                  className={cn(controlClass, "max-w-[118px]")}
+                                  aria-label={`Role for ${row.email} in ${program.name}`}
+                                  disabled={grantAccess.isPending || revokeAccess.isPending}
+                                >
+                                  <option value="contributor">contributor</option>
+                                  <option value="admin">admin</option>
+                                </select>
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => handleRevoke(row.email, program.id)}
+                                  disabled={grantAccess.isPending || revokeAccess.isPending}
+                                >
+                                  Revoke
+                                </Button>
+                              </div>
+                            </div>
+                          ) : (
+                            <Button
+                              type="button"
+                              variant="secondary"
+                              size="sm"
+                              onClick={() =>
+                                grantAccess.mutate({
+                                  email: row.email,
+                                  program: program.id,
+                                  role: "contributor",
+                                })
+                              }
+                              disabled={grantAccess.isPending || revokeAccess.isPending}
+                            >
+                              Grant
+                            </Button>
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/ui/src/components/layout/program-switcher.test.ts
+++ b/ui/src/components/layout/program-switcher.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { createElement } from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProgramSwitcher } from "./program-switcher";
+
+const useProgramsMock = vi.fn();
+const useActiveProgramMock = vi.fn();
+const useSetActiveProgramMock = vi.fn();
+
+vi.mock("@/hooks/use-programs", () => ({
+  usePrograms: () => useProgramsMock(),
+}));
+
+vi.mock("@/stores/program", () => ({
+  useActiveProgram: () => useActiveProgramMock(),
+  useSetActiveProgram: () => useSetActiveProgramMock(),
+}));
+
+describe("ProgramSwitcher", () => {
+  beforeEach(() => {
+    useActiveProgramMock.mockReturnValue("");
+    useSetActiveProgramMock.mockReturnValue(vi.fn());
+  });
+
+  it("shows an explicit no-access label when no programs are visible", () => {
+    useProgramsMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+
+    render(createElement(ProgramSwitcher));
+
+    const button = screen.getByRole("button", { name: /no programs/i });
+    expect(button).toBeDisabled();
+  });
+});

--- a/ui/src/components/layout/program-switcher.tsx
+++ b/ui/src/components/layout/program-switcher.tsx
@@ -25,7 +25,9 @@ export function ProgramSwitcher() {
   }, [programs, active, setActive]);
 
   const activeProgram = programs?.find((p) => p.id === active);
-  const label = activeProgram?.name ?? (isLoading ? "Loading…" : "Program");
+  const label =
+    activeProgram?.name ??
+    (isLoading ? "Loading…" : programs?.length === 0 ? "No programs" : "Program");
 
   const close = useCallback(() => setOpen(false), []);
 

--- a/ui/src/components/layout/shell.tsx
+++ b/ui/src/components/layout/shell.tsx
@@ -17,6 +17,7 @@ function AssistantCanvasLayer() {
 function ProgramReadyGate({ children }: { children: ReactNode }) {
   const program = useActiveProgram();
   const { data: programs, isLoading, isError, isSuccess } = usePrograms();
+  const hasNoProgramAccess = isSuccess && (programs ?? []).length === 0;
 
   /** Wait for a successful programs fetch before unblocking; `!programs?.length` was true when `data` was still undefined after load, unlocking with `program === ""`. */
   const ready = useMemo(() => {
@@ -33,6 +34,26 @@ function ProgramReadyGate({ children }: { children: ReactNode }) {
       <div className="flex min-h-[40vh] flex-col items-center justify-center gap-3 px-6 py-12">
         <Skeleton className="h-5 w-48 rounded-[6px]" />
         <Skeleton className="h-32 w-full max-w-md rounded-[8px]" />
+      </div>
+    );
+  }
+
+  if (hasNoProgramAccess) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center px-6 py-12">
+        <div className="max-w-md rounded-[10px] border border-border bg-surface-raised p-6 text-center shadow-sm">
+          <p className="font-mono text-[12px] font-semibold uppercase tracking-[0.12em] text-text-quaternary">
+            Program access
+          </p>
+          <h1 className="mt-2 text-[18px] font-semibold tracking-[-0.02em] text-text">
+            No program access yet
+          </h1>
+          <p className="mt-2 text-[13px] leading-relaxed text-text-secondary">
+            Your account is signed in, but it has not been granted access to a Sonde
+            program. Ask a program admin to run{" "}
+            <span className="font-mono">sonde admin grant-user</span> for your Aeolus account.
+          </p>
+        </div>
       </div>
     );
   }

--- a/ui/src/components/shared/record-unavailable.tsx
+++ b/ui/src/components/shared/record-unavailable.tsx
@@ -1,0 +1,26 @@
+interface RecordUnavailableProps {
+  recordLabel: string;
+  recordId: string;
+}
+
+export function RecordUnavailable({
+  recordLabel,
+  recordId,
+}: RecordUnavailableProps) {
+  return (
+    <div className="flex min-h-[40vh] items-center justify-center px-6 py-12">
+      <div className="max-w-md rounded-[10px] border border-border bg-surface-raised p-6 text-center shadow-sm">
+        <p className="font-mono text-[12px] font-semibold uppercase tracking-[0.12em] text-text-quaternary">
+          {recordLabel}
+        </p>
+        <h1 className="mt-2 text-[18px] font-semibold tracking-[-0.02em] text-text">
+          Not found or no access
+        </h1>
+        <p className="mt-2 text-[13px] leading-relaxed text-text-secondary">
+          <span className="font-mono">{recordId}</span> is either unavailable or outside your
+          program permissions.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/hooks/use-admin-access.ts
+++ b/ui/src/hooks/use-admin-access.ts
@@ -1,0 +1,275 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+import { queryKeys } from "@/lib/query-keys";
+import {
+  normalizeProgramAccessRole,
+  type ProgramAccessRole,
+  type ProgramAccessRow,
+  type ProgramAccessUserRow,
+} from "@/lib/admin-access-matrix";
+import { useAddToast } from "@/stores/toast";
+import type { Program } from "@/types/sonde";
+
+const adminAccessKeys = {
+  programs: ["admin", "access", "programs"] as const,
+  rows: ["admin", "access", "rows"] as const,
+};
+
+interface RawProgramAccessRow {
+  email: string;
+  user_id: string | null;
+  program: string;
+  role: string;
+  status: string;
+  granted_at: string | null;
+  applied_at: string | null;
+}
+
+interface GrantProgramAccessInput {
+  email: string;
+  program: string;
+  role: ProgramAccessRole;
+}
+
+interface RevokeProgramAccessInput {
+  email: string;
+  program: string;
+}
+
+interface BulkGrantProgramAccessInput {
+  emails: string[];
+  programs: Program[];
+  matrix: ProgramAccessUserRow[];
+  role: ProgramAccessRole;
+}
+
+export interface BulkGrantProgramAccessResult {
+  requested: number;
+  granted: number;
+  skipped: number;
+  failed: number;
+  failures: Array<{ email: string; program: string; message: string }>;
+}
+
+function normalizeAccessRow(row: RawProgramAccessRow): ProgramAccessRow {
+  return {
+    email: row.email,
+    user_id: row.user_id,
+    program: row.program,
+    role: normalizeProgramAccessRole(row.role),
+    status: row.status === "pending" ? "pending" : "active",
+    granted_at: row.granted_at,
+    applied_at: row.applied_at,
+  };
+}
+
+async function grantProgramAccess({
+  email,
+  program,
+  role,
+}: GrantProgramAccessInput): Promise<unknown> {
+  const { data, error } = await supabase.rpc("grant_program_access", {
+    p_email: email,
+    p_program: program,
+    p_role: role,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+}
+
+async function revokeProgramAccess({
+  email,
+  program,
+}: RevokeProgramAccessInput): Promise<unknown> {
+  const { data, error } = await supabase.rpc("revoke_program_access", {
+    p_email: email,
+    p_program: program,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function useManageablePrograms() {
+  return useQuery({
+    queryKey: adminAccessKeys.programs,
+    queryFn: async (): Promise<Program[]> => {
+      const { data, error } = await supabase.rpc("list_manageable_programs");
+      if (error) {
+        throw error;
+      }
+      return (data ?? []) as Program[];
+    },
+    staleTime: 60_000,
+  });
+}
+
+export function useManageableProgramAccess() {
+  return useQuery({
+    queryKey: adminAccessKeys.rows,
+    queryFn: async (): Promise<ProgramAccessRow[]> => {
+      const { data, error } = await supabase.rpc("list_manageable_program_access");
+      if (error) {
+        throw error;
+      }
+      return ((data ?? []) as RawProgramAccessRow[]).map(normalizeAccessRow);
+    },
+    staleTime: 30_000,
+  });
+}
+
+export function useGrantProgramAccess() {
+  const queryClient = useQueryClient();
+  const addToast = useAddToast();
+
+  return useMutation({
+    mutationFn: grantProgramAccess,
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: adminAccessKeys.rows }),
+        queryClient.invalidateQueries({ queryKey: adminAccessKeys.programs }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.programs.all() }),
+      ]);
+      addToast({
+        title: "Program access granted",
+        description: `${variables.email} now has ${variables.role} access to ${variables.program}.`,
+        variant: "success",
+      });
+    },
+    onError: (error: Error) => {
+      addToast({
+        title: "Failed to grant program access",
+        description: error.message,
+        variant: "error",
+      });
+    },
+  });
+}
+
+export function useRevokeProgramAccess() {
+  const queryClient = useQueryClient();
+  const addToast = useAddToast();
+
+  return useMutation({
+    mutationFn: revokeProgramAccess,
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: adminAccessKeys.rows }),
+        queryClient.invalidateQueries({ queryKey: adminAccessKeys.programs }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.programs.all() }),
+      ]);
+      addToast({
+        title: "Program access revoked",
+        description: `${variables.email} no longer has access to ${variables.program}.`,
+        variant: "success",
+      });
+    },
+    onError: (error: Error) => {
+      addToast({
+        title: "Failed to revoke program access",
+        description: error.message,
+        variant: "error",
+      });
+    },
+  });
+}
+
+export function useBulkGrantProgramAccess() {
+  const queryClient = useQueryClient();
+  const addToast = useAddToast();
+
+  return useMutation({
+    mutationFn: async ({
+      emails,
+      programs,
+      matrix,
+      role,
+    }: BulkGrantProgramAccessInput): Promise<BulkGrantProgramAccessResult> => {
+      const rowsByEmail = new Map(matrix.map((row) => [row.email, row]));
+      const tasks: Array<Promise<void>> = [];
+      const taskMeta: Array<{ email: string; program: string }> = [];
+      let skipped = 0;
+
+      for (const email of emails) {
+        const row = rowsByEmail.get(email);
+        for (const program of programs) {
+          if (row?.cells[program.id]) {
+            skipped += 1;
+            continue;
+          }
+
+          taskMeta.push({ email, program: program.id });
+          tasks.push(
+            grantProgramAccess({
+              email,
+              program: program.id,
+              role,
+            }).then(() => undefined),
+          );
+        }
+      }
+
+      const settled = await Promise.allSettled(tasks);
+      const failures: BulkGrantProgramAccessResult["failures"] = [];
+      let granted = 0;
+
+      settled.forEach((result, index) => {
+        const meta = taskMeta[index];
+        if (!meta) {
+          return;
+        }
+
+        if (result.status === "fulfilled") {
+          granted += 1;
+        } else {
+          failures.push({
+            ...meta,
+            message: errorMessage(result.reason),
+          });
+        }
+      });
+
+      return {
+        requested: taskMeta.length,
+        granted,
+        skipped,
+        failed: failures.length,
+        failures,
+      };
+    },
+    onSuccess: async (result) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: adminAccessKeys.rows }),
+        queryClient.invalidateQueries({ queryKey: adminAccessKeys.programs }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.programs.all() }),
+      ]);
+      addToast({
+        title: result.failed > 0 ? "Bulk grant partially applied" : "Bulk grant complete",
+        description:
+          result.failed > 0
+            ? `${result.granted} granted, ${result.skipped} already had access, ${result.failed} failed.`
+            : `${result.granted} grants applied; ${result.skipped} already had access.`,
+        variant: result.failed > 0 ? "error" : "success",
+        duration: result.failed > 0 ? 8000 : undefined,
+      });
+    },
+    onError: (error: Error) => {
+      addToast({
+        title: "Failed to apply bulk grants",
+        description: error.message,
+        variant: "error",
+      });
+    },
+  });
+}

--- a/ui/src/hooks/use-admin-access.ts
+++ b/ui/src/hooks/use-admin-access.ts
@@ -13,7 +13,21 @@ import type { Program } from "@/types/sonde";
 const adminAccessKeys = {
   programs: ["admin", "access", "programs"] as const,
   rows: ["admin", "access", "rows"] as const,
+  eventsBase: ["admin", "access", "events"] as const,
+  events: ({
+    program,
+    action,
+    limit,
+  }: {
+    program?: string;
+    action?: ProgramAccessEventAction;
+    limit: number;
+  }) => ["admin", "access", "events", program ?? "all", action ?? "all", limit] as const,
 };
+
+const DEFAULT_ACCESS_EVENT_LIMIT = 25;
+
+export type ProgramAccessEventAction = "grant" | "revoke" | "apply_pending";
 
 interface RawProgramAccessRow {
   email: string;
@@ -23,6 +37,36 @@ interface RawProgramAccessRow {
   status: string;
   granted_at: string | null;
   applied_at: string | null;
+}
+
+interface RawProgramAccessEventRow {
+  id: number;
+  action: string;
+  actor_email: string | null;
+  target_email: string;
+  program: string;
+  old_role: string | null;
+  new_role: string | null;
+  details: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface ProgramAccessEventRow {
+  id: number;
+  action: ProgramAccessEventAction;
+  actor_email: string | null;
+  target_email: string;
+  program: string;
+  old_role: ProgramAccessRole | null;
+  new_role: ProgramAccessRole | null;
+  details: Record<string, unknown>;
+  created_at: string;
+}
+
+interface ProgramAccessEventFilters {
+  program?: string;
+  action?: ProgramAccessEventAction;
+  limit?: number;
 }
 
 interface GrantProgramAccessInput {
@@ -60,6 +104,31 @@ function normalizeAccessRow(row: RawProgramAccessRow): ProgramAccessRow {
     status: row.status === "pending" ? "pending" : "active",
     granted_at: row.granted_at,
     applied_at: row.applied_at,
+  };
+}
+
+function normalizeProgramAccessEventAction(action: string): ProgramAccessEventAction {
+  if (action === "revoke" || action === "apply_pending") {
+    return action;
+  }
+  return "grant";
+}
+
+function normalizeNullableRole(role: string | null): ProgramAccessRole | null {
+  return role ? normalizeProgramAccessRole(role) : null;
+}
+
+function normalizeAccessEventRow(row: RawProgramAccessEventRow): ProgramAccessEventRow {
+  return {
+    id: row.id,
+    action: normalizeProgramAccessEventAction(row.action),
+    actor_email: row.actor_email,
+    target_email: row.target_email,
+    program: row.program,
+    old_role: normalizeNullableRole(row.old_role),
+    new_role: normalizeNullableRole(row.new_role),
+    details: row.details ?? {},
+    created_at: row.created_at,
   };
 }
 
@@ -129,6 +198,39 @@ export function useManageableProgramAccess() {
   });
 }
 
+export function useProgramAccessEvents({
+  program,
+  action,
+  limit = DEFAULT_ACCESS_EVENT_LIMIT,
+}: ProgramAccessEventFilters = {}) {
+  return useQuery({
+    queryKey: adminAccessKeys.events({ program, action, limit }),
+    queryFn: async (): Promise<ProgramAccessEventRow[]> => {
+      let query = supabase
+        .from("program_access_events")
+        .select(
+          "id,action,actor_email,target_email,program,old_role,new_role,details,created_at",
+        )
+        .order("created_at", { ascending: false })
+        .limit(limit);
+
+      if (program) {
+        query = query.eq("program", program);
+      }
+      if (action) {
+        query = query.eq("action", action);
+      }
+
+      const { data, error } = await query;
+      if (error) {
+        throw error;
+      }
+      return ((data ?? []) as RawProgramAccessEventRow[]).map(normalizeAccessEventRow);
+    },
+    staleTime: 30_000,
+  });
+}
+
 export function useGrantProgramAccess() {
   const queryClient = useQueryClient();
   const addToast = useAddToast();
@@ -139,6 +241,7 @@ export function useGrantProgramAccess() {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: adminAccessKeys.rows }),
         queryClient.invalidateQueries({ queryKey: adminAccessKeys.programs }),
+        queryClient.invalidateQueries({ queryKey: adminAccessKeys.eventsBase }),
         queryClient.invalidateQueries({ queryKey: queryKeys.programs.all() }),
       ]);
       addToast({
@@ -167,6 +270,7 @@ export function useRevokeProgramAccess() {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: adminAccessKeys.rows }),
         queryClient.invalidateQueries({ queryKey: adminAccessKeys.programs }),
+        queryClient.invalidateQueries({ queryKey: adminAccessKeys.eventsBase }),
         queryClient.invalidateQueries({ queryKey: queryKeys.programs.all() }),
       ]);
       addToast({
@@ -252,6 +356,7 @@ export function useBulkGrantProgramAccess() {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: adminAccessKeys.rows }),
         queryClient.invalidateQueries({ queryKey: adminAccessKeys.programs }),
+        queryClient.invalidateQueries({ queryKey: adminAccessKeys.eventsBase }),
         queryClient.invalidateQueries({ queryKey: queryKeys.programs.all() }),
       ]);
       addToast({

--- a/ui/src/hooks/use-directions.ts
+++ b/ui/src/hooks/use-directions.ts
@@ -7,12 +7,12 @@ import type { DirectionSummary } from "@/types/sonde";
 export function useDirection(id: string) {
   return useQuery({
     queryKey: queryKeys.directions.detail(id),
-    queryFn: async (): Promise<DirectionSummary> => {
+    queryFn: async (): Promise<DirectionSummary | null> => {
       const { data, error } = await supabase
         .from("direction_status")
         .select("*")
         .eq("id", id)
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
       return data;
@@ -60,12 +60,12 @@ export function useChildDirections(parentId: string) {
 export function useParentDirection(parentId: string | null | undefined) {
   return useQuery({
     queryKey: queryKeys.directions.detail(parentId ?? ""),
-    queryFn: async (): Promise<DirectionSummary> => {
+    queryFn: async (): Promise<DirectionSummary | null> => {
       const { data, error } = await supabase
         .from("direction_status")
         .select("*")
         .eq("id", parentId!)
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
       return data;

--- a/ui/src/hooks/use-experiments.ts
+++ b/ui/src/hooks/use-experiments.ts
@@ -34,15 +34,16 @@ export function useExperiments() {
 export function useExperiment(id: string) {
   return useQuery({
     queryKey: queryKeys.experiments.detail(id),
-    queryFn: async (): Promise<ExperimentSummary> => {
+    queryFn: async (): Promise<ExperimentSummary | null> => {
       // Use the view (RLS-accessible) rather than the raw table
       const { data, error } = await supabase
         .from("experiment_summary")
         .select("*")
         .eq("id", id)
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
+      if (!data) return null;
       return normalizeExperimentHypothesis(data);
     },
     enabled: !!id,

--- a/ui/src/hooks/use-findings.ts
+++ b/ui/src/hooks/use-findings.ts
@@ -54,14 +54,15 @@ export function useCurrentFindings() {
 export function useFinding(id: string) {
   return useQuery({
     queryKey: queryKeys.findings.detail(id),
-    queryFn: async (): Promise<Finding> => {
+    queryFn: async (): Promise<Finding | null> => {
       const { data, error } = await supabase
         .from("findings")
         .select("*")
         .eq("id", id)
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
+      if (!data) return null;
       return normalizeFinding(data);
     },
     enabled: !!id,

--- a/ui/src/hooks/use-projects.ts
+++ b/ui/src/hooks/use-projects.ts
@@ -27,12 +27,12 @@ export function useProjects() {
 export function useProject(id: string) {
   return useQuery({
     queryKey: queryKeys.projects.detail(id),
-    queryFn: async (): Promise<ProjectSummary> => {
+    queryFn: async (): Promise<ProjectSummary | null> => {
       const { data, error } = await supabase
         .from("project_status")
         .select("*")
         .eq("id", id)
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
       return data;

--- a/ui/src/hooks/use-questions.ts
+++ b/ui/src/hooks/use-questions.ts
@@ -26,12 +26,12 @@ export function useQuestions() {
 export function useQuestion(id: string) {
   return useQuery({
     queryKey: queryKeys.questions.detail(id),
-    queryFn: async (): Promise<QuestionSummary> => {
+    queryFn: async (): Promise<QuestionSummary | null> => {
       const { data, error } = await supabase
         .from("question_status")
         .select("*")
         .eq("id", id)
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
       return data;

--- a/ui/src/lib/admin-access-matrix.test.ts
+++ b/ui/src/lib/admin-access-matrix.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBulkGrantPreview,
+  buildProgramAccessMatrix,
+  parseAeolusEmailList,
+  type ProgramAccessRow,
+} from "./admin-access-matrix";
+import type { Program } from "@/types/sonde";
+
+const programs: Program[] = [
+  {
+    id: "alpha",
+    name: "Alpha",
+    description: null,
+    created_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: "beta",
+    name: "Beta",
+    description: null,
+    created_at: "2026-04-01T00:00:00Z",
+  },
+];
+
+describe("parseAeolusEmailList", () => {
+  it("normalizes, dedupes, and rejects non-Aeolus entries", () => {
+    const parsed = parseAeolusEmailList(
+      "Alice@Aeolus.Earth, bob@aeolus.earth\nbad@example.com alice@aeolus.earth",
+    );
+
+    expect(parsed.validEmails).toEqual(["alice@aeolus.earth", "bob@aeolus.earth"]);
+    expect(parsed.duplicates).toEqual(["alice@aeolus.earth"]);
+    expect(parsed.invalidEntries).toEqual(["bad@example.com"]);
+  });
+});
+
+describe("buildProgramAccessMatrix", () => {
+  it("merges active and pending rows into one user matrix", () => {
+    const rows: ProgramAccessRow[] = [
+      {
+        email: "alice@aeolus.earth",
+        user_id: "user-1",
+        program: "alpha",
+        role: "admin",
+        status: "active",
+        granted_at: "2026-04-01T00:00:00Z",
+        applied_at: "2026-04-01T00:01:00Z",
+      },
+      {
+        email: "alice@aeolus.earth",
+        user_id: null,
+        program: "beta",
+        role: "contributor",
+        status: "pending",
+        granted_at: "2026-04-02T00:00:00Z",
+        applied_at: null,
+      },
+    ];
+
+    const matrix = buildProgramAccessMatrix(programs, rows);
+
+    expect(matrix).toHaveLength(1);
+    expect(matrix[0]?.email).toBe("alice@aeolus.earth");
+    expect(matrix[0]?.activeCount).toBe(1);
+    expect(matrix[0]?.pendingCount).toBe(1);
+    expect(matrix[0]?.adminCount).toBe(1);
+    expect(matrix[0]?.contributorCount).toBe(1);
+    expect(matrix[0]?.cells.alpha?.role).toBe("admin");
+    expect(matrix[0]?.cells.beta?.status).toBe("pending");
+  });
+});
+
+describe("buildBulkGrantPreview", () => {
+  it("counts only missing grants so bulk FTE grants do not downgrade admins", () => {
+    const matrix = buildProgramAccessMatrix(programs, [
+      {
+        email: "alice@aeolus.earth",
+        user_id: "user-1",
+        program: "alpha",
+        role: "admin",
+        status: "active",
+        granted_at: "2026-04-01T00:00:00Z",
+        applied_at: "2026-04-01T00:01:00Z",
+      },
+    ]);
+
+    const preview = buildBulkGrantPreview({
+      input: "alice@aeolus.earth bob@aeolus.earth",
+      programs,
+      matrix,
+    });
+
+    expect(preview.validEmails).toEqual([
+      "alice@aeolus.earth",
+      "bob@aeolus.earth",
+    ]);
+    expect(preview.programCount).toBe(2);
+    expect(preview.alreadyGrantedCount).toBe(1);
+    expect(preview.grantCount).toBe(3);
+  });
+});

--- a/ui/src/lib/admin-access-matrix.ts
+++ b/ui/src/lib/admin-access-matrix.ts
@@ -1,0 +1,206 @@
+import type { Program } from "@/types/sonde";
+
+export type ProgramAccessRole = "contributor" | "admin";
+export type ProgramAccessStatus = "active" | "pending";
+
+export interface ProgramAccessRow {
+  email: string;
+  user_id: string | null;
+  program: string;
+  role: ProgramAccessRole;
+  status: ProgramAccessStatus;
+  granted_at: string | null;
+  applied_at: string | null;
+}
+
+export interface ProgramAccessCell {
+  email: string;
+  program: string;
+  role: ProgramAccessRole;
+  status: ProgramAccessStatus;
+  grantedAt: string | null;
+  appliedAt: string | null;
+}
+
+export interface ProgramAccessUserRow {
+  email: string;
+  userId: string | null;
+  cells: Record<string, ProgramAccessCell | undefined>;
+  activeCount: number;
+  pendingCount: number;
+  adminCount: number;
+  contributorCount: number;
+}
+
+export interface ParsedEmailList {
+  validEmails: string[];
+  invalidEntries: string[];
+  duplicates: string[];
+}
+
+export interface BulkGrantPreview extends ParsedEmailList {
+  programCount: number;
+  grantCount: number;
+  alreadyGrantedCount: number;
+}
+
+const AEOLUS_EMAIL_RE = /^[^\s@]+@aeolus[.]earth$/;
+
+function normalizeEmail(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
+export function normalizeProgramAccessRole(role: string): ProgramAccessRole {
+  return role === "admin" ? "admin" : "contributor";
+}
+
+function cellRank(cell: ProgramAccessCell): number {
+  const statusScore = cell.status === "active" ? 2 : 0;
+  const roleScore = cell.role === "admin" ? 1 : 0;
+  return statusScore + roleScore;
+}
+
+export function parseAeolusEmailList(input: string): ParsedEmailList {
+  const seen = new Set<string>();
+  const duplicateSeen = new Set<string>();
+  const validEmails: string[] = [];
+  const invalidEntries: string[] = [];
+  const duplicates: string[] = [];
+
+  for (const token of input.split(/[\s,;]+/)) {
+    const normalized = normalizeEmail(token);
+    if (!normalized) {
+      continue;
+    }
+
+    if (!AEOLUS_EMAIL_RE.test(normalized)) {
+      invalidEntries.push(token.trim());
+      continue;
+    }
+
+    if (seen.has(normalized)) {
+      if (!duplicateSeen.has(normalized)) {
+        duplicates.push(normalized);
+        duplicateSeen.add(normalized);
+      }
+      continue;
+    }
+
+    seen.add(normalized);
+    validEmails.push(normalized);
+  }
+
+  return { validEmails, invalidEntries, duplicates };
+}
+
+export function buildProgramAccessMatrix(
+  programs: Program[],
+  accessRows: ProgramAccessRow[],
+): ProgramAccessUserRow[] {
+  const programIds = new Set(programs.map((program) => program.id));
+  const users = new Map<string, ProgramAccessUserRow>();
+
+  for (const row of accessRows) {
+    const email = normalizeEmail(row.email);
+    if (!email || !programIds.has(row.program)) {
+      continue;
+    }
+
+    const existingUser =
+      users.get(email) ??
+      {
+        email,
+        userId: row.user_id,
+        cells: {},
+        activeCount: 0,
+        pendingCount: 0,
+        adminCount: 0,
+        contributorCount: 0,
+      };
+
+    if (!existingUser.userId && row.user_id) {
+      existingUser.userId = row.user_id;
+    }
+
+    const nextCell: ProgramAccessCell = {
+      email,
+      program: row.program,
+      role: row.role,
+      status: row.status,
+      grantedAt: row.granted_at,
+      appliedAt: row.applied_at,
+    };
+    const currentCell = existingUser.cells[row.program];
+    if (!currentCell || cellRank(nextCell) >= cellRank(currentCell)) {
+      existingUser.cells[row.program] = nextCell;
+    }
+
+    users.set(email, existingUser);
+  }
+
+  return Array.from(users.values())
+    .map((user) => {
+      let activeCount = 0;
+      let pendingCount = 0;
+      let adminCount = 0;
+      let contributorCount = 0;
+
+      for (const cell of Object.values(user.cells)) {
+        if (!cell) {
+          continue;
+        }
+        if (cell.status === "active") {
+          activeCount += 1;
+        } else {
+          pendingCount += 1;
+        }
+        if (cell.role === "admin") {
+          adminCount += 1;
+        } else {
+          contributorCount += 1;
+        }
+      }
+
+      return {
+        ...user,
+        activeCount,
+        pendingCount,
+        adminCount,
+        contributorCount,
+      };
+    })
+    .sort((a, b) => a.email.localeCompare(b.email));
+}
+
+export function buildBulkGrantPreview({
+  input,
+  programs,
+  matrix,
+}: {
+  input: string;
+  programs: Program[];
+  matrix: ProgramAccessUserRow[];
+}): BulkGrantPreview {
+  const parsed = parseAeolusEmailList(input);
+  const rowsByEmail = new Map(matrix.map((row) => [row.email, row]));
+  let grantCount = 0;
+  let alreadyGrantedCount = 0;
+
+  for (const email of parsed.validEmails) {
+    const row = rowsByEmail.get(email);
+    for (const program of programs) {
+      if (row?.cells[program.id]) {
+        alreadyGrantedCount += 1;
+      } else {
+        grantCount += 1;
+      }
+    }
+  }
+
+  return {
+    ...parsed,
+    programCount: programs.length,
+    grantCount,
+    alreadyGrantedCount,
+  };
+}

--- a/ui/src/routes/pages/admin-dashboard.tsx
+++ b/ui/src/routes/pages/admin-dashboard.tsx
@@ -19,6 +19,7 @@ import { useRealtimeInvalidation } from "@/hooks/use-realtime";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
+import { AdminAccessManagement } from "@/components/admin/access-management";
 import { RecordLink } from "@/components/shared/record-link";
 import { UsageChart } from "@/components/visualizations/usage-chart";
 import {
@@ -281,6 +282,8 @@ export default function AdminDashboard() {
           loading={statsLoading}
         />
       </div>
+
+      <AdminAccessManagement />
 
       {/* Managed cost hygiene */}
       <section className="space-y-3">

--- a/ui/src/routes/pages/direction-detail.tsx
+++ b/ui/src/routes/pages/direction-detail.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/skeleton";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Section, DetailRow } from "@/components/shared/detail-layout";
+import { RecordUnavailable } from "@/components/shared/record-unavailable";
 import { directionDetailShareUrl } from "@/lib/app-origin";
 import { formatDateTime, formatDateTimeShort } from "@/lib/utils";
 import { ArrowLeft, Copy, GitFork } from "lucide-react";
@@ -80,6 +81,10 @@ export default function DirectionDetailPage() {
       setLinkCopied(false);
     }
   }, [shareUrl]);
+
+  if (!loadingDir && !dir) {
+    return <RecordUnavailable recordLabel="Direction" recordId={id} />;
+  }
 
   if (loadingDir || !dir) {
     return (

--- a/ui/src/routes/pages/experiment-detail.tsx
+++ b/ui/src/routes/pages/experiment-detail.tsx
@@ -19,6 +19,7 @@ import { MarkdownView } from "@/components/ui/markdown-view";
 import { ArtifactGallery } from "@/components/artifacts/artifact-gallery";
 import { cn, formatDateTime, formatDateTimeShort } from "@/lib/utils";
 import { Section, DetailRow } from "@/components/shared/detail-layout";
+import { RecordUnavailable } from "@/components/shared/record-unavailable";
 import { RecordLink } from "@/components/shared/record-link";
 import { SondeLinkifiedText } from "@/components/shared/sonde-linkified-text";
 import { AuthGate } from "@/components/auth/auth-gate";
@@ -76,6 +77,10 @@ export default function ExperimentDetailPage() {
       setLinkCopied(false);
     }
   }, [shareUrl]);
+
+  if (!isLoading && !exp) {
+    return <RecordUnavailable recordLabel="Experiment" recordId={id} />;
+  }
 
   if (isLoading || !exp) {
     return (

--- a/ui/src/routes/pages/finding-detail.tsx
+++ b/ui/src/routes/pages/finding-detail.tsx
@@ -19,6 +19,7 @@ import { Skeleton, DetailSectionSkeleton } from "@/components/ui/skeleton";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { MarkdownView } from "@/components/ui/markdown-view";
 import { Section, DetailRow } from "@/components/shared/detail-layout";
+import { RecordUnavailable } from "@/components/shared/record-unavailable";
 import { RecordLink } from "@/components/shared/record-link";
 import {
   FINDING_CONFIDENCE_LEVELS,
@@ -104,6 +105,10 @@ export default function FindingDetailPage() {
     "Escape",
     useCallback(() => nav({ to: "/findings" }), [nav]),
   );
+
+  if (!isLoading && !finding) {
+    return <RecordUnavailable recordLabel="Finding" recordId={id} />;
+  }
 
   if (isLoading || !finding) {
     return (

--- a/ui/src/routes/pages/project-detail.tsx
+++ b/ui/src/routes/pages/project-detail.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/skeleton";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Section, DetailRow } from "@/components/shared/detail-layout";
+import { RecordUnavailable } from "@/components/shared/record-unavailable";
 import { RecordLink } from "@/components/shared/record-link";
 import { ArtifactGallery } from "@/components/artifacts/artifact-gallery";
 import { EmbeddedDocumentPreview } from "@/components/artifacts/embedded-document-preview";
@@ -133,6 +134,10 @@ export default function ProjectDetailPage() {
       ),
     [projectArtifacts, proj?.report_tex_artifact_id],
   );
+
+  if (!loadingProj && !proj) {
+    return <RecordUnavailable recordLabel="Project" recordId={id} />;
+  }
 
   if (loadingProj || !proj) {
     return (

--- a/ui/src/routes/pages/question-detail.tsx
+++ b/ui/src/routes/pages/question-detail.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/skeleton";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Section, DetailRow } from "@/components/shared/detail-layout";
+import { RecordUnavailable } from "@/components/shared/record-unavailable";
 import { RecordLink } from "@/components/shared/record-link";
 import { sortFindingsByImportanceAndRecency } from "@/lib/finding-importance";
 import { formatDateTime, formatDateTimeShort } from "@/lib/utils";
@@ -99,6 +100,10 @@ export default function QuestionDetailPage() {
     enabled: !!id,
   });
   const sortedFindings = sortFindingsByImportanceAndRecency(findings ?? []);
+
+  if (!isLoading && !question) {
+    return <RecordUnavailable recordLabel="Question" recordId={id} />;
+  }
 
   if (isLoading || !question) {
     return (


### PR DESCRIPTION
## Summary

This adds explicit program-level RBAC for Aeolus-managed contractors and makes Postgres/RLS the enforcement point instead of relying on UI filtering or stale JWT assumptions.

Key changes:
- Adds Supabase migrations for explicit `program_access_grants`, access audit events, grant/revoke/list RPCs, pending grants that apply on first sign-in, scoped `programs` visibility, and no implicit `shared` access for future ungranted users.
- Treats `shared` admins as global access managers while preserving program admins for only the programs they administer.
- Adds a last-shared-admin guard so the org-admin path cannot be accidentally locked out.
- Adds admin CLI commands: `sonde admin grant-user`, `revoke-user`, `list-users`, and `user-access`.
- Updates agent token admin checks so shared admins can create scoped agent tokens for any program.
- Adds admin-dashboard access management: manageable program/library list, user-by-program access matrix, single-user grants/revokes, role changes, pending-grant display, and paste-and-preview FTE bulk contributor grants.
- Adds admin-dashboard polish: recent access-change audit trail, action/program event filters, active/pending user filters, and a confirmation step before bulk FTE grants.
- Keeps the UI aligned with RBAC by showing explicit no-program-access states and “not found or no access” detail states for records hidden by RLS.
- Extends the RLS security harness with contractor RBAC, admin-dashboard RPC regressions, and scoped access-event visibility regressions.

## Validation

Local validation:
- `bash scripts/ci/core.sh guard`
- `bash scripts/ci/core.sh cli`
- `bash scripts/ci/core.sh ui`
- `bash scripts/ci/core.sh server`
- `bash scripts/ci/security.sh`
- `bash scripts/ci/data.sh`
- `npm run lint --prefix ui`
- `npm run test --prefix ui -- --run src/lib/admin-access-matrix.test.ts src/components/admin/access-management.test.ts`
- `npm run test --prefix ui -- --run src/components/admin/access-management.test.ts`
- `git diff --check`

GitHub validation on `39ac0fd`:
- CI: `changes`, `legacy-provider-guard`, `cli-core`, `ui-core`, `server-core`, `hosted-preflight`, `hosted-contract`, `browser-regression`, `browser-smoke`, `data-integration`, and `managed-auth-parity` passed.
- CodeQL actions, JavaScript/TypeScript, and Python analysis passed.
- Vercel preview deployments for `sonde` and `sonde-staging` passed.
- Merge Readiness passed.

Notes:
- The UI build still emits the existing Vite dynamic/static Supabase import warning; it does not fail the build.
- GitHub still reports the existing Dependabot vulnerability backlog on the default branch; that is unrelated to this PR and remains worth a separate dependency-hardening pass.