### PR TITLE
[codex] Order production audits after smoke

### DIFF
--- a/.github/workflows/cli-hosted-audit.yml
+++ b/.github/workflows/cli-hosted-audit.yml
@@ -2,7 +2,10 @@ name: CLI Hosted Audit
 
 on:
   push:
-    branches: [staging, main]
+    branches: [staging]
+  workflow_run:
+    workflows: ["Production Smoke"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       target:
@@ -23,8 +26,13 @@ jobs:
     if: >-
       ${{
         github.ref_name == 'staging' ||
-        github.event.inputs.target == 'staging' ||
-        github.event.inputs.target == 'both'
+        (
+          github.event_name == 'workflow_dispatch' &&
+          (
+            github.event.inputs.target == 'staging' ||
+            github.event.inputs.target == 'both'
+          )
+        )
       }}
     runs-on: ubuntu-latest
     environment: staging
@@ -132,9 +140,19 @@ jobs:
   production-cli-audit:
     if: >-
       ${{
-        github.ref_name == 'main' ||
-        github.event.inputs.target == 'production' ||
-        github.event.inputs.target == 'both'
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main' &&
+          github.event.workflow_run.event == 'push'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          (
+            github.event.inputs.target == 'production' ||
+            github.event.inputs.target == 'both'
+          )
+        )
       }}
     runs-on: ubuntu-latest
     environment: production
@@ -142,6 +160,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -190,7 +210,7 @@ jobs:
         env:
           PARITY_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
           PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
-          PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
+          PARITY_EXPECT_COMMIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
           PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
           PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           PARITY_REQUIRED_KEYS: ${{ steps.contract.outputs.audit_required_runtime_keys_csv }}

--- a/.github/workflows/config-audit.yml
+++ b/.github/workflows/config-audit.yml
@@ -2,7 +2,10 @@ name: Config Audit
 
 on:
   push:
-    branches: [staging, main]
+    branches: [staging]
+  workflow_run:
+    workflows: ["Production Smoke"]
+    types: [completed]
   schedule:
     - cron: "23 14 * * *"
   workflow_dispatch:
@@ -26,8 +29,13 @@ jobs:
       ${{
         github.event_name == 'schedule' ||
         github.ref_name == 'staging' ||
-        github.event.inputs.target == 'staging' ||
-        github.event.inputs.target == 'both'
+        (
+          github.event_name == 'workflow_dispatch' &&
+          (
+            github.event.inputs.target == 'staging' ||
+            github.event.inputs.target == 'both'
+          )
+        )
       }}
     runs-on: ubuntu-latest
     environment: staging
@@ -135,15 +143,27 @@ jobs:
     if: >-
       ${{
         github.event_name == 'schedule' ||
-        github.ref_name == 'main' ||
-        github.event.inputs.target == 'production' ||
-        github.event.inputs.target == 'both'
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main' &&
+          github.event.workflow_run.event == 'push'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          (
+            github.event.inputs.target == 'production' ||
+            github.event.inputs.target == 'both'
+          )
+        )
       }}
     runs-on: ubuntu-latest
     environment: production
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: actions/setup-node@v6
         with:
@@ -206,7 +226,7 @@ jobs:
         env:
           PARITY_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
           PARITY_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
-          PARITY_EXPECT_COMMIT_SHA: ${{ github.sha }}
+          PARITY_EXPECT_COMMIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
           PARITY_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
           PARITY_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           PARITY_REQUIRED_KEYS: ${{ steps.contract.outputs.audit_required_runtime_keys_csv }}
@@ -221,7 +241,7 @@ jobs:
           AUDIT_AGENT_BASE: ${{ steps.contract.outputs.agent_url }}
           AUDIT_RUNTIME_TOKEN: ${{ secrets.SONDE_RUNTIME_AUDIT_TOKEN }}
           AUDIT_EXPECT_ENVIRONMENT: ${{ steps.contract.outputs.runtime_environment }}
-          AUDIT_EXPECT_COMMIT_SHA: ${{ github.sha }}
+          AUDIT_EXPECT_COMMIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
           AUDIT_EXPECT_SCHEMA_VERSION: ${{ steps.schema.outputs.remote_version }}
           AUDIT_EXPECT_SUPABASE_PROJECT_REF: ${{ steps.contract.outputs.supabase_project_ref }}
           AUDIT_REQUIRE_ANTHROPIC: ${{ steps.contract.outputs.audit_require_anthropic }}

--- a/scripts/ci/check-hosted-workflow-action.sh
+++ b/scripts/ci/check-hosted-workflow-action.sh
@@ -62,6 +62,26 @@ if grep -REn 'steps\.schema\.outputs\.version' "${workflows[@]}" >/tmp/hosted-wo
   exit 1
 fi
 
+production_audit_workflows=(
+  ".github/workflows/config-audit.yml"
+  ".github/workflows/cli-hosted-audit.yml"
+)
+
+for workflow in "${production_audit_workflows[@]}"; do
+  if grep -Eq 'branches:[[:space:]]+\[[^]]*main' "$workflow"; then
+    echo "::error file=${workflow}::Production hosted audits must not run directly on main push. Run them after Production Smoke so migrations/deploys finish before schema parity is resolved."
+    exit 1
+  fi
+  if ! grep -Eq 'workflows:[[:space:]]+\["Production Smoke"\]' "$workflow"; then
+    echo "::error file=${workflow}::Production hosted audits must be triggered by Production Smoke workflow_run."
+    exit 1
+  fi
+  if ! grep -Eq 'github\.event\.workflow_run\.head_sha[[:space:]]+\|\|[[:space:]]+github\.sha' "$workflow"; then
+    echo "::error file=${workflow}::Production hosted audits must use the Production Smoke head SHA when auditing workflow_run events."
+    exit 1
+  fi
+done
+
 ruby <<'RUBY'
 require "yaml"
 

--- a/server/scripts/release-health.mjs
+++ b/server/scripts/release-health.mjs
@@ -19,13 +19,13 @@ export const REQUIRED_WORKFLOWS = [
     label: "Config Audit",
     workflowId: "config-audit.yml",
     branch: "main",
-    event: "push",
+    event: "workflow_run",
   },
   {
     label: "CLI Hosted Audit",
     workflowId: "cli-hosted-audit.yml",
     branch: "main",
-    event: "push",
+    event: "workflow_run",
   },
   {
     label: "CI",

--- a/server/scripts/release-health.test.mjs
+++ b/server/scripts/release-health.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  REQUIRED_WORKFLOWS,
   itemStateFromCheckGroup,
   itemStateFromCommitStatus,
   itemStateFromReleaseTag,
@@ -70,6 +71,16 @@ describe("release-health", () => {
 
     assert.equal(state.status, "pending");
     assert.match(state.details, /v0.1.12 points to old-sha/);
+  });
+
+  it("expects production audits to run after production smoke", () => {
+    const configAudit = REQUIRED_WORKFLOWS.find((workflow) => workflow.label === "Config Audit");
+    const cliHostedAudit = REQUIRED_WORKFLOWS.find(
+      (workflow) => workflow.label === "CLI Hosted Audit",
+    );
+
+    assert.equal(configAudit?.event, "workflow_run");
+    assert.equal(cliHostedAudit?.event, "workflow_run");
   });
 
   it("turns pending items into failures at the final timeout", () => {


### PR DESCRIPTION
## Summary

This fixes the post-main audit race we saw after the latest deployment. `Config Audit` and `CLI Hosted Audit` were running immediately on the `main` push, at the same time as production migrations/deploy. They could resolve the hosted schema before migrations finished, then wait for a runtime that had already moved to the newer schema.

The production audit jobs now follow the successful `Production Smoke` workflow via `workflow_run`, which means production smoke/migrations/deploy settle first and then the deeper config/CLI audits inspect the deployed stack. Staging audits still run directly on staging pushes so the promotion signal stays fast.

## Changes

- Run `Config Audit` and `CLI Hosted Audit` on `staging` pushes only, plus production `workflow_run` events after `Production Smoke` succeeds.
- Audit the `Production Smoke` head SHA when production audits run from `workflow_run`.
- Update release-health to expect the production audit runs as `workflow_run` checks.
- Add a release-health unit test and hosted-workflow guard rules so CI catches regressions back to direct `main` push audits.

## Validation

- `bash scripts/ci/check-hosted-workflow-action.sh`
- `actionlint .github/workflows/cli-hosted-audit.yml .github/workflows/config-audit.yml .github/workflows/release-health.yml`
- `node --test server/scripts/release-health.test.mjs`
- `npm run lint --prefix server`
- `npm test --prefix server`
- `git diff --check`