### PR TITLE
Harden hosted CLI audit timeouts

### DIFF
--- a/.github/workflows/cli-hosted-audit.yml
+++ b/.github/workflows/cli-hosted-audit.yml
@@ -28,6 +28,7 @@ jobs:
       }}
     runs-on: ubuntu-latest
     environment: staging
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v6
@@ -110,6 +111,7 @@ jobs:
         run: node scripts/run-cli-hosted-audit.mjs
 
       - name: Run staging CLI audit (device approval contract)
+        timeout-minutes: 5
         working-directory: server
         env:
           CLI_AUDIT_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
@@ -122,6 +124,7 @@ jobs:
           CLI_AUDIT_EXPECT_EXPERIMENT_ID: ${{ steps.contract.outputs.smoke_expected_experiment_id }}
           CLI_AUDIT_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
           CLI_AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
+          CLI_AUDIT_LOGIN_TIMEOUT_MS: "120000"
           SMOKE_USER_EMAIL: ${{ secrets.SONDE_STAGING_SMOKE_USER_EMAIL }}
           SMOKE_USER_PASSWORD: ${{ secrets.SONDE_STAGING_SMOKE_USER_PASSWORD }}
         run: node scripts/run-cli-hosted-audit.mjs
@@ -135,6 +138,7 @@ jobs:
       }}
     runs-on: ubuntu-latest
     environment: production
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v6
@@ -216,6 +220,7 @@ jobs:
         run: node scripts/run-cli-hosted-audit.mjs
 
       - name: Run production CLI audit (device approval contract)
+        timeout-minutes: 5
         working-directory: server
         env:
           CLI_AUDIT_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
@@ -227,6 +232,7 @@ jobs:
           CLI_AUDIT_EXPECT_EXPERIMENT_ID: ${{ steps.contract.outputs.smoke_expected_experiment_id }}
           CLI_AUDIT_WAIT_TIMEOUT_MS: ${{ steps.contract.outputs.audit_wait_timeout_ms }}
           CLI_AUDIT_WAIT_INTERVAL_MS: ${{ steps.contract.outputs.audit_wait_interval_ms }}
+          CLI_AUDIT_LOGIN_TIMEOUT_MS: "120000"
           SMOKE_USER_EMAIL: ${{ secrets.SONDE_PRODUCTION_SMOKE_USER_EMAIL }}
           SMOKE_USER_PASSWORD: ${{ secrets.SONDE_PRODUCTION_SMOKE_USER_PASSWORD }}
         run: node scripts/run-cli-hosted-audit.mjs

--- a/server/scripts/run-cli-hosted-audit.mjs
+++ b/server/scripts/run-cli-hosted-audit.mjs
@@ -141,12 +141,77 @@ function runCli(command, args, env) {
   }
 }
 
-function waitForChildExit(child) {
+function childOutputForError(stdout, stderr) {
+  const trimmedStdout = stdout().trim();
+  const trimmedStderr = stderr().trim();
+  return `stdout:\n${trimmedStdout}\nstderr:\n${trimmedStderr}`;
+}
+
+function stopChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.kill("SIGTERM");
+  const killTimer = setTimeout(() => {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+    }
+  }, 3_000);
+  killTimer.unref?.();
+}
+
+export function waitForChildExit(
+  child,
+  {
+    timeoutMs,
+    description,
+    stdout = () => "",
+    stderr = () => "",
+  } = {},
+) {
   return new Promise((resolve, reject) => {
-    child.on("error", reject);
-    child.on("close", (code, signal) => {
-      resolve({ code, signal });
-    });
+    let settled = false;
+    const cleanup = () => {
+      child.off("error", onError);
+      child.off("close", onClose);
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+    const finish = (callback) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      callback();
+    };
+    const onError = (error) => {
+      finish(() => reject(error));
+    };
+    const onClose = (code, signal) => {
+      finish(() => resolve({ code, signal }));
+    };
+
+    const parsedTimeoutMs = parsePositiveInt(String(timeoutMs ?? ""), 0);
+    const timer =
+      parsedTimeoutMs > 0
+        ? setTimeout(() => {
+            stopChild(child);
+            finish(() =>
+              reject(
+                new Error(
+                  `${description ?? "child process"} timed out after ${parsedTimeoutMs}ms\n` +
+                    childOutputForError(stdout, stderr)
+                )
+              )
+            );
+          }, parsedTimeoutMs)
+        : null;
+    timer?.unref?.();
+
+    child.on("error", onError);
+    child.on("close", onClose);
   });
 }
 
@@ -215,6 +280,7 @@ async function completeHostedCliLogin({
   env,
   agentBase,
   approvalSession,
+  timeoutMs,
 }) {
   const child = spawn(command, ["login", "--json"], {
     env,
@@ -232,55 +298,79 @@ async function completeHostedCliLogin({
     stderr += chunk;
   });
 
-  const userCode = await new Promise((resolve, reject) => {
-    const deadline = Date.now() + 60_000;
-
-    const poll = () => {
-      const details = extractActivationDetails(stderr);
-      if (details.userCode) {
-        resolve(details.userCode);
-        return;
-      }
-      if (Date.now() >= deadline) {
-        reject(
-          new Error(
-            `Timed out waiting for sonde login activation code.\nCLI stderr:\n${stderr.trim()}`
-          )
-        );
-        return;
-      }
-      setTimeout(poll, 100);
-    };
-
-    poll();
+  const childExit = waitForChildExit(child, {
+    timeoutMs,
+    description: "sonde login --json",
+    stdout: () => stdout,
+    stderr: () => stderr,
   });
+  childExit.catch(() => {});
 
-  await requestJson(`${agentBase}/auth/device/approve`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      Authorization: `Bearer ${approvalSession.access_token}`,
-    },
-    body: JSON.stringify({
-      user_code: userCode,
-      decision: "approve",
-      session: approvalSession,
-    }),
-  });
+  try {
+    const userCode = await new Promise((resolve, reject) => {
+      const activationTimeoutMs = Math.min(
+        parsePositiveInt(String(timeoutMs), 60_000),
+        60_000,
+      );
+      const deadline = Date.now() + activationTimeoutMs;
 
-  const { code, signal } = await waitForChildExit(child);
-  if (code !== 0) {
-    const signalSuffix = signal ? ` (signal ${signal})` : "";
-    throw new Error(
-      `sonde login --json failed with exit code ${code}${signalSuffix}\nstdout:\n${stdout.trim()}\nstderr:\n${stderr.trim()}`
-    );
+      const poll = () => {
+        const details = extractActivationDetails(stderr);
+        if (details.userCode) {
+          resolve(details.userCode);
+          return;
+        }
+        if (Date.now() >= deadline) {
+          reject(
+            new Error(
+              `Timed out waiting for sonde login activation code.\nCLI stderr:\n${stderr.trim()}`
+            )
+          );
+          return;
+        }
+        setTimeout(poll, 100);
+      };
+
+      poll();
+    });
+    console.log(`[run-cli-hosted-audit] Approving hosted activation code ${userCode}.`);
+
+    const approval = await requestJson(`${agentBase}/auth/device/approve`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${approvalSession.access_token}`,
+      },
+      body: JSON.stringify({
+        user_code: userCode,
+        decision: "approve",
+        session: approvalSession,
+      }),
+    });
+    if (approval?.status !== "approved") {
+      throw new Error(
+        `Hosted activation approval returned status=${approval?.status ?? "unknown"}.`
+      );
+    }
+    console.log("[run-cli-hosted-audit] Hosted activation approved; waiting for CLI session.");
+
+    const { code, signal } = await childExit;
+    if (code !== 0) {
+      const signalSuffix = signal ? ` (signal ${signal})` : "";
+      throw new Error(
+        `sonde login --json failed with exit code ${code}${signalSuffix}\nstdout:\n${stdout.trim()}\nstderr:\n${stderr.trim()}`
+      );
+    }
+
+    const loginOutput = parseJsonOutput(stdout, "login");
+    if (!loginOutput?.email) {
+      throw new Error(`Hosted CLI login did not emit a usable JSON payload: ${stdout.trim()}`);
+    }
+    return loginOutput;
+  } catch (error) {
+    stopChild(child);
+    throw error;
   }
-
-  const loginOutput = parseJsonOutput(stdout, "login");
-  if (!loginOutput?.email) {
-    throw new Error(`Hosted CLI login did not emit a usable JSON payload: ${stdout.trim()}`);
-  }
-  return loginOutput;
 }
 
 function persistSession(configDir, session) {
@@ -304,6 +394,7 @@ async function main() {
   const sondeExecutable = process.env.CLI_AUDIT_SONDE_BIN?.trim() || "sonde";
   const waitTimeoutMs = parsePositiveInt(process.env.CLI_AUDIT_WAIT_TIMEOUT_MS, 0);
   const waitIntervalMs = parsePositiveInt(process.env.CLI_AUDIT_WAIT_INTERVAL_MS, 10_000);
+  const loginTimeoutMs = parsePositiveInt(process.env.CLI_AUDIT_LOGIN_TIMEOUT_MS, 120_000);
 
   const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "sonde-cli-audit-"));
   fs.chmodSync(configDir, 0o700);
@@ -348,6 +439,7 @@ async function main() {
       env: cliEnv,
       agentBase,
       approvalSession: session,
+      timeoutMs: loginTimeoutMs,
     });
   }
 

--- a/server/scripts/run-cli-hosted-audit.test.mjs
+++ b/server/scripts/run-cli-hosted-audit.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import http from "node:http";
 import { describe, it } from "node:test";
 import {
   assertAgentExchangeRejectsInvalidTokens,
   validateAgentAuditToken,
+  waitForChildExit,
 } from "./run-cli-hosted-audit.mjs";
 
 describe("run-cli-hosted-audit", () => {
@@ -82,6 +84,38 @@ describe("run-cli-hosted-audit", () => {
       );
     } finally {
       await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it("times out and terminates hung child processes", async () => {
+    const child = spawn(
+      process.execPath,
+      ["-e", "console.error('waiting forever'); setInterval(() => {}, 1000);"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    try {
+      await assert.rejects(
+        waitForChildExit(child, {
+          timeoutMs: 50,
+          description: "test child",
+          stdout: () => stdout,
+          stderr: () => stderr,
+        }),
+        /test child timed out after 50ms/,
+      );
+    } finally {
+      child.kill("SIGKILL");
     }
   });
 });

--- a/server/src/device-auth.ts
+++ b/server/src/device-auth.ts
@@ -477,6 +477,15 @@ function updateMemoryRecord(
   return { ...next };
 }
 
+function recordIncludesUpdates(
+  record: StoredDeviceAuthRequest,
+  updates: Partial<StoredDeviceAuthRequest>,
+): boolean {
+  return Object.entries(updates).every(
+    ([key, value]) => record[key as keyof StoredDeviceAuthRequest] === value,
+  );
+}
+
 async function updateRecord(
   id: string,
   updates: Partial<StoredDeviceAuthRequest>,
@@ -502,7 +511,11 @@ async function updateRecord(
     throw new Error(`Failed to update device login request: ${error.message}`);
   }
   if (!data) {
-    return null;
+    const refreshed = await findRecordById(id, env);
+    if (recordIncludesUpdates(refreshed, updates)) {
+      return refreshed;
+    }
+    throw new Error("Failed to update device login request: no row was updated.");
   }
   return toStoredRecord(data as Record<string, unknown>);
 }


### PR DESCRIPTION
## Summary
- add bounded job/step timeouts for hosted CLI audits
- add a script-level timeout around hosted device login so a stuck child process fails with diagnostics
- validate hosted device approval responses and verify durable device-auth updates before reporting success

## Validation
- npm run lint --prefix server
- npm test --prefix server
- node --test server/scripts/run-cli-hosted-audit.test.mjs
- actionlint .github/workflows/cli-hosted-audit.yml
- bash scripts/ci/check-hosted-workflow-action.sh
- git diff --check