### PR TITLE
[codex] Harden program access operations

### DIFF
--- a/cli/src/sonde/commands/admin.py
+++ b/cli/src/sonde/commands/admin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import click
@@ -188,18 +188,57 @@ def revoke_token(ctx: click.Context, token_name: str, force: bool) -> None:
     show_default=True,
     help="Program role to grant",
 )
+@click.option(
+    "--contractor",
+    is_flag=True,
+    help="Create a contractor-style grant that expires in 90 days unless --expires-days is set.",
+)
+@click.option(
+    "--expires-days",
+    type=click.IntRange(min=1),
+    help="Expire access after this many days.",
+)
+@click.option("--no-expiry", is_flag=True, help="Create or renew a non-expiring grant.")
 @pass_output_options
 @click.pass_context
-def grant_user(ctx: click.Context, email: str, program: str, role: str) -> None:
+def grant_user(
+    ctx: click.Context,
+    email: str,
+    program: str,
+    role: str,
+    contractor: bool,
+    expires_days: int | None,
+    no_expiry: bool,
+) -> None:
     """Grant an Aeolus-managed user access to a program.
 
     \b
     Examples:
       sonde admin grant-user contractor@aeolus.earth -p weather-intervention
+      sonde admin grant-user contractor@aeolus.earth -p weather-intervention --contractor
       sonde admin grant-user lead@aeolus.earth -p shared --role admin
     """
     try:
-        grant = access_db.grant_user(email=email, program=program, role=role)
+        expires_at = _resolve_access_expiry(
+            contractor=contractor,
+            expires_days=expires_days,
+            no_expiry=no_expiry,
+        )
+    except ValueError as e:
+        print_error(
+            "Invalid expiration",
+            str(e),
+            "Use either --contractor/--expires-days for expiring access or --no-expiry.",
+        )
+        raise SystemExit(1) from None
+
+    try:
+        grant = access_db.grant_user(
+            email=email,
+            program=program,
+            role=role,
+            expires_at=expires_at,
+        )
     except APIError as e:
         _print_access_api_error(e, program=program, action="grant access")
         raise SystemExit(1) from None
@@ -215,6 +254,7 @@ def grant_user(ctx: click.Context, email: str, program: str, role: str) -> None:
     print_success(f"Granted {grant['role']} access to {grant['email']}")
     err.print(f"  Program: {grant['program']}")
     err.print(f"  Status:  {status}")
+    err.print(f"  Expires: {_format_access_expiry(grant.get('expires_at'))}")
     if status == "pending":
         err.print("  The grant will apply automatically when this Aeolus account first signs in.")
 
@@ -255,6 +295,75 @@ def revoke_user(ctx: click.Context, email: str, program: str, force: bool) -> No
         err.print(f"[yellow]No active or pending access found for {email} on {program}.[/yellow]")
 
 
+@admin.command("offboard-user")
+@click.argument("email")
+@click.option("--force", "-f", is_flag=True, help="Skip confirmation")
+@pass_output_options
+@click.pass_context
+def offboard_user(ctx: click.Context, email: str, force: bool) -> None:
+    """Revoke all manageable program access for a user.
+
+    \b
+    Examples:
+      sonde admin offboard-user contractor@aeolus.earth --force
+    """
+    if not force:
+        click.confirm(
+            f"Revoke all manageable active and pending access for {email}?",
+            abort=True,
+        )
+
+    try:
+        result = access_db.offboard_user(email=email)
+    except APIError as e:
+        _print_access_api_error(e, action="offboard user")
+        raise SystemExit(1) from None
+    except Exception as e:
+        print_error("Failed to offboard user", str(e), "Check your admin permissions and retry.")
+        raise SystemExit(1) from None
+
+    if ctx.obj.get("json"):
+        print_json(result)
+        return
+
+    revoked_count = int(result.get("revoked_count") or 0)
+    skipped_count = int(result.get("skipped_count") or 0)
+    if revoked_count:
+        print_success(f"Revoked {revoked_count} program grant(s) for {result['email']}")
+    else:
+        err.print(f"[yellow]No manageable access found for {email}.[/yellow]")
+
+    revoked_programs = result.get("revoked_programs")
+    if isinstance(revoked_programs, list) and revoked_programs:
+        print_table(
+            ["program", "active", "grant"],
+            [
+                {
+                    "program": row.get("program", ""),
+                    "active": "yes" if row.get("revoked_active") else "no",
+                    "grant": "yes" if row.get("revoked_grant") else "no",
+                }
+                for row in revoked_programs
+                if isinstance(row, dict)
+            ],
+        )
+
+    skipped_programs = result.get("skipped_programs")
+    if skipped_count and isinstance(skipped_programs, list):
+        err.print("[yellow]Some access was skipped for safety:[/yellow]")
+        print_table(
+            ["program", "reason"],
+            [
+                {
+                    "program": row.get("program", ""),
+                    "reason": row.get("reason", ""),
+                }
+                for row in skipped_programs
+                if isinstance(row, dict)
+            ],
+        )
+
+
 @admin.command("list-users")
 @click.option("--program", "-p", required=True, help="Program id to inspect")
 @pass_output_options
@@ -284,7 +393,7 @@ def list_users(ctx: click.Context, program: str) -> None:
         return
 
     print_table(
-        ["email", "program", "role", "status", "granted"],
+        ["email", "program", "role", "status", "granted", "expires"],
         [_format_access_table_row(row) for row in rows],
     )
 
@@ -318,7 +427,7 @@ def user_access(ctx: click.Context, email: str) -> None:
         return
 
     print_table(
-        ["email", "program", "role", "status", "granted"],
+        ["email", "program", "role", "status", "granted", "expires"],
         [_format_access_table_row(row) for row in rows],
     )
 
@@ -474,7 +583,36 @@ def _format_access_table_row(row: dict[str, Any]) -> dict[str, Any]:
         "role": row.get("role", ""),
         "status": row.get("status", ""),
         "granted": granted_at[:10],
+        "expires": _format_access_expiry(row.get("expires_at")),
     }
+
+
+def _resolve_access_expiry(
+    *,
+    contractor: bool,
+    expires_days: int | None,
+    no_expiry: bool,
+) -> str | None:
+    if no_expiry and (contractor or expires_days is not None):
+        raise ValueError("--no-expiry cannot be combined with --contractor or --expires-days.")
+
+    if no_expiry:
+        return None
+
+    days = expires_days
+    if contractor and days is None:
+        days = 90
+
+    if days is None:
+        return None
+
+    return (datetime.now(UTC) + timedelta(days=days)).isoformat()
+
+
+def _format_access_expiry(value: object) -> str:
+    if not value:
+        return "never"
+    return str(value)[:10]
 
 
 def _print_access_api_error(
@@ -497,6 +635,12 @@ def _print_access_api_error(
                 f"You are not an admin for {program or 'the requested program'}.",
                 "Ask a shared admin or that program's admin to make this change.",
             )
+    elif "Expiration" in msg:
+        print_error(
+            "Invalid expiration",
+            msg,
+            "Use a future expiration date or create a non-expiring FTE grant.",
+        )
     elif error.code == "22023" or "@aeolus.earth" in msg:
         print_error(
             "Invalid user",

--- a/cli/src/sonde/db/admin_access.py
+++ b/cli/src/sonde/db/admin_access.py
@@ -11,7 +11,12 @@ PUBLIC_ROLE = "contributor"
 DB_ROLE = "member"
 
 
-def grant_user(email: str, program: str, role: str = PUBLIC_ROLE) -> dict[str, Any]:
+def grant_user(
+    email: str,
+    program: str,
+    role: str = PUBLIC_ROLE,
+    expires_at: str | None = None,
+) -> dict[str, Any]:
     """Grant a human user access to one program.
 
     Existing Aeolus-managed Google users are updated immediately; users who
@@ -25,6 +30,7 @@ def grant_user(email: str, program: str, role: str = PUBLIC_ROLE) -> dict[str, A
                 "p_email": email,
                 "p_program": program,
                 "p_role": _to_db_role(role),
+                "p_expires_at": expires_at,
             },
         )
         .execute()
@@ -42,6 +48,22 @@ def revoke_user(email: str, program: str) -> dict[str, Any]:
             {
                 "p_email": email,
                 "p_program": program,
+            },
+        )
+        .execute()
+        .data
+    )
+    return _result_dict(data)
+
+
+def offboard_user(email: str) -> dict[str, Any]:
+    """Revoke all manageable active or pending access for one user."""
+    data = (
+        db_client.get_client()
+        .rpc(
+            "revoke_user_program_access",
+            {
+                "p_email": email,
             },
         )
         .execute()

--- a/cli/tests/test_admin_commands.py
+++ b/cli/tests/test_admin_commands.py
@@ -226,6 +226,7 @@ class TestUserAccessAdmin:
                 "role": "contributor",
                 "status": "active",
                 "user_id": "user-1",
+                "expires_at": None,
             },
         ):
             result = runner.invoke(
@@ -242,6 +243,35 @@ class TestUserAccessAdmin:
         assert result.exit_code == 0
         assert "Granted contributor access" in result.output
         assert "weather-intervention" in result.output
+        assert "Expires:" in result.output
+
+    def test_grant_user_contractor_sets_expiry(self, runner: CliRunner, patched_db: MagicMock):
+        with patch(
+            "sonde.commands.admin.access_db.grant_user",
+            return_value={
+                "email": "contractor@aeolus.earth",
+                "program": "weather-intervention",
+                "role": "contributor",
+                "status": "active",
+                "user_id": "user-1",
+                "expires_at": "2026-07-16T00:00:00+00:00",
+            },
+        ) as grant_user:
+            result = runner.invoke(
+                cli,
+                [
+                    "admin",
+                    "grant-user",
+                    "contractor@aeolus.earth",
+                    "-p",
+                    "weather-intervention",
+                    "--contractor",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert grant_user.call_args.kwargs["expires_at"] is not None
+        assert "2026-07-16" in result.output
 
     def test_grant_user_pending_json(self, runner: CliRunner, patched_db: MagicMock):
         with patch(
@@ -252,6 +282,7 @@ class TestUserAccessAdmin:
                 "role": "contributor",
                 "status": "pending",
                 "user_id": None,
+                "expires_at": None,
             },
         ):
             result = runner.invoke(
@@ -326,6 +357,7 @@ class TestUserAccessAdmin:
                     "role": "contributor",
                     "status": "active",
                     "granted_at": "2026-04-17T12:00:00+00:00",
+                    "expires_at": "2026-07-16T12:00:00+00:00",
                 }
             ],
         ):
@@ -334,6 +366,7 @@ class TestUserAccessAdmin:
         assert result.exit_code == 0
         assert "contractor" in result.output
         assert "contributor" in result.output
+        assert "2026-07-16" in result.output
 
     def test_user_access_json(self, runner: CliRunner, patched_db: MagicMock):
         with patch(
@@ -345,6 +378,7 @@ class TestUserAccessAdmin:
                     "role": "contributor",
                     "status": "active",
                     "granted_at": "2026-04-17T12:00:00+00:00",
+                    "expires_at": None,
                 }
             ],
         ):
@@ -355,6 +389,37 @@ class TestUserAccessAdmin:
 
         assert result.exit_code == 0
         assert '"program": "weather-intervention"' in result.output
+
+    def test_offboard_user_force(self, runner: CliRunner, patched_db: MagicMock):
+        with patch(
+            "sonde.commands.admin.access_db.offboard_user",
+            return_value={
+                "email": "contractor@aeolus.earth",
+                "revoked_count": 2,
+                "skipped_count": 0,
+                "revoked_programs": [
+                    {
+                        "program": "weather-intervention",
+                        "revoked_active": True,
+                        "revoked_grant": True,
+                    },
+                    {
+                        "program": "shared",
+                        "revoked_active": False,
+                        "revoked_grant": True,
+                    },
+                ],
+                "skipped_programs": [],
+            },
+        ):
+            result = runner.invoke(
+                cli,
+                ["admin", "offboard-user", "contractor@aeolus.earth", "--force"],
+            )
+
+        assert result.exit_code == 0
+        assert "Revoked 2 program grant" in result.output
+        assert "weather-intervention" in result.output
 
     def test_last_shared_admin_error_has_safe_next_step(
         self, runner: CliRunner, patched_db: MagicMock

--- a/supabase/migrations/20260418000001_expiring_program_access.sql
+++ b/supabase/migrations/20260418000001_expiring_program_access.sql
@@ -1,0 +1,776 @@
+-- Expiring program access grants and bulk offboarding helpers.
+--
+-- The existing RBAC boundary remains program/library scoped. This migration
+-- adds an operational expiry layer on top of explicit grants while preserving
+-- legacy user_programs rows that do not have a matching grant record.
+
+ALTER TABLE public.program_access_grants
+    ADD COLUMN IF NOT EXISTS expires_at timestamptz;
+
+-- Program-admin helpers must ignore expired grant-backed access. Rows in
+-- user_programs without a grant are treated as durable legacy/FTE access.
+CREATE OR REPLACE FUNCTION public.admin_programs()
+RETURNS text[]
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT coalesce(array_agg(up.program ORDER BY up.program), ARRAY[]::text[])
+    FROM public.user_programs up
+    JOIN auth.users u ON u.id = up.user_id
+    LEFT JOIN public.program_access_grants g
+      ON g.email = lower(u.email)
+     AND g.program = up.program
+    WHERE up.user_id = auth.uid()
+      AND up.role = 'admin'
+      AND (g.expires_at IS NULL OR g.expires_at > now());
+$$;
+
+CREATE OR REPLACE FUNCTION public.user_programs()
+RETURNS text[]
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    jwt_programs text[];
+    live_programs text[];
+    is_agent boolean := coalesce((auth.jwt() -> 'app_metadata' ->> 'agent')::boolean, false);
+    token_id_text text;
+    token_id uuid;
+    token_is_active boolean;
+BEGIN
+    jwt_programs := coalesce(
+        array(
+            SELECT jsonb_array_elements_text(auth.jwt() -> 'app_metadata' -> 'programs')
+        ),
+        ARRAY[]::text[]
+    );
+
+    IF is_agent THEN
+        token_id_text := auth.jwt() -> 'app_metadata' ->> 'token_id';
+        IF token_id_text IS NULL OR token_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+            RETURN ARRAY[]::text[];
+        END IF;
+
+        token_id := token_id_text::uuid;
+        SELECT EXISTS (
+            SELECT 1
+            FROM public.agent_tokens token
+            WHERE token.id = token_id
+              AND token.revoked_at IS NULL
+              AND token.expires_at > now()
+              AND jwt_programs <@ token.programs
+        )
+        INTO token_is_active;
+
+        IF NOT token_is_active THEN
+            RETURN ARRAY[]::text[];
+        END IF;
+
+        RETURN jwt_programs;
+    END IF;
+
+    SELECT coalesce(array_agg(up.program ORDER BY up.program), ARRAY[]::text[])
+    INTO live_programs
+    FROM public.user_programs up
+    JOIN auth.users u ON u.id = up.user_id
+    LEFT JOIN public.program_access_grants g
+      ON g.email = lower(u.email)
+     AND g.program = up.program
+    WHERE up.user_id = auth.uid()
+      AND (g.expires_at IS NULL OR g.expires_at > now());
+
+    RETURN live_programs;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS public.grant_program_access(text, text, text);
+CREATE OR REPLACE FUNCTION public.grant_program_access(
+    p_email text,
+    p_program text,
+    p_role text DEFAULT 'member',
+    p_expires_at timestamptz DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    target_email text := public.normalize_program_access_email(p_email);
+    target_program text := btrim(coalesce(p_program, ''));
+    target_role text := public.normalize_program_access_role(p_role);
+    target_expires_at timestamptz := p_expires_at;
+    target_user_id uuid;
+    old_role text;
+    result_status text;
+    shared_admin_count integer;
+BEGIN
+    IF target_expires_at IS NOT NULL AND target_expires_at <= now() THEN
+        RAISE EXCEPTION 'Expiration must be in the future'
+            USING ERRCODE = '22023';
+    END IF;
+
+    IF target_program = '' OR NOT EXISTS (SELECT 1 FROM public.programs WHERE id = target_program) THEN
+        RAISE EXCEPTION 'Program does not exist: %', target_program
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    IF NOT public.can_manage_program(target_program) THEN
+        RAISE EXCEPTION 'Only admins of % can grant program access', target_program
+            USING ERRCODE = '42501';
+    END IF;
+
+    SELECT u.id
+    INTO target_user_id
+    FROM auth.users u
+    WHERE lower(u.email) = target_email
+    ORDER BY u.created_at DESC
+    LIMIT 1;
+
+    IF target_user_id IS NOT NULL THEN
+        SELECT role
+        INTO old_role
+        FROM public.user_programs
+        WHERE user_id = target_user_id
+          AND program = target_program;
+
+        IF target_program = 'shared'
+           AND old_role = 'admin'
+           AND target_role <> 'admin' THEN
+            SELECT count(*)
+            INTO shared_admin_count
+            FROM public.user_programs up
+            JOIN auth.users u ON u.id = up.user_id
+            LEFT JOIN public.program_access_grants g
+              ON g.email = lower(u.email)
+             AND g.program = up.program
+            WHERE up.program = 'shared'
+              AND up.role = 'admin'
+              AND (g.expires_at IS NULL OR g.expires_at > now());
+
+            IF shared_admin_count <= 1 THEN
+                RAISE EXCEPTION 'Cannot downgrade the last shared admin'
+                    USING ERRCODE = '42501';
+            END IF;
+        END IF;
+
+        INSERT INTO public.user_programs (user_id, program, role)
+        VALUES (target_user_id, target_program, target_role)
+        ON CONFLICT (user_id, program) DO UPDATE
+        SET role = EXCLUDED.role;
+
+        result_status := 'active';
+    ELSE
+        result_status := 'pending';
+    END IF;
+
+    INSERT INTO public.program_access_grants (
+        email,
+        program,
+        role,
+        granted_by,
+        created_at,
+        applied_user_id,
+        applied_at,
+        expires_at
+    )
+    VALUES (
+        target_email,
+        target_program,
+        target_role,
+        auth.uid(),
+        now(),
+        target_user_id,
+        CASE WHEN target_user_id IS NULL THEN NULL ELSE now() END,
+        target_expires_at
+    )
+    ON CONFLICT (email, program) DO UPDATE
+    SET role = EXCLUDED.role,
+        granted_by = EXCLUDED.granted_by,
+        created_at = EXCLUDED.created_at,
+        applied_user_id = EXCLUDED.applied_user_id,
+        applied_at = EXCLUDED.applied_at,
+        expires_at = EXCLUDED.expires_at;
+
+    INSERT INTO public.program_access_events (
+        action,
+        actor_user_id,
+        actor_email,
+        target_user_id,
+        target_email,
+        program,
+        old_role,
+        new_role,
+        details
+    )
+    VALUES (
+        'grant',
+        auth.uid(),
+        auth.jwt() ->> 'email',
+        target_user_id,
+        target_email,
+        target_program,
+        old_role,
+        target_role,
+        jsonb_build_object(
+            'status', result_status,
+            'expires_at', target_expires_at
+        )
+    );
+
+    RETURN jsonb_build_object(
+        'email', target_email,
+        'program', target_program,
+        'role', target_role,
+        'status', result_status,
+        'user_id', target_user_id,
+        'expires_at', target_expires_at
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.revoke_user_program_access(p_email text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    target_email text := public.normalize_program_access_email(p_email);
+    target_user_id uuid;
+    access_row record;
+    deleted_grants integer := 0;
+    deleted_active integer := 0;
+    shared_admin_count integer;
+    revoked_programs jsonb := '[]'::jsonb;
+    skipped_programs jsonb := '[]'::jsonb;
+BEGIN
+    SELECT u.id
+    INTO target_user_id
+    FROM auth.users u
+    WHERE lower(u.email) = target_email
+    ORDER BY u.created_at DESC
+    LIMIT 1;
+
+    FOR access_row IN
+        SELECT DISTINCT ON (program)
+            program,
+            role,
+            has_active,
+            has_grant
+        FROM (
+            SELECT
+                up.program,
+                up.role,
+                true AS has_active,
+                false AS has_grant
+            FROM public.user_programs up
+            JOIN auth.users u ON u.id = up.user_id
+            WHERE lower(u.email) = target_email
+              AND public.can_manage_program(up.program)
+
+            UNION ALL
+
+            SELECT
+                g.program,
+                g.role,
+                false AS has_active,
+                true AS has_grant
+            FROM public.program_access_grants g
+            WHERE g.email = target_email
+              AND public.can_manage_program(g.program)
+        ) scoped_access
+        ORDER BY program, has_active DESC
+    LOOP
+        deleted_active := 0;
+        deleted_grants := 0;
+
+        IF access_row.program = 'shared' AND access_row.role = 'admin' THEN
+            SELECT count(*)
+            INTO shared_admin_count
+            FROM public.user_programs up
+            JOIN auth.users u ON u.id = up.user_id
+            LEFT JOIN public.program_access_grants g
+              ON g.email = lower(u.email)
+             AND g.program = up.program
+            WHERE up.program = 'shared'
+              AND up.role = 'admin'
+              AND (g.expires_at IS NULL OR g.expires_at > now());
+
+            IF shared_admin_count <= 1 THEN
+                skipped_programs := skipped_programs || jsonb_build_array(
+                    jsonb_build_object(
+                        'program', access_row.program,
+                        'reason', 'last_shared_admin'
+                    )
+                );
+                CONTINUE;
+            END IF;
+        END IF;
+
+        IF target_user_id IS NOT NULL THEN
+            DELETE FROM public.user_programs
+            WHERE user_id = target_user_id
+              AND program = access_row.program;
+            GET DIAGNOSTICS deleted_active = ROW_COUNT;
+        END IF;
+
+        DELETE FROM public.program_access_grants
+        WHERE email = target_email
+          AND program = access_row.program;
+        GET DIAGNOSTICS deleted_grants = ROW_COUNT;
+
+        IF deleted_active > 0 OR deleted_grants > 0 THEN
+            revoked_programs := revoked_programs || jsonb_build_array(
+                jsonb_build_object(
+                    'program', access_row.program,
+                    'revoked_active', deleted_active > 0,
+                    'revoked_grant', deleted_grants > 0
+                )
+            );
+
+            INSERT INTO public.program_access_events (
+                action,
+                actor_user_id,
+                actor_email,
+                target_user_id,
+                target_email,
+                program,
+                old_role,
+                new_role,
+                details
+            )
+            VALUES (
+                'revoke',
+                auth.uid(),
+                auth.jwt() ->> 'email',
+                target_user_id,
+                target_email,
+                access_row.program,
+                access_row.role,
+                NULL,
+                jsonb_build_object(
+                    'source', 'bulk_offboard',
+                    'revoked_active', deleted_active > 0,
+                    'revoked_grant', deleted_grants > 0
+                )
+            );
+        END IF;
+    END LOOP;
+
+    RETURN jsonb_build_object(
+        'email', target_email,
+        'revoked_count', jsonb_array_length(revoked_programs),
+        'skipped_count', jsonb_array_length(skipped_programs),
+        'revoked_programs', revoked_programs,
+        'skipped_programs', skipped_programs
+    );
+END;
+$$;
+
+DROP FUNCTION IF EXISTS public.list_program_access(text);
+CREATE OR REPLACE FUNCTION public.list_program_access(p_program text)
+RETURNS TABLE (
+    email text,
+    user_id uuid,
+    program text,
+    role text,
+    status text,
+    granted_at timestamptz,
+    applied_at timestamptz,
+    expires_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    target_program text := btrim(coalesce(p_program, ''));
+BEGIN
+    IF target_program = '' OR NOT EXISTS (SELECT 1 FROM public.programs WHERE id = target_program) THEN
+        RAISE EXCEPTION 'Program does not exist: %', target_program
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    IF NOT public.can_manage_program(target_program) THEN
+        RAISE EXCEPTION 'Only admins of % can list program access', target_program
+            USING ERRCODE = '42501';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        lower(u.email)::text AS email,
+        up.user_id,
+        up.program,
+        up.role,
+        CASE
+            WHEN g.expires_at IS NOT NULL AND g.expires_at <= now() THEN 'expired'
+            ELSE 'active'
+        END::text AS status,
+        coalesce(g.created_at, up.created_at) AS granted_at,
+        g.applied_at,
+        g.expires_at
+    FROM public.user_programs up
+    JOIN auth.users u ON u.id = up.user_id
+    LEFT JOIN public.program_access_grants g
+      ON g.email = lower(u.email)
+     AND g.program = up.program
+    WHERE up.program = target_program
+
+    UNION ALL
+
+    SELECT
+        g.email,
+        NULL::uuid AS user_id,
+        g.program,
+        g.role,
+        CASE
+            WHEN g.expires_at IS NOT NULL AND g.expires_at <= now() THEN 'expired'
+            ELSE 'pending'
+        END::text AS status,
+        g.created_at AS granted_at,
+        NULL::timestamptz AS applied_at,
+        g.expires_at
+    FROM public.program_access_grants g
+    LEFT JOIN auth.users u ON lower(u.email) = g.email
+    LEFT JOIN public.user_programs up
+      ON up.user_id = u.id
+     AND up.program = g.program
+    WHERE g.program = target_program
+      AND u.id IS NULL
+    ORDER BY status, email;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS public.get_user_program_access(text);
+CREATE OR REPLACE FUNCTION public.get_user_program_access(p_email text)
+RETURNS TABLE (
+    email text,
+    user_id uuid,
+    program text,
+    role text,
+    status text,
+    granted_at timestamptz,
+    applied_at timestamptz,
+    expires_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    target_email text := public.normalize_program_access_email(p_email);
+BEGIN
+    RETURN QUERY
+    SELECT
+        lower(u.email)::text AS email,
+        up.user_id,
+        up.program,
+        up.role,
+        CASE
+            WHEN g.expires_at IS NOT NULL AND g.expires_at <= now() THEN 'expired'
+            ELSE 'active'
+        END::text AS status,
+        coalesce(g.created_at, up.created_at) AS granted_at,
+        g.applied_at,
+        g.expires_at
+    FROM public.user_programs up
+    JOIN auth.users u ON u.id = up.user_id
+    LEFT JOIN public.program_access_grants g
+      ON g.email = lower(u.email)
+     AND g.program = up.program
+    WHERE lower(u.email) = target_email
+      AND public.can_manage_program(up.program)
+
+    UNION ALL
+
+    SELECT
+        g.email,
+        NULL::uuid AS user_id,
+        g.program,
+        g.role,
+        CASE
+            WHEN g.expires_at IS NOT NULL AND g.expires_at <= now() THEN 'expired'
+            ELSE 'pending'
+        END::text AS status,
+        g.created_at AS granted_at,
+        NULL::timestamptz AS applied_at,
+        g.expires_at
+    FROM public.program_access_grants g
+    LEFT JOIN auth.users u ON lower(u.email) = g.email
+    LEFT JOIN public.user_programs up
+      ON up.user_id = u.id
+     AND up.program = g.program
+    WHERE g.email = target_email
+      AND u.id IS NULL
+      AND public.can_manage_program(g.program)
+    ORDER BY status, program;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS public.list_manageable_program_access();
+CREATE OR REPLACE FUNCTION public.list_manageable_program_access()
+RETURNS TABLE (
+    email text,
+    user_id uuid,
+    program text,
+    role text,
+    status text,
+    granted_at timestamptz,
+    applied_at timestamptz,
+    expires_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    PERFORM public.require_program_access_manager();
+
+    RETURN QUERY
+    WITH manageable_programs AS (
+        SELECT p.id
+        FROM public.programs p
+        WHERE public.can_manage_program(p.id)
+    ),
+    active_access AS (
+        SELECT
+            lower(u.email)::text AS email,
+            up.user_id,
+            up.program,
+            up.role,
+            CASE
+                WHEN g.expires_at IS NOT NULL AND g.expires_at <= now() THEN 'expired'
+                ELSE 'active'
+            END::text AS status,
+            coalesce(g.created_at, up.created_at) AS granted_at,
+            g.applied_at,
+            g.expires_at
+        FROM public.user_programs up
+        JOIN manageable_programs mp ON mp.id = up.program
+        JOIN auth.users u ON u.id = up.user_id
+        LEFT JOIN public.program_access_grants g
+          ON g.email = lower(u.email)
+         AND g.program = up.program
+    ),
+    pending_access AS (
+        SELECT
+            g.email,
+            NULL::uuid AS user_id,
+            g.program,
+            g.role,
+            CASE
+                WHEN g.expires_at IS NOT NULL AND g.expires_at <= now() THEN 'expired'
+                ELSE 'pending'
+            END::text AS status,
+            g.created_at AS granted_at,
+            NULL::timestamptz AS applied_at,
+            g.expires_at
+        FROM public.program_access_grants g
+        JOIN manageable_programs mp ON mp.id = g.program
+        LEFT JOIN auth.users u ON lower(u.email) = g.email
+        LEFT JOIN public.user_programs up
+          ON up.user_id = u.id
+         AND up.program = g.program
+        WHERE u.id IS NULL
+    )
+    SELECT *
+    FROM active_access
+    UNION ALL
+    SELECT *
+    FROM pending_access
+    ORDER BY program, status, email;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.apply_pending_program_access_grants()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    normalized_email text;
+    grant_row public.program_access_grants%rowtype;
+BEGIN
+    normalized_email := lower(coalesce(NEW.email, ''));
+
+    IF normalized_email NOT LIKE '%@aeolus.earth' THEN
+        RETURN NEW;
+    END IF;
+
+    FOR grant_row IN
+        SELECT *
+        FROM public.program_access_grants
+        WHERE email = normalized_email
+          AND (expires_at IS NULL OR expires_at > now())
+    LOOP
+        INSERT INTO public.user_programs (user_id, program, role)
+        VALUES (NEW.id, grant_row.program, grant_row.role)
+        ON CONFLICT (user_id, program) DO UPDATE
+        SET role = EXCLUDED.role;
+
+        UPDATE public.program_access_grants
+        SET applied_user_id = NEW.id,
+            applied_at = now()
+        WHERE email = grant_row.email
+          AND program = grant_row.program;
+
+        INSERT INTO public.program_access_events (
+            action,
+            actor_user_id,
+            target_user_id,
+            target_email,
+            program,
+            old_role,
+            new_role,
+            details
+        )
+        VALUES (
+            'apply_pending',
+            grant_row.granted_by,
+            NEW.id,
+            normalized_email,
+            grant_row.program,
+            NULL,
+            grant_row.role,
+            jsonb_build_object(
+                'source', 'auth.users trigger',
+                'expires_at', grant_row.expires_at
+            )
+        );
+    END LOOP;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    claims jsonb;
+    app_meta jsonb;
+    user_email text;
+    user_programs_arr text[];
+    agent_programs text[];
+    is_admin boolean;
+    is_agent boolean;
+    token_id_text text;
+    token_id uuid;
+    token_name text;
+BEGIN
+    claims := event -> 'claims';
+    app_meta := coalesce(claims -> 'app_metadata', '{}'::jsonb);
+    user_email := claims ->> 'email';
+    is_agent := coalesce((app_meta ->> 'agent')::boolean, false);
+
+    IF user_email IS NOT NULL AND user_email NOT LIKE '%@aeolus.earth' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'http_code', 403,
+                'message', 'Only @aeolus.earth accounts are allowed'
+            )
+        );
+    END IF;
+
+    IF is_agent THEN
+        token_id_text := app_meta ->> 'token_id';
+        IF token_id_text IS NULL
+           OR token_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'http_code', 403,
+                    'message', 'Invalid or expired agent token'
+                )
+            );
+        END IF;
+
+        token_id := token_id_text::uuid;
+        SELECT token.programs, token.name
+        INTO agent_programs, token_name
+        FROM public.agent_tokens token
+        WHERE token.id = token_id
+          AND token.revoked_at IS NULL
+          AND token.expires_at > now();
+
+        IF NOT FOUND THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'http_code', 403,
+                    'message', 'Invalid or expired agent token'
+                )
+            );
+        END IF;
+
+        claims := jsonb_set(
+            claims,
+            '{app_metadata}',
+            app_meta ||
+            jsonb_build_object(
+                'agent', true,
+                'programs', to_jsonb(agent_programs),
+                'is_admin', false,
+                'token_id', token_id,
+                'token_name', token_name,
+                'agent_name', token_name
+            )
+        );
+
+        event := jsonb_set(event, '{claims}', claims);
+        RETURN event;
+    END IF;
+
+    SELECT
+        coalesce(array_agg(up.program ORDER BY up.program), ARRAY[]::text[]),
+        coalesce(bool_or(up.role = 'admin'), false)
+    INTO user_programs_arr, is_admin
+    FROM public.user_programs up
+    JOIN auth.users u ON u.id = up.user_id
+    LEFT JOIN public.program_access_grants g
+      ON g.email = lower(u.email)
+     AND g.program = up.program
+    WHERE up.user_id = (claims ->> 'sub')::uuid
+      AND (g.expires_at IS NULL OR g.expires_at > now());
+
+    claims := jsonb_set(
+        claims,
+        '{app_metadata}',
+        app_meta ||
+        jsonb_build_object(
+            'programs', to_jsonb(coalesce(user_programs_arr, ARRAY[]::text[])),
+            'is_admin', coalesce(is_admin, false)
+        )
+    );
+
+    event := jsonb_set(event, '{claims}', claims);
+    RETURN event;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.grant_program_access(text, text, text, timestamptz) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.revoke_user_program_access(text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.list_program_access(text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.get_user_program_access(text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.list_manageable_program_access() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.grant_program_access(text, text, text, timestamptz) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.revoke_user_program_access(text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_program_access(text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_user_program_access(text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_manageable_program_access() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb) TO supabase_auth_admin;
+GRANT SELECT ON TABLE public.program_access_grants TO supabase_auth_admin;
+
+UPDATE public.schema_version
+SET version = GREATEST(version, 8),
+    updated_at = now()
+WHERE singleton = TRUE;

--- a/ui/src/components/admin/access-management.test.ts
+++ b/ui/src/components/admin/access-management.test.ts
@@ -10,6 +10,7 @@ const useManageableProgramAccessMock = vi.fn();
 const useProgramAccessEventsMock = vi.fn();
 const useGrantProgramAccessMock = vi.fn();
 const useRevokeProgramAccessMock = vi.fn();
+const useOffboardProgramAccessMock = vi.fn();
 const useBulkGrantProgramAccessMock = vi.fn();
 
 vi.mock("@/hooks/use-admin-access", () => ({
@@ -18,6 +19,7 @@ vi.mock("@/hooks/use-admin-access", () => ({
   useProgramAccessEvents: (filters: unknown) => useProgramAccessEventsMock(filters),
   useGrantProgramAccess: () => useGrantProgramAccessMock(),
   useRevokeProgramAccess: () => useRevokeProgramAccessMock(),
+  useOffboardProgramAccess: () => useOffboardProgramAccessMock(),
   useBulkGrantProgramAccess: () => useBulkGrantProgramAccessMock(),
 }));
 
@@ -72,15 +74,28 @@ const accessEvents = [
   },
 ];
 
+const activeAccessRow = {
+  email: "alice@aeolus.earth",
+  user_id: "user-1",
+  program: "alpha",
+  role: "admin",
+  status: "active",
+  granted_at: "2026-04-01T00:00:00Z",
+  applied_at: "2026-04-01T00:01:00Z",
+  expires_at: null,
+};
+
 describe("AdminAccessManagement", () => {
   const grantMutate = vi.fn();
   const revokeMutate = vi.fn();
+  const offboardMutate = vi.fn();
   const bulkMutate = vi.fn();
   let confirmMock: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     grantMutate.mockReset();
     revokeMutate.mockReset();
+    offboardMutate.mockReset();
     bulkMutate.mockReset();
     confirmMock = vi.spyOn(window, "confirm").mockReturnValue(true);
     useManageableProgramsMock.mockReturnValue({
@@ -89,17 +104,7 @@ describe("AdminAccessManagement", () => {
       error: null,
     });
     useManageableProgramAccessMock.mockReturnValue({
-      data: [
-        {
-          email: "alice@aeolus.earth",
-          user_id: "user-1",
-          program: "alpha",
-          role: "admin",
-          status: "active",
-          granted_at: "2026-04-01T00:00:00Z",
-          applied_at: "2026-04-01T00:01:00Z",
-        },
-      ],
+      data: [activeAccessRow],
       isLoading: false,
       error: null,
     });
@@ -126,6 +131,10 @@ describe("AdminAccessManagement", () => {
     });
     useRevokeProgramAccessMock.mockReturnValue({
       mutate: revokeMutate,
+      isPending: false,
+    });
+    useOffboardProgramAccessMock.mockReturnValue({
+      mutate: offboardMutate,
       isPending: false,
     });
     useBulkGrantProgramAccessMock.mockReturnValue({
@@ -155,7 +164,7 @@ describe("AdminAccessManagement", () => {
     expect(screen.getByText("bob@aeolus.earth")).toBeVisible();
   });
 
-  it("previews, confirms, and applies bulk FTE contributor grants", () => {
+  it("previews, confirms, and applies bulk FTE contributor grants without expiry", () => {
     render(createElement(AdminAccessManagement));
 
     fireEvent.change(screen.getByPlaceholderText(/alice@aeolus/i), {
@@ -178,6 +187,7 @@ describe("AdminAccessManagement", () => {
         emails: ["alice@aeolus.earth", "bob@aeolus.earth"],
         programs,
         role: "contributor",
+        expiresAt: null,
       }),
       expect.objectContaining({
         onSuccess: expect.any(Function),
@@ -216,15 +226,7 @@ describe("AdminAccessManagement", () => {
   it("filters users by pending access", () => {
     useManageableProgramAccessMock.mockReturnValue({
       data: [
-        {
-          email: "alice@aeolus.earth",
-          user_id: "user-1",
-          program: "alpha",
-          role: "admin",
-          status: "active",
-          granted_at: "2026-04-01T00:00:00Z",
-          applied_at: "2026-04-01T00:01:00Z",
-        },
+        activeAccessRow,
         {
           email: "carol@aeolus.earth",
           user_id: null,
@@ -233,6 +235,7 @@ describe("AdminAccessManagement", () => {
           status: "pending",
           granted_at: "2026-04-02T00:00:00Z",
           applied_at: null,
+          expires_at: "2026-07-01T00:00:00Z",
         },
       ],
       isLoading: false,
@@ -250,6 +253,70 @@ describe("AdminAccessManagement", () => {
     expect(matrixPanel).toBeTruthy();
     expect(within(matrixPanel!).queryByText("alice@aeolus.earth")).not.toBeInTheDocument();
     expect(within(matrixPanel!).getByText("carol@aeolus.earth")).toBeVisible();
+  });
+
+  it("grants scoped contractor access with a 90-day expiry", () => {
+    render(createElement(AdminAccessManagement));
+
+    fireEvent.change(screen.getByPlaceholderText("person@aeolus.earth"), {
+      target: { value: "contractor@aeolus.earth" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Grant scoped access" }));
+
+    expect(bulkMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emails: ["contractor@aeolus.earth"],
+        programs: [programs[0]],
+        role: "contributor",
+        expiresAt: expect.any(String),
+      }),
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+      }),
+    );
+  });
+
+  it("shows expired grants and can renew them", () => {
+    useManageableProgramAccessMock.mockReturnValue({
+      data: [
+        {
+          email: "dana@aeolus.earth",
+          user_id: "user-2",
+          program: "alpha",
+          role: "contributor",
+          status: "expired",
+          granted_at: "2026-01-01T00:00:00Z",
+          applied_at: "2026-01-01T00:01:00Z",
+          expires_at: "2026-02-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    render(createElement(AdminAccessManagement));
+
+    fireEvent.change(screen.getByLabelText("Filter users by access status"), {
+      target: { value: "expired" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Renew 90d" }));
+
+    expect(screen.getByText("dana@aeolus.earth")).toBeVisible();
+    expect(grantMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "dana@aeolus.earth",
+        program: "alpha",
+        expiresAt: expect.any(String),
+      }),
+    );
+  });
+
+  it("offboards a user from manageable programs", () => {
+    render(createElement(AdminAccessManagement));
+
+    fireEvent.click(screen.getByRole("button", { name: "Offboard" }));
+
+    expect(confirmMock).toHaveBeenCalledWith(expect.stringContaining("alice@aeolus.earth"));
+    expect(offboardMutate).toHaveBeenCalledWith({ email: "alice@aeolus.earth" });
   });
 
   it("filters recent access changes by action and program", () => {

--- a/ui/src/components/admin/access-management.tsx
+++ b/ui/src/components/admin/access-management.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   useBulkGrantProgramAccess,
   useGrantProgramAccess,
   useManageableProgramAccess,
   useManageablePrograms,
+  useOffboardProgramAccess,
   useProgramAccessEvents,
   useRevokeProgramAccess,
   type BulkGrantProgramAccessResult,
@@ -27,8 +28,9 @@ import type { Program } from "@/types/sonde";
 const cardClass = "rounded-[8px] border border-border bg-surface p-3";
 const controlClass =
   "rounded-[6px] border border-border bg-surface px-2 py-1 text-[12px] text-text placeholder:text-text-quaternary";
+const DEFAULT_CONTRACTOR_GRANT_DAYS = 90;
 
-type AccessMatrixStatusFilter = "all" | "active" | "pending";
+type AccessMatrixStatusFilter = "all" | "active" | "pending" | "expired";
 type ProgramAccessEventActionFilter = "all" | ProgramAccessEventAction;
 
 const accessEventActionOptions: Array<{
@@ -77,7 +79,12 @@ function optionalRoleLabel(role: ProgramAccessRole | null): string {
   return role ? roleLabel(role) : "access";
 }
 
-function statusVariant(cell: ProgramAccessCell): "complete" | "open" | "running" {
+function statusVariant(
+  cell: ProgramAccessCell,
+): "complete" | "open" | "running" | "failed" {
+  if (cell.status === "expired") {
+    return "failed";
+  }
   if (cell.status === "pending") {
     return "open";
   }
@@ -86,7 +93,12 @@ function statusVariant(cell: ProgramAccessCell): "complete" | "open" | "running"
 
 function currentCellTitle(cell: ProgramAccessCell): string {
   const when = cell.appliedAt ?? cell.grantedAt;
-  const status = cell.status === "pending" ? "pending grant" : "active grant";
+  const status =
+    cell.status === "expired"
+      ? "expired grant"
+      : cell.status === "pending"
+        ? "pending grant"
+        : "active grant";
   return when ? `${status}, ${formatDateTimeShort(when)}` : status;
 }
 
@@ -126,6 +138,37 @@ function eventRoleSummary(event: ProgramAccessEventRow): string {
   return "access updated";
 }
 
+function eventExpirySummary(event: ProgramAccessEventRow): string | null {
+  const expiresAt = event.details.expires_at;
+  if (typeof expiresAt !== "string" || !expiresAt) {
+    return null;
+  }
+  return `expires ${formatDateTimeShort(expiresAt)}`;
+}
+
+function defaultContractorExpiryDate(): string {
+  const date = new Date();
+  date.setDate(date.getDate() + DEFAULT_CONTRACTOR_GRANT_DAYS);
+  return date.toISOString().slice(0, 10);
+}
+
+function dateInputToExpiryIso(value: string): string | null {
+  if (!value) {
+    return null;
+  }
+  const expiry = new Date(`${value}T23:59:59.999Z`);
+  if (Number.isNaN(expiry.getTime()) || expiry <= new Date()) {
+    return null;
+  }
+  return expiry.toISOString();
+}
+
+function futureExpiryIso(days: number): string {
+  const expiry = new Date();
+  expiry.setDate(expiry.getDate() + days);
+  return expiry.toISOString();
+}
+
 function grantableProgramsForBulk({
   programs,
   matrix,
@@ -137,7 +180,10 @@ function grantableProgramsForBulk({
 }): Program[] {
   const rowsByEmail = new Map(matrix.map((row) => [row.email, row]));
   return programs.filter((program) =>
-    emails.some((email) => !rowsByEmail.get(email)?.cells[program.id]),
+    emails.some((email) => {
+      const cell = rowsByEmail.get(email)?.cells[program.id];
+      return !cell || cell.status === "expired";
+    }),
   );
 }
 
@@ -146,8 +192,9 @@ export function AdminAccessManagement() {
   const [accessStatusFilter, setAccessStatusFilter] =
     useState<AccessMatrixStatusFilter>("all");
   const [grantEmail, setGrantEmail] = useState("");
-  const [grantProgram, setGrantProgram] = useState("");
+  const [grantProgramIds, setGrantProgramIds] = useState<string[]>([]);
   const [grantRole, setGrantRole] = useState<ProgramAccessRole>("contributor");
+  const [grantExpiresOn, setGrantExpiresOn] = useState(defaultContractorExpiryDate);
   const [bulkInput, setBulkInput] = useState("");
   const [eventActionFilter, setEventActionFilter] =
     useState<ProgramAccessEventActionFilter>("all");
@@ -175,12 +222,30 @@ export function AdminAccessManagement() {
   });
   const grantAccess = useGrantProgramAccess();
   const revokeAccess = useRevokeProgramAccess();
+  const offboardAccess = useOffboardProgramAccess();
   const bulkGrantAccess = useBulkGrantProgramAccess();
 
-  const selectedGrantProgram = grantProgram || programs[0]?.id || "";
   const programsById = useMemo(
     () => new Map(programs.map((program) => [program.id, program])),
     [programs],
+  );
+  useEffect(() => {
+    setGrantProgramIds((current) => {
+      const visible = current.filter((id) => programsById.has(id));
+      if (visible.length > 0 || programs.length === 0) {
+        return visible;
+      }
+      return [programs[0]!.id];
+    });
+  }, [programs, programsById]);
+
+  const selectedGrantPrograms = useMemo(
+    () => programs.filter((program) => grantProgramIds.includes(program.id)),
+    [grantProgramIds, programs],
+  );
+  const grantExpiresAt = useMemo(
+    () => dateInputToExpiryIso(grantExpiresOn),
+    [grantExpiresOn],
   );
   const matrix = useMemo(
     () => buildProgramAccessMatrix(programs, accessRows),
@@ -196,6 +261,9 @@ export function AdminAccessManagement() {
         return false;
       }
       if (accessStatusFilter === "pending" && row.pendingCount === 0) {
+        return false;
+      }
+      if (accessStatusFilter === "expired" && row.expiredCount === 0) {
         return false;
       }
       return true;
@@ -225,12 +293,14 @@ export function AdminAccessManagement() {
   );
   const activeGrantCount = accessRows.filter((row) => row.status === "active").length;
   const pendingGrantCount = accessRows.filter((row) => row.status === "pending").length;
+  const expiredGrantCount = accessRows.filter((row) => row.status === "expired").length;
   const isLoading = programsLoading || accessLoading;
   const loadError = programsError ?? accessError;
   const canSingleGrant =
     singleGrantParsed.validEmails.length === 1 &&
     singleGrantParsed.invalidEntries.length === 0 &&
-    Boolean(selectedGrantProgram);
+    selectedGrantPrograms.length > 0 &&
+    Boolean(grantExpiresAt);
   const canBulkGrant =
     bulkPreview.validEmails.length > 0 &&
     bulkPreview.invalidEntries.length === 0 &&
@@ -241,11 +311,23 @@ export function AdminAccessManagement() {
     if (!canSingleGrant) {
       return;
     }
-    grantAccess.mutate({
-      email: singleGrantParsed.validEmails[0]!,
-      program: selectedGrantProgram,
-      role: grantRole,
-    });
+    bulkGrantAccess.mutate(
+      {
+        emails: [singleGrantParsed.validEmails[0]!],
+        programs: selectedGrantPrograms,
+        matrix,
+        role: grantRole,
+        expiresAt: grantExpiresAt,
+      },
+      {
+        onSuccess: (result) => {
+          if (result.failed === 0) {
+            setGrantEmail("");
+            setGrantExpiresOn(defaultContractorExpiryDate());
+          }
+        },
+      },
+    );
   }
 
   function handleBulkGrant() {
@@ -265,6 +347,7 @@ export function AdminAccessManagement() {
         programs: bulkGrantablePrograms,
         matrix,
         role: "contributor",
+        expiresAt: null,
       },
       {
         onSuccess: (result) => {
@@ -288,6 +371,25 @@ export function AdminAccessManagement() {
     revokeAccess.mutate({ email, program });
   }
 
+  function handleOffboard(email: string) {
+    if (
+      !window.confirm(
+        `Revoke all manageable program access for ${email}? This removes their active, pending, and expired grants from every library you can manage.`,
+      )
+    ) {
+      return;
+    }
+    offboardAccess.mutate({ email });
+  }
+
+  function toggleGrantProgram(programId: string) {
+    setGrantProgramIds((current) =>
+      current.includes(programId)
+        ? current.filter((id) => id !== programId)
+        : [...current, programId],
+    );
+  }
+
   return (
     <section className="space-y-3">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -296,9 +398,9 @@ export function AdminAccessManagement() {
             Access management
           </h2>
           <p className="mt-0.5 max-w-[720px] text-[11px] leading-relaxed text-text-quaternary">
-            Manage users with active or pending Sonde program / library access. FTE
-            bulk grants add contributor access only where it is missing, so existing
-            admin grants are preserved instead of silently downgraded.
+            Manage users with active, pending, or expired Sonde program / library
+            access. FTE bulk grants add contributor access only where it is missing,
+            so existing admin grants are preserved instead of silently downgraded.
           </p>
         </div>
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -320,11 +422,12 @@ export function AdminAccessManagement() {
             <option value="all">All access</option>
             <option value="active">Active</option>
             <option value="pending">Pending</option>
+            <option value="expired">Expired</option>
           </select>
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-5">
         <AccessStatCard
           value={programs.length}
           label="Manageable programs"
@@ -339,6 +442,11 @@ export function AdminAccessManagement() {
         <AccessStatCard
           value={pendingGrantCount}
           label="Pending grants"
+          loading={isLoading}
+        />
+        <AccessStatCard
+          value={expiredGrantCount}
+          label="Expired grants"
           loading={isLoading}
         />
       </div>
@@ -356,10 +464,13 @@ export function AdminAccessManagement() {
 
       <div className="grid gap-3 lg:grid-cols-[1fr_1.4fr]">
         <div className={cardClass}>
-          <h3 className="text-[12px] font-medium text-text">Grant one user</h3>
+          <h3 className="text-[12px] font-medium text-text">
+            Grant contractor access
+          </h3>
           <p className="mt-1 text-[11px] leading-relaxed text-text-quaternary">
-            Use this for contractors or one-off changes. New users can be granted access
-            before they sign in; the grant becomes active on first login.
+            Use this for contractors or one-off scoped access. Grants default to a
+            90-day expiration and can target one or more libraries before the user
+            first signs in.
           </p>
           <div className="mt-3 grid gap-2">
             <input
@@ -370,18 +481,33 @@ export function AdminAccessManagement() {
               className={controlClass}
             />
             <div className="grid gap-2 sm:grid-cols-[1fr_150px]">
-              <select
-                value={selectedGrantProgram}
-                onChange={(event) => setGrantProgram(event.target.value)}
-                className={controlClass}
-                disabled={programs.length === 0}
-              >
-                {programs.map((program) => (
-                  <option key={program.id} value={program.id}>
-                    {program.name}
-                  </option>
-                ))}
-              </select>
+              <div className="max-h-[150px] overflow-y-auto rounded-[6px] border border-border bg-surface-raised px-2 py-1.5">
+                {programs.length === 0 ? (
+                  <p className="py-1 text-[11px] text-text-quaternary">
+                    No manageable libraries.
+                  </p>
+                ) : (
+                  programs.map((program) => (
+                    <label
+                      key={program.id}
+                      className="flex cursor-pointer items-start gap-2 py-1 text-[12px] text-text-secondary"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={grantProgramIds.includes(program.id)}
+                        onChange={() => toggleGrantProgram(program.id)}
+                        className="mt-0.5"
+                      />
+                      <span className="min-w-0">
+                        <span className="block truncate">{program.name}</span>
+                        <span className="block truncate text-[10px] text-text-quaternary">
+                          {program.id}
+                        </span>
+                      </span>
+                    </label>
+                  ))
+                )}
+              </div>
               <select
                 value={grantRole}
                 onChange={(event) => setGrantRole(event.target.value as ProgramAccessRole)}
@@ -391,17 +517,31 @@ export function AdminAccessManagement() {
                 <option value="admin">admin</option>
               </select>
             </div>
+            <label className="grid gap-1 text-[11px] text-text-tertiary">
+              <span>Expires on</span>
+              <input
+                type="date"
+                value={grantExpiresOn}
+                onChange={(event) => setGrantExpiresOn(event.target.value)}
+                className={controlClass}
+              />
+            </label>
             {singleGrantParsed.invalidEntries.length > 0 && (
               <p className="text-[11px] text-status-failed">
                 Only @aeolus.earth emails can receive access.
               </p>
             )}
+            {!grantExpiresAt && (
+              <p className="text-[11px] text-status-failed">
+                Contractor access needs a valid future expiration date.
+              </p>
+            )}
             <Button
               size="sm"
               onClick={handleSingleGrant}
-              disabled={!canSingleGrant || grantAccess.isPending}
+              disabled={!canSingleGrant || bulkGrantAccess.isPending}
             >
-              Grant access
+              Grant scoped access
             </Button>
           </div>
         </div>
@@ -414,10 +554,11 @@ export function AdminAccessManagement() {
               </h3>
               <p className="mt-1 text-[11px] leading-relaxed text-text-quaternary">
                 Paste Aeolus FTE emails to give contributor access to every manageable
-                program / library. Existing grants are skipped.
+                program / library. Existing active or pending grants are skipped;
+                expired grants are renewed without an expiration.
               </p>
             </div>
-            <Badge variant="tag">contributor only</Badge>
+            <Badge variant="tag">contributor · no expiry</Badge>
           </div>
           <textarea
             value={bulkInput}
@@ -472,7 +613,8 @@ export function AdminAccessManagement() {
             </Button>
             {bulkPreview.grantCount === 0 && bulkPreview.validEmails.length > 0 && (
               <span className="text-[11px] text-text-quaternary">
-                Everyone in this list already has access to all manageable programs.
+                Everyone in this list already has active or pending access to all
+                manageable programs.
               </span>
             )}
           </div>
@@ -486,8 +628,9 @@ export function AdminAccessManagement() {
               User access matrix
             </h3>
             <p className="mt-0.5 text-[11px] text-text-quaternary">
-              Showing users with active or pending program access. Role changes here
-              are explicit; bulk FTE grants never downgrade existing admins.
+              Showing users with active, pending, or expired program access. Role
+              changes here are explicit; bulk FTE grants never downgrade existing
+              admins.
             </p>
           </div>
           <Badge variant="tag">{filteredMatrix.length} shown</Badge>
@@ -533,8 +676,24 @@ export function AdminAccessManagement() {
                     <td className="sticky left-0 z-10 bg-surface px-3 py-2 align-top">
                       <p className="font-medium text-text">{row.email}</p>
                       <p className="mt-1 text-[11px] text-text-quaternary">
-                        {row.activeCount} active, {row.pendingCount} pending
+                        {row.activeCount} active, {row.pendingCount} pending,
+                        {" "}
+                        {row.expiredCount} expired
                       </p>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="mt-2"
+                        onClick={() => handleOffboard(row.email)}
+                        disabled={
+                          grantAccess.isPending ||
+                          revokeAccess.isPending ||
+                          offboardAccess.isPending
+                        }
+                      >
+                        Offboard
+                      </Button>
                     </td>
                     {programs.map((program) => {
                       const cell = row.cells[program.id];
@@ -544,34 +703,67 @@ export function AdminAccessManagement() {
                             <div className="space-y-2">
                               <div className="flex flex-wrap items-center gap-2">
                                 <Badge variant={statusVariant(cell)}>
-                                  {cell.status === "pending"
-                                    ? "pending"
-                                    : roleLabel(cell.role)}
+                                  {cell.status === "expired"
+                                    ? "expired"
+                                    : cell.status === "pending"
+                                      ? "pending"
+                                      : roleLabel(cell.role)}
                                 </Badge>
                                 <span
                                   className="text-[10px] text-text-quaternary"
                                   title={currentCellTitle(cell)}
                                 >
-                                  {cell.status === "pending" ? "not signed in" : "active"}
+                                  {cell.status === "expired"
+                                    ? "needs renewal"
+                                    : cell.status === "pending"
+                                      ? "not signed in"
+                                      : "active"}
                                 </span>
+                                {cell.expiresAt && (
+                                  <span className="text-[10px] text-text-quaternary">
+                                    expires {formatDateTimeShort(cell.expiresAt)}
+                                  </span>
+                                )}
                               </div>
                               <div className="flex flex-wrap items-center gap-1.5">
-                                <select
-                                  value={cell.role}
-                                  onChange={(event) =>
-                                    grantAccess.mutate({
-                                      email: row.email,
-                                      program: program.id,
-                                      role: event.target.value as ProgramAccessRole,
-                                    })
-                                  }
-                                  className={cn(controlClass, "max-w-[118px]")}
-                                  aria-label={`Role for ${row.email} in ${program.name}`}
-                                  disabled={grantAccess.isPending || revokeAccess.isPending}
-                                >
-                                  <option value="contributor">contributor</option>
-                                  <option value="admin">admin</option>
-                                </select>
+                                {cell.status === "expired" ? (
+                                  <Button
+                                    type="button"
+                                    variant="secondary"
+                                    size="sm"
+                                    onClick={() =>
+                                      grantAccess.mutate({
+                                        email: row.email,
+                                        program: program.id,
+                                        role: cell.role,
+                                        expiresAt: futureExpiryIso(
+                                          DEFAULT_CONTRACTOR_GRANT_DAYS,
+                                        ),
+                                      })
+                                    }
+                                    disabled={grantAccess.isPending || revokeAccess.isPending}
+                                  >
+                                    Renew 90d
+                                  </Button>
+                                ) : (
+                                  <select
+                                    value={cell.role}
+                                    onChange={(event) =>
+                                      grantAccess.mutate({
+                                        email: row.email,
+                                        program: program.id,
+                                        role: event.target.value as ProgramAccessRole,
+                                        expiresAt: cell.expiresAt,
+                                      })
+                                    }
+                                    className={cn(controlClass, "max-w-[118px]")}
+                                    aria-label={`Role for ${row.email} in ${program.name}`}
+                                    disabled={grantAccess.isPending || revokeAccess.isPending}
+                                  >
+                                    <option value="contributor">contributor</option>
+                                    <option value="admin">admin</option>
+                                  </select>
+                                )}
                                 <Button
                                   type="button"
                                   variant="ghost"
@@ -593,6 +785,7 @@ export function AdminAccessManagement() {
                                   email: row.email,
                                   program: program.id,
                                   role: "contributor",
+                                  expiresAt: null,
                                 })
                               }
                               disabled={grantAccess.isPending || revokeAccess.isPending}
@@ -618,8 +811,9 @@ export function AdminAccessManagement() {
               Recent access changes
             </h3>
             <p className="mt-0.5 text-[11px] leading-relaxed text-text-quaternary">
-              Audit trail for grants, revokes, and pending grants that became active
-              on first sign-in. Visibility is scoped by the same program-admin RLS.
+              Audit trail for grants, revokes, pending grants that became active on
+              first sign-in, and grant expiration metadata. Visibility is scoped by
+              the same program-admin RLS.
             </p>
           </div>
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -697,6 +891,9 @@ export function AdminAccessManagement() {
                     </p>
                     <p className="mt-0.5 truncate text-[11px] text-text-quaternary">
                       {program?.name ?? event.program} · {eventRoleSummary(event)}
+                      {eventExpirySummary(event)
+                        ? ` · ${eventExpirySummary(event)}`
+                        : ""}
                     </p>
                   </div>
                   <p

--- a/ui/src/components/shared/inline-markdown-text.test.ts
+++ b/ui/src/components/shared/inline-markdown-text.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+import { createElement } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { InlineMarkdownText } from "./inline-markdown-text";
+
+describe("InlineMarkdownText", () => {
+  it("renders compact bold markdown without raw asterisks", () => {
+    render(
+      createElement(InlineMarkdownText, {
+        content: "**H0 (pre-registered).** The policy beats baseline.",
+      }),
+    );
+
+    expect(screen.getByText("H0 (pre-registered).")).toHaveClass("font-semibold");
+    expect(screen.queryByText(/\*\*/)).not.toBeInTheDocument();
+  });
+
+  it("uses the fallback for empty compact text", () => {
+    render(createElement(InlineMarkdownText, { content: "   " }));
+
+    expect(screen.getByText("\u2014")).toBeVisible();
+  });
+});

--- a/ui/src/components/shared/inline-markdown-text.tsx
+++ b/ui/src/components/shared/inline-markdown-text.tsx
@@ -1,0 +1,139 @@
+import { memo, useMemo } from "react";
+import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { Link } from "@tanstack/react-router";
+import { linkifySondeRecordIds } from "@/lib/linkify-sonde-ids";
+import { parseInternalHref } from "@/lib/parse-internal-href";
+import { cn } from "@/lib/utils";
+
+const inlineLinkClass =
+  "text-accent underline decoration-accent/25 underline-offset-2 hover:decoration-accent";
+
+const inlineMarkdownComponents: Components = {
+  p: ({ children }) => <>{children}</>,
+  strong: ({ children }) => (
+    <strong className="font-semibold text-text">{children}</strong>
+  ),
+  em: ({ children }) => <em className="italic">{children}</em>,
+  code: ({ children }) => (
+    <code className="rounded-[3px] bg-surface-raised px-1 py-0.5 font-mono text-[0.95em] text-accent">
+      {children}
+    </code>
+  ),
+  del: ({ children }) => <span className="line-through">{children}</span>,
+  a: ({ href, children }) => {
+    const internal = parseInternalHref(href);
+
+    if (internal?.to === "/questions") {
+      return (
+        <Link
+          to="/questions"
+          hash={internal.hash}
+          className={inlineLinkClass}
+          onClick={(event) => event.stopPropagation()}
+        >
+          {children}
+        </Link>
+      );
+    }
+
+    if (internal?.to === "/experiments/$id") {
+      return (
+        <Link
+          to="/experiments/$id"
+          params={internal.params}
+          hash={internal.hash}
+          className={inlineLinkClass}
+          onClick={(event) => event.stopPropagation()}
+        >
+          {children}
+        </Link>
+      );
+    }
+
+    if (internal?.to === "/findings/$id") {
+      return (
+        <Link
+          to="/findings/$id"
+          params={internal.params}
+          hash={internal.hash}
+          className={inlineLinkClass}
+          onClick={(event) => event.stopPropagation()}
+        >
+          {children}
+        </Link>
+      );
+    }
+
+    if (internal?.to === "/directions/$id") {
+      return (
+        <Link
+          to="/directions/$id"
+          params={internal.params}
+          hash={internal.hash}
+          className={inlineLinkClass}
+          onClick={(event) => event.stopPropagation()}
+        >
+          {children}
+        </Link>
+      );
+    }
+
+    if (internal?.to === "/projects/$id") {
+      return (
+        <Link
+          to="/projects/$id"
+          params={internal.params}
+          hash={internal.hash}
+          className={inlineLinkClass}
+          onClick={(event) => event.stopPropagation()}
+        >
+          {children}
+        </Link>
+      );
+    }
+
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={inlineLinkClass}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {children}
+      </a>
+    );
+  },
+};
+
+export const InlineMarkdownText = memo(function InlineMarkdownText({
+  content,
+  fallback = "\u2014",
+  className,
+  title,
+}: {
+  content: string | null | undefined;
+  fallback?: string;
+  className?: string;
+  title?: string;
+}) {
+  const normalized = useMemo(() => {
+    const text = (content ?? "").replace(/\s+/g, " ").trim();
+    return text ? linkifySondeRecordIds(text) : fallback;
+  }, [content, fallback]);
+
+  return (
+    <span className={cn("min-w-0", className)} title={title ?? content ?? fallback}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={inlineMarkdownComponents}
+        allowedElements={["p", "strong", "em", "code", "del", "a"]}
+        unwrapDisallowed
+      >
+        {normalized}
+      </ReactMarkdown>
+    </span>
+  );
+});

--- a/ui/src/components/visualizations/experiment-graph/node-types/experiment-node.tsx
+++ b/ui/src/components/visualizations/experiment-graph/node-types/experiment-node.tsx
@@ -2,6 +2,7 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { ChevronDown, ChevronRight, GitFork } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
+import { InlineMarkdownText } from "@/components/shared/inline-markdown-text";
 import type { ExperimentSummary } from "@/types/sonde";
 
 import type { StatusColorMap } from "../graph-builder";
@@ -73,9 +74,10 @@ export function ExperimentNode({ data }: NodeProps) {
               </div>
             )}
             {(d.finding || d.hypothesis) && (
-              <p className="mt-1 line-clamp-2 text-[10px] leading-snug text-text-tertiary">
-                {d.finding ?? d.hypothesis}
-              </p>
+              <InlineMarkdownText
+                content={d.finding ?? d.hypothesis}
+                className="mt-1 line-clamp-2 text-[10px] leading-snug text-text-tertiary"
+              />
             )}
             {!d.isExpanded && d.childCount > 0 && (
               <p className="mt-1 text-[9px] text-text-quaternary">

--- a/ui/src/components/visualizations/research-tree.tsx
+++ b/ui/src/components/visualizations/research-tree.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { FindingImportanceBadge } from "@/components/shared/finding-importance-badge";
 import { Badge } from "@/components/ui/badge";
+import { InlineMarkdownText } from "@/components/shared/inline-markdown-text";
 import { Input } from "@/components/ui/input";
 import {
   useStatusChartColors,
@@ -1385,12 +1386,11 @@ export const ResearchTree = memo(function ResearchTree({
             </span>
           )}
           {summary && (
-            <span
+            <InlineMarkdownText
+              content={summary}
               className="min-w-0 flex-1 truncate text-[11px] text-text-tertiary"
               title={summary}
-            >
-              {summary}
-            </span>
+            />
           )}
           {row.findings.length > 0 && (
             <div className="flex shrink-0 flex-wrap items-center gap-1">

--- a/ui/src/hooks/use-admin-access.ts
+++ b/ui/src/hooks/use-admin-access.ts
@@ -37,6 +37,7 @@ interface RawProgramAccessRow {
   status: string;
   granted_at: string | null;
   applied_at: string | null;
+  expires_at: string | null;
 }
 
 interface RawProgramAccessEventRow {
@@ -73,6 +74,7 @@ interface GrantProgramAccessInput {
   email: string;
   program: string;
   role: ProgramAccessRole;
+  expiresAt?: string | null;
 }
 
 interface RevokeProgramAccessInput {
@@ -85,6 +87,23 @@ interface BulkGrantProgramAccessInput {
   programs: Program[];
   matrix: ProgramAccessUserRow[];
   role: ProgramAccessRole;
+  expiresAt?: string | null;
+}
+
+interface OffboardProgramAccessInput {
+  email: string;
+}
+
+export interface OffboardProgramAccessResult {
+  email: string;
+  revoked_count: number;
+  skipped_count: number;
+  revoked_programs: Array<{
+    program: string;
+    revoked_active: boolean;
+    revoked_grant: boolean;
+  }>;
+  skipped_programs: Array<{ program: string; reason: string }>;
 }
 
 export interface BulkGrantProgramAccessResult {
@@ -101,9 +120,15 @@ function normalizeAccessRow(row: RawProgramAccessRow): ProgramAccessRow {
     user_id: row.user_id,
     program: row.program,
     role: normalizeProgramAccessRole(row.role),
-    status: row.status === "pending" ? "pending" : "active",
+    status:
+      row.status === "pending"
+        ? "pending"
+        : row.status === "expired"
+          ? "expired"
+          : "active",
     granted_at: row.granted_at,
     applied_at: row.applied_at,
+    expires_at: row.expires_at,
   };
 }
 
@@ -136,11 +161,13 @@ async function grantProgramAccess({
   email,
   program,
   role,
+  expiresAt,
 }: GrantProgramAccessInput): Promise<unknown> {
   const { data, error } = await supabase.rpc("grant_program_access", {
     p_email: email,
     p_program: program,
     p_role: role,
+    p_expires_at: expiresAt ?? null,
   });
 
   if (error) {
@@ -164,6 +191,20 @@ async function revokeProgramAccess({
   }
 
   return data;
+}
+
+async function offboardProgramAccess({
+  email,
+}: OffboardProgramAccessInput): Promise<OffboardProgramAccessResult> {
+  const { data, error } = await supabase.rpc("revoke_user_program_access", {
+    p_email: email,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  return data as OffboardProgramAccessResult;
 }
 
 function errorMessage(error: unknown): string {
@@ -289,6 +330,42 @@ export function useRevokeProgramAccess() {
   });
 }
 
+export function useOffboardProgramAccess() {
+  const queryClient = useQueryClient();
+  const addToast = useAddToast();
+
+  return useMutation({
+    mutationFn: offboardProgramAccess,
+    onSuccess: async (result) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: adminAccessKeys.rows }),
+        queryClient.invalidateQueries({ queryKey: adminAccessKeys.programs }),
+        queryClient.invalidateQueries({ queryKey: adminAccessKeys.eventsBase }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.programs.all() }),
+      ]);
+      addToast({
+        title:
+          result.skipped_count > 0
+            ? "User partially offboarded"
+            : "User access revoked",
+        description:
+          result.skipped_count > 0
+            ? `${result.revoked_count} program grant(s) revoked; ${result.skipped_count} skipped for safety.`
+            : `${result.revoked_count} program grant(s) revoked for ${result.email}.`,
+        variant: result.skipped_count > 0 ? "error" : "success",
+        duration: result.skipped_count > 0 ? 8000 : undefined,
+      });
+    },
+    onError: (error: Error) => {
+      addToast({
+        title: "Failed to offboard user",
+        description: error.message,
+        variant: "error",
+      });
+    },
+  });
+}
+
 export function useBulkGrantProgramAccess() {
   const queryClient = useQueryClient();
   const addToast = useAddToast();
@@ -299,6 +376,7 @@ export function useBulkGrantProgramAccess() {
       programs,
       matrix,
       role,
+      expiresAt,
     }: BulkGrantProgramAccessInput): Promise<BulkGrantProgramAccessResult> => {
       const rowsByEmail = new Map(matrix.map((row) => [row.email, row]));
       const tasks: Array<Promise<void>> = [];
@@ -308,7 +386,8 @@ export function useBulkGrantProgramAccess() {
       for (const email of emails) {
         const row = rowsByEmail.get(email);
         for (const program of programs) {
-          if (row?.cells[program.id]) {
+          const currentCell = row?.cells[program.id];
+          if (currentCell && currentCell.status !== "expired") {
             skipped += 1;
             continue;
           }
@@ -319,6 +398,7 @@ export function useBulkGrantProgramAccess() {
               email,
               program: program.id,
               role,
+              expiresAt,
             }).then(() => undefined),
           );
         }

--- a/ui/src/lib/admin-access-matrix.test.ts
+++ b/ui/src/lib/admin-access-matrix.test.ts
@@ -45,6 +45,7 @@ describe("buildProgramAccessMatrix", () => {
         status: "active",
         granted_at: "2026-04-01T00:00:00Z",
         applied_at: "2026-04-01T00:01:00Z",
+        expires_at: null,
       },
       {
         email: "alice@aeolus.earth",
@@ -54,6 +55,7 @@ describe("buildProgramAccessMatrix", () => {
         status: "pending",
         granted_at: "2026-04-02T00:00:00Z",
         applied_at: null,
+        expires_at: "2026-07-01T00:00:00Z",
       },
     ];
 
@@ -63,6 +65,7 @@ describe("buildProgramAccessMatrix", () => {
     expect(matrix[0]?.email).toBe("alice@aeolus.earth");
     expect(matrix[0]?.activeCount).toBe(1);
     expect(matrix[0]?.pendingCount).toBe(1);
+    expect(matrix[0]?.expiredCount).toBe(0);
     expect(matrix[0]?.adminCount).toBe(1);
     expect(matrix[0]?.contributorCount).toBe(1);
     expect(matrix[0]?.cells.alpha?.role).toBe("admin");
@@ -81,6 +84,7 @@ describe("buildBulkGrantPreview", () => {
         status: "active",
         granted_at: "2026-04-01T00:00:00Z",
         applied_at: "2026-04-01T00:01:00Z",
+        expires_at: null,
       },
     ]);
 
@@ -97,5 +101,30 @@ describe("buildBulkGrantPreview", () => {
     expect(preview.programCount).toBe(2);
     expect(preview.alreadyGrantedCount).toBe(1);
     expect(preview.grantCount).toBe(3);
+  });
+
+  it("treats expired grants as grantable for FTE renewal", () => {
+    const matrix = buildProgramAccessMatrix(programs, [
+      {
+        email: "alice@aeolus.earth",
+        user_id: "user-1",
+        program: "alpha",
+        role: "contributor",
+        status: "expired",
+        granted_at: "2026-01-01T00:00:00Z",
+        applied_at: "2026-01-01T00:01:00Z",
+        expires_at: "2026-02-01T00:00:00Z",
+      },
+    ]);
+
+    const preview = buildBulkGrantPreview({
+      input: "alice@aeolus.earth",
+      programs,
+      matrix,
+    });
+
+    expect(matrix[0]?.expiredCount).toBe(1);
+    expect(preview.alreadyGrantedCount).toBe(0);
+    expect(preview.grantCount).toBe(2);
   });
 });

--- a/ui/src/lib/admin-access-matrix.ts
+++ b/ui/src/lib/admin-access-matrix.ts
@@ -1,7 +1,7 @@
 import type { Program } from "@/types/sonde";
 
 export type ProgramAccessRole = "contributor" | "admin";
-export type ProgramAccessStatus = "active" | "pending";
+export type ProgramAccessStatus = "active" | "pending" | "expired";
 
 export interface ProgramAccessRow {
   email: string;
@@ -11,6 +11,7 @@ export interface ProgramAccessRow {
   status: ProgramAccessStatus;
   granted_at: string | null;
   applied_at: string | null;
+  expires_at: string | null;
 }
 
 export interface ProgramAccessCell {
@@ -20,6 +21,7 @@ export interface ProgramAccessCell {
   status: ProgramAccessStatus;
   grantedAt: string | null;
   appliedAt: string | null;
+  expiresAt: string | null;
 }
 
 export interface ProgramAccessUserRow {
@@ -28,6 +30,7 @@ export interface ProgramAccessUserRow {
   cells: Record<string, ProgramAccessCell | undefined>;
   activeCount: number;
   pendingCount: number;
+  expiredCount: number;
   adminCount: number;
   contributorCount: number;
 }
@@ -55,9 +58,14 @@ export function normalizeProgramAccessRole(role: string): ProgramAccessRole {
 }
 
 function cellRank(cell: ProgramAccessCell): number {
-  const statusScore = cell.status === "active" ? 2 : 0;
+  const statusScore =
+    cell.status === "active" ? 3 : cell.status === "pending" ? 2 : 0;
   const roleScore = cell.role === "admin" ? 1 : 0;
   return statusScore + roleScore;
+}
+
+function isCoveredGrant(cell: ProgramAccessCell | undefined): boolean {
+  return Boolean(cell && cell.status !== "expired");
 }
 
 export function parseAeolusEmailList(input: string): ParsedEmailList {
@@ -114,6 +122,7 @@ export function buildProgramAccessMatrix(
         cells: {},
         activeCount: 0,
         pendingCount: 0,
+        expiredCount: 0,
         adminCount: 0,
         contributorCount: 0,
       };
@@ -129,6 +138,7 @@ export function buildProgramAccessMatrix(
       status: row.status,
       grantedAt: row.granted_at,
       appliedAt: row.applied_at,
+      expiresAt: row.expires_at,
     };
     const currentCell = existingUser.cells[row.program];
     if (!currentCell || cellRank(nextCell) >= cellRank(currentCell)) {
@@ -142,6 +152,7 @@ export function buildProgramAccessMatrix(
     .map((user) => {
       let activeCount = 0;
       let pendingCount = 0;
+      let expiredCount = 0;
       let adminCount = 0;
       let contributorCount = 0;
 
@@ -151,8 +162,10 @@ export function buildProgramAccessMatrix(
         }
         if (cell.status === "active") {
           activeCount += 1;
-        } else {
+        } else if (cell.status === "pending") {
           pendingCount += 1;
+        } else {
+          expiredCount += 1;
         }
         if (cell.role === "admin") {
           adminCount += 1;
@@ -165,6 +178,7 @@ export function buildProgramAccessMatrix(
         ...user,
         activeCount,
         pendingCount,
+        expiredCount,
         adminCount,
         contributorCount,
       };
@@ -189,7 +203,7 @@ export function buildBulkGrantPreview({
   for (const email of parsed.validEmails) {
     const row = rowsByEmail.get(email);
     for (const program of programs) {
-      if (row?.cells[program.id]) {
+      if (isCoveredGrant(row?.cells[program.id])) {
         alreadyGrantedCount += 1;
       } else {
         grantCount += 1;

--- a/ui/src/routes/pages/brief.tsx
+++ b/ui/src/routes/pages/brief.tsx
@@ -12,6 +12,7 @@ import { FindingImportanceBadge } from "@/components/shared/finding-importance-b
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RecordLink } from "@/components/shared/record-link";
+import { InlineMarkdownText } from "@/components/shared/inline-markdown-text";
 import { Section } from "@/components/shared/detail-layout";
 import { MarkdownView } from "@/components/ui/markdown-view";
 import { sortFindingsByImportanceAndRecency } from "@/lib/finding-importance";
@@ -312,9 +313,10 @@ export default function BriefPage() {
                 <Badge variant={active.status}>{active.status}</Badge>
               </div>
               {(active.finding || active.hypothesis) && (
-                <p className="mt-1.5 text-[13px] leading-relaxed text-text">
-                  {active.finding ?? active.hypothesis}
-                </p>
+                <InlineMarkdownText
+                  content={active.finding ?? active.hypothesis}
+                  className="mt-1.5 block text-[13px] leading-relaxed text-text"
+                />
               )}
               {active.project_id && (
                 <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-text-tertiary">
@@ -426,9 +428,10 @@ export default function BriefPage() {
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
                         <RecordLink recordId={e.id} />
-                        <span className="line-clamp-2 text-[12px] text-text-tertiary">
-                          {e.finding ?? e.hypothesis ?? "—"}
-                        </span>
+                        <InlineMarkdownText
+                          content={e.finding ?? e.hypothesis}
+                          className="line-clamp-2 text-[12px] text-text-tertiary"
+                        />
                       </div>
                       <BriefExperimentLinks
                         projectId={e.project_id}
@@ -456,9 +459,10 @@ export default function BriefPage() {
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
                         <RecordLink recordId={e.id} />
-                        <span className="line-clamp-2 text-[12px] text-text-tertiary">
-                          {e.hypothesis ?? "—"}
-                        </span>
+                        <InlineMarkdownText
+                          content={e.hypothesis}
+                          className="line-clamp-2 text-[12px] text-text-tertiary"
+                        />
                       </div>
                       <BriefExperimentLinks
                         projectId={e.project_id}

--- a/ui/src/routes/pages/direction-detail.tsx
+++ b/ui/src/routes/pages/direction-detail.tsx
@@ -19,6 +19,7 @@ import {
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Section, DetailRow } from "@/components/shared/detail-layout";
 import { RecordUnavailable } from "@/components/shared/record-unavailable";
+import { InlineMarkdownText } from "@/components/shared/inline-markdown-text";
 import { directionDetailShareUrl } from "@/lib/app-origin";
 import { formatDateTime, formatDateTimeShort } from "@/lib/utils";
 import { ArrowLeft, Copy, GitFork } from "lucide-react";
@@ -314,9 +315,10 @@ export default function DirectionDetailPage() {
                       {exp.id}
                     </span>
                     <Badge variant={exp.status}>{exp.status}</Badge>
-                    <span className="min-w-0 flex-1 truncate text-[12px] text-text-tertiary">
-                      {exp.finding ?? exp.hypothesis ?? "—"}
-                    </span>
+                    <InlineMarkdownText
+                      content={exp.finding ?? exp.hypothesis}
+                      className="min-w-0 flex-1 truncate text-[12px] text-text-tertiary"
+                    />
                     <span
                       className="shrink-0 text-[11px] text-text-quaternary"
                       title={formatDateTime(exp.created_at)}

--- a/ui/src/routes/pages/experiments-list.tsx
+++ b/ui/src/routes/pages/experiments-list.tsx
@@ -20,6 +20,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { ExperimentRowSkeleton } from "@/components/ui/skeleton";
 import { TimeRangeBar } from "@/components/shared/time-range-bar";
+import { InlineMarkdownText } from "@/components/shared/inline-markdown-text";
 import { formatDateTimeShort, formatDateTime, cn } from "@/lib/utils";
 import {
   buildExperimentsProjectTree,
@@ -104,12 +105,14 @@ const ExperimentRow = memo(function ExperimentRow({
       <span className="flex items-center">
         <Badge variant={exp.status}>{exp.status}</Badge>
       </span>
-      <span className="truncate text-[13px] text-text-secondary">
-        {exp.hypothesis ?? "\u2014"}
-      </span>
-      <span className="truncate text-[13px] text-text-secondary">
-        {exp.finding ?? "\u2014"}
-      </span>
+      <InlineMarkdownText
+        content={exp.hypothesis}
+        className="truncate text-[13px] text-text-secondary"
+      />
+      <InlineMarkdownText
+        content={exp.finding}
+        className="truncate text-[13px] text-text-secondary"
+      />
       <span className="truncate text-[12px] text-text-tertiary">
         {exp.source}
       </span>

--- a/ui/src/routes/pages/finding-detail.tsx
+++ b/ui/src/routes/pages/finding-detail.tsx
@@ -21,6 +21,7 @@ import { MarkdownView } from "@/components/ui/markdown-view";
 import { Section, DetailRow } from "@/components/shared/detail-layout";
 import { RecordUnavailable } from "@/components/shared/record-unavailable";
 import { RecordLink } from "@/components/shared/record-link";
+import { InlineMarkdownText } from "@/components/shared/inline-markdown-text";
 import {
   FINDING_CONFIDENCE_LEVELS,
   findingConfidenceLabel,
@@ -455,9 +456,11 @@ function EvidenceExperimentRow({
           <RecordLink recordId={experiment.id} />
           <Badge variant={experiment.status}>{experiment.status}</Badge>
         </div>
-        <p className="mt-1 line-clamp-2 text-[12px] text-text-tertiary">
-          {experiment.finding ?? experiment.hypothesis ?? "No finding recorded"}
-        </p>
+        <InlineMarkdownText
+          content={experiment.finding ?? experiment.hypothesis}
+          fallback="No finding recorded"
+          className="mt-1 line-clamp-2 text-[12px] text-text-tertiary"
+        />
       </div>
       <div className="flex shrink-0 flex-col items-end gap-1 text-right">
         {project ? (

--- a/ui/src/routes/pages/project-detail.tsx
+++ b/ui/src/routes/pages/project-detail.tsx
@@ -24,6 +24,7 @@ import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Section, DetailRow } from "@/components/shared/detail-layout";
 import { RecordUnavailable } from "@/components/shared/record-unavailable";
 import { RecordLink } from "@/components/shared/record-link";
+import { InlineMarkdownText } from "@/components/shared/inline-markdown-text";
 import { ArtifactGallery } from "@/components/artifacts/artifact-gallery";
 import { EmbeddedDocumentPreview } from "@/components/artifacts/embedded-document-preview";
 import { formatDateTime, formatDateTimeShort } from "@/lib/utils";
@@ -610,9 +611,10 @@ function ProjectExperimentRow({
         {experiment.id}
       </span>
       <Badge variant={experiment.status}>{experiment.status}</Badge>
-      <span className="min-w-0 flex-1 truncate text-[12px] text-text-tertiary">
-        {experiment.finding ?? experiment.hypothesis ?? "—"}
-      </span>
+      <InlineMarkdownText
+        content={experiment.finding ?? experiment.hypothesis}
+        className="min-w-0 flex-1 truncate text-[12px] text-text-tertiary"
+      />
       <span
         className="text-[11px] text-text-quaternary"
         title={formatDateTime(experiment.created_at)}


### PR DESCRIPTION
## Summary

This PR finishes the access-operations polish pass for scoped program/library RBAC and experiment-card markdown rendering.

- Adds expiring program access grants in Supabase, including expiry-aware `user_programs()`, `admin_programs()`, the custom access-token hook, access dashboard RPCs, and pending-grant application.
- Adds bulk offboarding through `revoke_user_program_access`, with the last shared-admin safety rule preserved.
- Extends the admin CLI with contractor-style expiring grants, explicit no-expiry FTE grants, expiry display in access tables, and `sonde admin offboard-user`.
- Upgrades the admin dashboard so admins can see active/pending/expired user access, grant scoped contractor access across one or more libraries, bulk grant FTE access with no expiry, renew expired grants, and offboard users from manageable libraries.
- Adds safe inline markdown rendering for compact experiment-card text so values such as `**H0**` render as emphasis instead of leaking raw asterisks.

## Why

The current contractor/FTE permission flow needed to be operationally crisp: contractors should be easy to grant scoped, expiring access; Aeolus FTEs should be easy to grant broad durable access; and admins should be able to see and clean up user access from the UI without dropping into SQL. The compact experiment cards also displayed agent-authored markdown literally, which made cards look broken when agents used `**bold**`.

## Validation

- `bash scripts/ci/core.sh all`
- `bash scripts/ci/data.sh`
- `npm test -- src/components/admin/access-management.test.ts`
- `git diff --check`

Notes: the UI build still emits the pre-existing Vite warning about `ui/src/lib/supabase.ts` being both statically and dynamically imported. It does not fail the build. `scripts/ci/data.sh` applied all 82 migrations, reported schema version 8, matched 82/82 migration files applied, and passed the RLS security regression harness. The artifact-sync integration test remains skipped by its existing guard.