### PR TITLE
Fix hosted schema parity checks

### DIFF
--- a/.github/workflows/cli-hosted-audit.yml
+++ b/.github/workflows/cli-hosted-audit.yml
@@ -66,21 +66,13 @@ jobs:
           google-client-id: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
           google-client-secret: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
 
-      - name: Resolve expected staging schema version
+      - name: Resolve hosted staging schema version
         id: schema
+        env:
+          SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
         run: |
-          VERSION="$(node - <<'NODE'
-          const fs = require("node:fs");
-          const text = fs.readFileSync("cli/src/sonde/db/compat.py", "utf8");
-          const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
-          if (!match) {
-            console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");
-            process.exit(1);
-          }
-          process.stdout.write(match[1]);
-          NODE
-          )"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          node server/scripts/resolve-hosted-schema-version.mjs >> "$GITHUB_OUTPUT"
 
       - name: Wait for staging agent runtime parity
         working-directory: server
@@ -89,7 +81,7 @@ jobs:
           PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
           PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
-          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           PARITY_REQUIRED_KEYS: ${{ steps.contract.outputs.audit_required_runtime_keys_csv }}
           PARITY_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
           PARITY_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
@@ -181,21 +173,13 @@ jobs:
           google-client-id: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
           google-client-secret: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
 
-      - name: Resolve expected production schema version
+      - name: Resolve hosted production schema version
         id: schema
+        env:
+          SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
         run: |
-          VERSION="$(node - <<'NODE'
-          const fs = require("node:fs");
-          const text = fs.readFileSync("cli/src/sonde/db/compat.py", "utf8");
-          const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
-          if (!match) {
-            console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");
-            process.exit(1);
-          }
-          process.stdout.write(match[1]);
-          NODE
-          )"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          node server/scripts/resolve-hosted-schema-version.mjs >> "$GITHUB_OUTPUT"
 
       - name: Wait for production agent runtime parity
         working-directory: server
@@ -204,7 +188,7 @@ jobs:
           PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
           PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
-          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           PARITY_REQUIRED_KEYS: ${{ steps.contract.outputs.audit_required_runtime_keys_csv }}
           PARITY_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
           PARITY_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}

--- a/.github/workflows/config-audit.yml
+++ b/.github/workflows/config-audit.yml
@@ -68,21 +68,13 @@ jobs:
           SMOKE_USER_PASSWORD: ${{ secrets.SONDE_STAGING_SMOKE_USER_PASSWORD }}
         run: node scripts/mint-smoke-session.mjs >/dev/null
 
-      - name: Resolve expected staging schema version
+      - name: Resolve hosted staging schema version
         id: schema
+        env:
+          SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
         run: |
-          VERSION="$(node - <<'NODE'
-          const fs = require("node:fs");
-          const text = fs.readFileSync("cli/src/sonde/db/compat.py", "utf8");
-          const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
-          if (!match) {
-            console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");
-            process.exit(1);
-          }
-          process.stdout.write(match[1]);
-          NODE
-          )"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          node server/scripts/resolve-hosted-schema-version.mjs >> "$GITHUB_OUTPUT"
 
       - name: Wait for staging UI and agent
         run: |
@@ -106,7 +98,7 @@ jobs:
           PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
           PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
-          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           PARITY_REQUIRED_KEYS: ${{ steps.contract.outputs.audit_required_runtime_keys_csv }}
           PARITY_WAIT_TIMEOUT_MS: 600000
           PARITY_WAIT_INTERVAL_MS: 10000
@@ -120,7 +112,7 @@ jobs:
           AUDIT_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           AUDIT_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
           AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
-          AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
           AUDIT_REQUIRE_ANTHROPIC: ${{ steps.contract.outputs.audit_require_anthropic }}
           AUDIT_REQUIRE_AGENT_COMMIT_MATCH: ${{ steps.contract.outputs.audit_require_agent_commit_match }}
@@ -186,21 +178,13 @@ jobs:
           SMOKE_USER_PASSWORD: ${{ secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD }}
         run: node scripts/mint-smoke-session.mjs >/dev/null
 
-      - name: Resolve expected production schema version
+      - name: Resolve hosted production schema version
         id: schema
+        env:
+          SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
         run: |
-          VERSION="$(node - <<'NODE'
-          const fs = require("node:fs");
-          const text = fs.readFileSync("cli/src/sonde/db/compat.py", "utf8");
-          const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
-          if (!match) {
-            console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");
-            process.exit(1);
-          }
-          process.stdout.write(match[1]);
-          NODE
-          )"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          node server/scripts/resolve-hosted-schema-version.mjs >> "$GITHUB_OUTPUT"
 
       - name: Wait for production UI and agent
         run: |
@@ -224,7 +208,7 @@ jobs:
           PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
           PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
-          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           PARITY_REQUIRED_KEYS: ${{ steps.contract.outputs.audit_required_runtime_keys_csv }}
           PARITY_WAIT_TIMEOUT_MS: 600000
           PARITY_WAIT_INTERVAL_MS: 10000
@@ -238,7 +222,7 @@ jobs:
           AUDIT_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           AUDIT_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
           AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
-          AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
           AUDIT_REQUIRE_ANTHROPIC: ${{ steps.contract.outputs.audit_require_anthropic }}
           AUDIT_REQUIRE_AGENT_COMMIT_MATCH: ${{ steps.contract.outputs.audit_require_agent_commit_match }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -205,15 +205,14 @@ jobs:
           google-client-id: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
           google-client-secret: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
 
-      - name: Resolve staging schema version
+      - name: Resolve hosted staging schema version
         id: schema
         if: ${{ steps.contract.outputs.supabase_project_ref != '' && steps.contract.outputs.supabase_anon_key != '' }}
+        env:
+          SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
         run: |
-          VERSION=$(curl -sf \
-            -H "apikey: ${{ steps.contract.outputs.supabase_anon_key }}" \
-            -H "Authorization: Bearer ${{ steps.contract.outputs.supabase_anon_key }}" \
-            "https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co/rest/v1/rpc/get_schema_version" | tr -d '"')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          node server/scripts/resolve-hosted-schema-version.mjs >> "$GITHUB_OUTPUT"
 
       - name: Validate required staging runtime secrets
         env:
@@ -266,7 +265,7 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_STAGING_PROJECT_TOKEN }}
           RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_STAGING_PROJECT_ID }}
           SONDE_MANAGED_ENVIRONMENT_ID: ${{ vars.SONDE_ANTHROPIC_MANAGED_ENVIRONMENT_ID }}
-          SONDE_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          SONDE_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           SONDE_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           SONDE_WS_TOKEN_SECRET: ${{ secrets.SONDE_WS_TOKEN_SECRET }}
@@ -333,7 +332,7 @@ jobs:
           PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
           PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
-          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           PARITY_REQUIRED_KEYS: ${{ steps.contract.outputs.audit_required_runtime_keys_csv }}
           PARITY_WAIT_TIMEOUT_MS: 300000
           PARITY_WAIT_INTERVAL_MS: 10000

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,15 +185,14 @@ jobs:
           google-client-id: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
           google-client-secret: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
 
-      - name: Resolve production schema version
+      - name: Resolve hosted production schema version
         id: schema
         if: ${{ steps.contract.outputs.supabase_project_ref != '' && steps.contract.outputs.supabase_anon_key != '' }}
+        env:
+          SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
         run: |
-          VERSION=$(curl -sf \
-            -H "apikey: ${{ steps.contract.outputs.supabase_anon_key }}" \
-            -H "Authorization: Bearer ${{ steps.contract.outputs.supabase_anon_key }}" \
-            "https://${{ steps.contract.outputs.supabase_project_ref }}.supabase.co/rest/v1/rpc/get_schema_version" | tr -d '"')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          node server/scripts/resolve-hosted-schema-version.mjs >> "$GITHUB_OUTPUT"
 
       - name: Validate required production runtime secrets
         env:
@@ -250,7 +249,7 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_PROJECT_TOKEN }}
           RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PRODUCTION_PROJECT_ID }}
           SONDE_MANAGED_ENVIRONMENT_ID: ${{ vars.SONDE_ANTHROPIC_MANAGED_ENVIRONMENT_ID }}
-          SONDE_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          SONDE_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           SONDE_RUNTIME_AUDIT_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           SONDE_WS_TOKEN_SECRET: ${{ secrets.SONDE_WS_TOKEN_SECRET }}
@@ -321,7 +320,7 @@ jobs:
           PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
           PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
-          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           PARITY_REQUIRED_KEYS: ${{ steps.contract.outputs.audit_required_runtime_keys_csv }}
           PARITY_WAIT_TIMEOUT_MS: 300000
           PARITY_WAIT_INTERVAL_MS: 10000
@@ -336,7 +335,7 @@ jobs:
           AUDIT_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           AUDIT_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
           AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
-          AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
           AUDIT_REQUIRE_ANTHROPIC: ${{ steps.contract.outputs.audit_require_anthropic }}
           AUDIT_REQUIRE_AGENT_COMMIT_MATCH: ${{ steps.contract.outputs.audit_require_agent_commit_match }}

--- a/.github/workflows/smoke-production.yml
+++ b/.github/workflows/smoke-production.yml
@@ -89,21 +89,14 @@ jobs:
             echo "Smoke testing agent: $AGENT_URL"
           fi
 
-      - name: Resolve expected production schema version
+      - name: Resolve hosted production schema version
         id: schema
+        working-directory: ${{ github.workspace }}
+        env:
+          SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
         run: |
-          VERSION="$(node - <<'NODE'
-          const fs = require("node:fs");
-          const text = fs.readFileSync("../cli/src/sonde/db/compat.py", "utf8");
-          const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
-          if (!match) {
-            console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");
-            process.exit(1);
-          }
-          process.stdout.write(match[1]);
-          NODE
-          )"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          node server/scripts/resolve-hosted-schema-version.mjs >> "$GITHUB_OUTPUT"
 
       - name: Wait for production UI
         run: |
@@ -167,7 +160,7 @@ jobs:
           PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
           PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
-          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           PARITY_REQUIRED_KEYS: ${{ steps.contract.outputs.audit_required_runtime_keys_csv }}
           PARITY_WAIT_TIMEOUT_MS: 600000
           PARITY_WAIT_INTERVAL_MS: 10000
@@ -182,7 +175,7 @@ jobs:
           AUDIT_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           AUDIT_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
           AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
-          AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
           AUDIT_REQUIRE_ANTHROPIC: ${{ steps.contract.outputs.audit_require_anthropic }}
           AUDIT_REQUIRE_AGENT_COMMIT_MATCH: ${{ steps.contract.outputs.audit_require_agent_commit_match }}

--- a/.github/workflows/smoke-staging.yml
+++ b/.github/workflows/smoke-staging.yml
@@ -89,21 +89,14 @@ jobs:
             echo "Smoke testing agent: $AGENT_URL"
           fi
 
-      - name: Resolve expected staging schema version
+      - name: Resolve hosted staging schema version
         id: schema
+        working-directory: ${{ github.workspace }}
+        env:
+          SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
+          SUPABASE_ANON_KEY: ${{ steps.contract.outputs.supabase_anon_key }}
         run: |
-          VERSION="$(node - <<'NODE'
-          const fs = require("node:fs");
-          const text = fs.readFileSync("../cli/src/sonde/db/compat.py", "utf8");
-          const match = text.match(/MINIMUM_SCHEMA_VERSION = (\d+)/);
-          if (!match) {
-            console.error("Could not determine MINIMUM_SCHEMA_VERSION from cli/src/sonde/db/compat.py");
-            process.exit(1);
-          }
-          process.stdout.write(match[1]);
-          NODE
-          )"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          node server/scripts/resolve-hosted-schema-version.mjs >> "$GITHUB_OUTPUT"
 
       - name: Wait for staging UI
         run: |
@@ -156,7 +149,7 @@ jobs:
           PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
           PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
-          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           PARITY_REQUIRED_KEYS: ${{ steps.contract.outputs.audit_required_runtime_keys_csv }}
           PARITY_WAIT_TIMEOUT_MS: 600000
           PARITY_WAIT_INTERVAL_MS: 10000
@@ -171,7 +164,7 @@ jobs:
           AUDIT_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           AUDIT_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
           AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
-          AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.version }}
+          AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
           AUDIT_REQUIRE_ANTHROPIC: ${{ steps.contract.outputs.audit_require_anthropic }}
           AUDIT_REQUIRE_AGENT_COMMIT_MATCH: ${{ steps.contract.outputs.audit_require_agent_commit_match }}

--- a/scripts/ci/check-hosted-workflow-action.sh
+++ b/scripts/ci/check-hosted-workflow-action.sh
@@ -50,6 +50,18 @@ if grep -REn '^[[:space:]]+HOSTED_[A-Z0-9_]+:' "${workflows[@]}" >/tmp/hosted-wo
   exit 1
 fi
 
+if grep -REn 'MINIMUM_SCHEMA_VERSION' "${workflows[@]}" >/tmp/hosted-workflow-schema-minimum.txt; then
+  echo "::error::Hosted workflows must not use the CLI minimum schema as an exact deployed schema. Use server/scripts/resolve-hosted-schema-version.mjs and pass remote_version to runtime parity."
+  cat /tmp/hosted-workflow-schema-minimum.txt
+  exit 1
+fi
+
+if grep -REn 'steps\.schema\.outputs\.version' "${workflows[@]}" >/tmp/hosted-workflow-schema-version-alias.txt; then
+  echo "::error::Hosted workflows must use steps.schema.outputs.remote_version for deployed runtime schema parity."
+  cat /tmp/hosted-workflow-schema-version-alias.txt
+  exit 1
+fi
+
 ruby <<'RUBY'
 require "yaml"
 

--- a/server/scripts/resolve-hosted-schema-version.mjs
+++ b/server/scripts/resolve-hosted-schema-version.mjs
@@ -1,0 +1,133 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_COMPAT_PATH = "cli/src/sonde/db/compat.py";
+
+function requiredValue(name, value) {
+  const normalized = value?.trim();
+  if (!normalized) {
+    throw new Error(`Missing required env: ${name}`);
+  }
+  return normalized;
+}
+
+export function parseMinimumSchemaVersion(text, source = DEFAULT_COMPAT_PATH) {
+  const match = text.match(/^\s*MINIMUM_SCHEMA_VERSION\s*=\s*(\d+)\s*$/m);
+  if (!match) {
+    throw new Error(`Could not determine MINIMUM_SCHEMA_VERSION from ${source}.`);
+  }
+  return Number.parseInt(match[1], 10);
+}
+
+export function normalizeSchemaVersion(value, source = "get_schema_version") {
+  let normalized = value;
+  if (Array.isArray(normalized)) {
+    if (normalized.length === 0) {
+      throw new Error(`${source} returned an empty array.`);
+    }
+    normalized = normalized[0];
+  }
+  if (normalized && typeof normalized === "object") {
+    normalized = normalized.get_schema_version ?? normalized.version;
+  }
+  if (typeof normalized === "string") {
+    normalized = normalized.trim();
+    if (!/^\d+$/.test(normalized)) {
+      throw new Error(`${source} returned a non-numeric schema version: ${normalized}`);
+    }
+    return Number.parseInt(normalized, 10);
+  }
+  if (typeof normalized === "number" && Number.isInteger(normalized) && normalized >= 0) {
+    return normalized;
+  }
+  throw new Error(`${source} returned an invalid schema version.`);
+}
+
+export function parseSchemaVersionResponse(bodyText, source = "get_schema_version") {
+  const trimmed = bodyText.trim();
+  if (!trimmed) {
+    throw new Error(`${source} returned an empty response.`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new Error(`${source} returned invalid JSON: ${trimmed.slice(0, 160)}`);
+  }
+  return normalizeSchemaVersion(parsed, source);
+}
+
+export function assertHostedSchemaCompatible(remoteVersion, minimumVersion) {
+  if (remoteVersion < minimumVersion) {
+    throw new Error(
+      `Hosted schema version ${remoteVersion} is below CLI minimum ${minimumVersion}. Run the hosted Supabase migrations before deploying this commit.`,
+    );
+  }
+}
+
+export async function resolveHostedSchemaVersion({
+  projectRef,
+  anonKey,
+  compatPath = DEFAULT_COMPAT_PATH,
+  fetchImpl = globalThis.fetch,
+  readFile = readFileSync,
+} = {}) {
+  const resolvedProjectRef = requiredValue("SUPABASE_PROJECT_REF", projectRef);
+  const resolvedAnonKey = requiredValue("SUPABASE_ANON_KEY", anonKey);
+  if (typeof fetchImpl !== "function") {
+    throw new Error("No fetch implementation is available.");
+  }
+
+  const minimumVersion = parseMinimumSchemaVersion(readFile(compatPath, "utf8"), compatPath);
+  const url = `https://${resolvedProjectRef}.supabase.co/rest/v1/rpc/get_schema_version`;
+  const response = await fetchImpl(url, {
+    headers: {
+      apikey: resolvedAnonKey,
+      Authorization: `Bearer ${resolvedAnonKey}`,
+    },
+  });
+  const bodyText = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `get_schema_version failed (${response.status}) for ${url}: ${bodyText.slice(0, 160)}`,
+    );
+  }
+
+  const remoteVersion = parseSchemaVersionResponse(bodyText, "get_schema_version");
+  assertHostedSchemaCompatible(remoteVersion, minimumVersion);
+  return { minimumVersion, remoteVersion };
+}
+
+export function renderGithubOutputs({ minimumVersion, remoteVersion }) {
+  return [
+    `minimum_version=${minimumVersion}`,
+    `remote_version=${remoteVersion}`,
+    `version=${remoteVersion}`,
+  ].join("\n");
+}
+
+function envValue(name, fallbackName = null) {
+  return process.env[name] ?? (fallbackName ? process.env[fallbackName] : undefined);
+}
+
+async function main() {
+  const result = await resolveHostedSchemaVersion({
+    projectRef: envValue("HOSTED_SCHEMA_SUPABASE_PROJECT_REF", "SUPABASE_PROJECT_REF"),
+    anonKey: envValue("HOSTED_SCHEMA_SUPABASE_ANON_KEY", "SUPABASE_ANON_KEY"),
+    compatPath: process.env.SCHEMA_COMPAT_PATH ?? DEFAULT_COMPAT_PATH,
+  });
+  console.error(
+    `Hosted schema version ${result.remoteVersion} satisfies CLI minimum ${result.minimumVersion}.`,
+  );
+  console.log(renderGithubOutputs(result));
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error(
+      `[resolve-hosted-schema-version] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  });
+}

--- a/server/scripts/resolve-hosted-schema-version.test.mjs
+++ b/server/scripts/resolve-hosted-schema-version.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  assertHostedSchemaCompatible,
+  normalizeSchemaVersion,
+  parseMinimumSchemaVersion,
+  parseSchemaVersionResponse,
+  renderGithubOutputs,
+  resolveHostedSchemaVersion,
+} from "./resolve-hosted-schema-version.mjs";
+
+function response(body, { ok = true, status = 200 } = {}) {
+  return {
+    ok,
+    status,
+    async text() {
+      return body;
+    },
+  };
+}
+
+describe("resolve-hosted-schema-version", () => {
+  it("parses the CLI minimum schema version", () => {
+    assert.equal(parseMinimumSchemaVersion("MINIMUM_SCHEMA_VERSION = 5\n"), 5);
+  });
+
+  it("normalizes common Supabase RPC response shapes", () => {
+    assert.equal(normalizeSchemaVersion(7), 7);
+    assert.equal(normalizeSchemaVersion("7"), 7);
+    assert.equal(normalizeSchemaVersion([{ get_schema_version: "7" }]), 7);
+    assert.equal(normalizeSchemaVersion({ version: 7 }), 7);
+  });
+
+  it("parses JSON schema version responses", () => {
+    assert.equal(parseSchemaVersionResponse("7"), 7);
+    assert.equal(parseSchemaVersionResponse('"7"'), 7);
+    assert.equal(parseSchemaVersionResponse('{"get_schema_version":7}'), 7);
+  });
+
+  it("accepts hosted schemas newer than the CLI minimum", async () => {
+    const result = await resolveHostedSchemaVersion({
+      projectRef: "example-ref",
+      anonKey: "example-anon-key",
+      readFile: () => "MINIMUM_SCHEMA_VERSION = 5\n",
+      fetchImpl: async (url, init) => {
+        assert.equal(url, "https://example-ref.supabase.co/rest/v1/rpc/get_schema_version");
+        assert.equal(init.headers.apikey, "example-anon-key");
+        assert.equal(init.headers.Authorization, "Bearer example-anon-key");
+        return response("7");
+      },
+    });
+
+    assert.deepEqual(result, { minimumVersion: 5, remoteVersion: 7 });
+  });
+
+  it("rejects hosted schemas below the CLI minimum", () => {
+    assert.throws(
+      () => assertHostedSchemaCompatible(4, 5),
+      /Hosted schema version 4 is below CLI minimum 5/,
+    );
+  });
+
+  it("fails clearly when the RPC response is invalid", async () => {
+    await assert.rejects(
+      resolveHostedSchemaVersion({
+        projectRef: "example-ref",
+        anonKey: "example-anon-key",
+        readFile: () => "MINIMUM_SCHEMA_VERSION = 5\n",
+        fetchImpl: async () => response("not-json"),
+      }),
+      /invalid JSON/,
+    );
+  });
+
+  it("renders stable GitHub outputs", () => {
+    assert.equal(
+      renderGithubOutputs({ minimumVersion: 5, remoteVersion: 7 }),
+      "minimum_version=5\nremote_version=7\nversion=7",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- resolve hosted schema version from the live Supabase environment instead of treating the CLI minimum schema as exact runtime schema
- pass the live hosted schema version into staging/production smoke, audit, and deploy parity checks
- add a hosted workflow guard and server tests so this schema parity failure does not come back

## Verification
- node --test server/scripts/resolve-hosted-schema-version.test.mjs
- bash scripts/ci/check-hosted-workflow-action.sh
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'
- npm run lint --prefix server
- npm test --prefix server
- bash scripts/ci/core.sh guard
- bash scripts/ci/core.sh server
- git diff --check
- actionlint .github/workflows/cli-hosted-audit.yml .github/workflows/config-audit.yml .github/workflows/deploy-staging.yml .github/workflows/deploy.yml .github/workflows/smoke-production.yml .github/workflows/smoke-staging.yml