### PR TITLE
Polish experiment review card contrast

### DIFF
--- a/docs/ops/production-backup-recovery.md
+++ b/docs/ops/production-backup-recovery.md
@@ -1,0 +1,169 @@
+# Production Backup And Recovery
+
+This runbook explains how Sonde production backups work, how to verify that a
+backup exists, and how to perform a safe restore into a fresh recovery project.
+
+Use this during an incident. The safest default is always: restore into a new
+Supabase project first, verify the data, and only then decide whether to copy
+records back or repoint production services.
+
+## What Runs Automatically
+
+Production backups are created by the GitHub Actions workflow named
+`Production Backup Archive`.
+
+- Workflow file: `.github/workflows/production-backup.yml`
+- Schedule: daily at `09:31 UTC`
+- Default retention: 14 daily snapshots
+- Source: production Supabase project
+- Destination: separate backup Supabase project
+- Backup bucket: `sonde-production-backups`
+- Backup prefix: `production/<snapshot-id>/`
+- Latest pointer: `production/latest.json`
+- Encryption: `age`
+- Decrypt identity: stored in 1Password as `Sonde Production Backup Recovery`
+
+Each successful snapshot contains:
+
+- Supabase roles dump: `database/roles.sql`
+- Supabase schema dump: `database/schema.sql`
+- Supabase data dump: `database/data.sql`
+- Storage objects from the production `artifacts` bucket
+- `manifest.json`
+- `RECOVERY.md`
+- Encrypted archive parts uploaded to the backup bucket
+
+## Manual Backup
+
+Use a manual backup before risky maintenance or after changing backup behavior.
+
+1. Open GitHub Actions.
+2. Select `Production Backup Archive`.
+3. Choose `Run workflow`.
+4. Select branch `main`.
+5. Keep the default inputs unless there is a specific reason to change them.
+
+The default inputs are:
+
+- `retention_days`: `14`
+- `part_size_bytes`: `104857600`
+
+A successful run uploads a sanitized GitHub artifact named
+`production-backup-summary`. It also writes a new snapshot to the backup
+Supabase project.
+
+## Verify A Backup Exists
+
+A backup is usable only after the workflow succeeds.
+
+Check GitHub first:
+
+1. Open the latest `Production Backup Archive` run.
+2. Confirm the run status is success.
+3. Open the `production-backup-summary` artifact.
+4. Confirm it reports a backup prefix, artifact count, database dump sizes, and
+   encrypted archive parts.
+
+Check Supabase next:
+
+1. Open the backup Supabase project.
+2. Open Storage.
+3. Open bucket `sonde-production-backups`.
+4. Confirm `production/latest.json` exists.
+5. Open the snapshot prefix from `latest.json`.
+6. Confirm `manifest.json` and encrypted archive part files exist.
+
+If the workflow fails before a restorable snapshot is produced, it should upload
+a sanitized `failure.md` artifact explaining the failing phase.
+
+## Safe Restore Path
+
+Do not restore directly over production during normal recovery. Create a fresh
+Supabase project and restore there first.
+
+1. Create a new Supabase recovery project.
+2. Configure it like production enough for validation.
+3. Create or confirm the target `artifacts` storage bucket.
+4. Get the `age` private decrypt identity from 1Password:
+   `Sonde Production Backup Recovery`.
+5. Get the backup project service role key from GitHub or the Supabase backup
+   project.
+6. Get the target recovery project service role key.
+7. Get the target recovery database connection URL.
+8. Run a dry-run restore first.
+9. Inspect `production-backup-restore/restore-summary.json`.
+10. Only then run an apply restore into the recovery project.
+
+Dry-run restore:
+
+```bash
+SONDE_RESTORE_TARGET_PROJECT_REF="<fresh-recovery-project-ref>" \
+SONDE_RESTORE_TARGET_SUPABASE_URL="https://<fresh-recovery-project-ref>.supabase.co" \
+SONDE_RESTORE_TARGET_SERVICE_ROLE_KEY="<fresh-recovery-service-role-key>" \
+SONDE_RESTORE_TARGET_DB_URL="<fresh-recovery-postgres-url>" \
+SUPABASE_BACKUP_PROJECT_REF="<backup-project-ref>" \
+SUPABASE_BACKUP_SERVICE_ROLE_KEY="<backup-service-role-key>" \
+SUPABASE_BACKUP_BUCKET="sonde-production-backups" \
+SONDE_BACKUP_AGE_IDENTITY_FILE="<path-to-age-identity-file>" \
+node server/scripts/supabase-production-backup.mjs restore
+```
+
+Apply restore into the fresh recovery project:
+
+```bash
+SONDE_RESTORE_APPLY=1 \
+SONDE_RESTORE_TARGET_PROJECT_REF="<fresh-recovery-project-ref>" \
+SONDE_RESTORE_TARGET_SUPABASE_URL="https://<fresh-recovery-project-ref>.supabase.co" \
+SONDE_RESTORE_TARGET_SERVICE_ROLE_KEY="<fresh-recovery-service-role-key>" \
+SONDE_RESTORE_TARGET_DB_URL="<fresh-recovery-postgres-url>" \
+SUPABASE_BACKUP_PROJECT_REF="<backup-project-ref>" \
+SUPABASE_BACKUP_SERVICE_ROLE_KEY="<backup-service-role-key>" \
+SUPABASE_BACKUP_BUCKET="sonde-production-backups" \
+SONDE_BACKUP_AGE_IDENTITY_FILE="<path-to-age-identity-file>" \
+node server/scripts/supabase-production-backup.mjs restore
+```
+
+The restore command refuses to restore over the source production project unless
+`SONDE_RESTORE_ALLOW_SOURCE_OVERWRITE=1` is also set. Treat that override as an
+explicit emergency-only action requiring human review.
+
+## Validate Restored Data
+
+After restoring into the recovery project:
+
+1. Confirm the command reports `Database restore: applied`.
+2. Confirm the command reports storage objects were applied.
+3. Compare important table counts against the source backup manifest.
+4. Spot-check high-value projects, experiments, findings, notes, and artifacts.
+5. Open several artifact files from the recovered `artifacts` bucket.
+6. Only after validation, decide whether to copy data back into production,
+   export selected rows, or repoint an app to the recovery project.
+
+## Schema Changes
+
+Backups do not apply migrations. They capture the live production schema, data,
+and artifacts at the time the backup runs.
+
+Schema deployment is handled by separate workflows:
+
+- Staging: `Sync Staging Infra`
+- Production: `Sync Production Infra`
+
+If a code change needs database changes, add a migration under
+`supabase/migrations/`. The infra workflows apply migrations when `supabase/**`
+changes land on `staging` and then `main`.
+
+Avoid making manual production schema changes in the Supabase dashboard. A
+manual change will be captured by backups, but it will not be represented in
+git, so future migrations and recovery work become harder to reason about.
+
+## Emergency Rules
+
+- Do not delete production data while trying to recover production data.
+- Do not restore directly over production unless there is an explicit emergency
+  approval.
+- Do not paste decrypt identities, service role keys, or database passwords into
+  issue comments, PR comments, Slack, or chat.
+- Use a fresh recovery project first.
+- Keep the 1Password item `Sonde Production Backup Recovery` current.
+- If a workflow fails, read the uploaded failure artifact before rerunning.

--- a/server/scripts/supabase-production-backup.mjs
+++ b/server/scripts/supabase-production-backup.mjs
@@ -27,6 +27,8 @@ const DEFAULT_RETENTION_DAYS = 14;
 const DEFAULT_PART_SIZE_BYTES = 100 * 1024 * 1024;
 const DEFAULT_OUTPUT_DIR = "production-backup-summary";
 const DEFAULT_BACKUP_BUCKET = "sonde-production-backups";
+const DEFAULT_STORAGE_RETRY_ATTEMPTS = 5;
+const DEFAULT_STORAGE_RETRY_DELAY_MS = 1500;
 const ARTIFACT_BUCKET = "artifacts";
 const BACKUP_FORMAT_VERSION = 1;
 
@@ -43,6 +45,10 @@ function parseBooleanFlag(value, fallback = false) {
 function parsePositiveInt(value, fallback) {
   const parsed = Number.parseInt(trim(value), 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function requireEnv(env, name) {
@@ -187,6 +193,14 @@ function readBackupConfig(env = process.env) {
       env.SONDE_BACKUP_PART_SIZE_BYTES,
       DEFAULT_PART_SIZE_BYTES,
     ),
+    storageRetryAttempts: parsePositiveInt(
+      env.SONDE_BACKUP_STORAGE_RETRY_ATTEMPTS,
+      DEFAULT_STORAGE_RETRY_ATTEMPTS,
+    ),
+    storageRetryDelayMs: parsePositiveInt(
+      env.SONDE_BACKUP_STORAGE_RETRY_DELAY_MS,
+      DEFAULT_STORAGE_RETRY_DELAY_MS,
+    ),
     outputDir: trim(env.SONDE_BACKUP_OUTPUT_DIR) || DEFAULT_OUTPUT_DIR,
     skipLink: parseBooleanFlag(env.SONDE_BACKUP_SKIP_LINK),
     keepTemp: parseBooleanFlag(env.SONDE_BACKUP_KEEP_TEMP),
@@ -212,11 +226,81 @@ function readRestoreConfig(env = process.env) {
       supabaseUrlFromProjectRef(requireEnv(env, "SONDE_RESTORE_TARGET_PROJECT_REF")),
     targetServiceRoleKey: requireEnv(env, "SONDE_RESTORE_TARGET_SERVICE_ROLE_KEY"),
     targetDatabaseUrl: requireEnv(env, "SONDE_RESTORE_TARGET_DB_URL"),
+    storageRetryAttempts: parsePositiveInt(
+      env.SONDE_BACKUP_STORAGE_RETRY_ATTEMPTS,
+      DEFAULT_STORAGE_RETRY_ATTEMPTS,
+    ),
+    storageRetryDelayMs: parsePositiveInt(
+      env.SONDE_BACKUP_STORAGE_RETRY_DELAY_MS,
+      DEFAULT_STORAGE_RETRY_DELAY_MS,
+    ),
     allowSourceOverwrite: parseBooleanFlag(env.SONDE_RESTORE_ALLOW_SOURCE_OVERWRITE),
     apply: parseBooleanFlag(env.SONDE_RESTORE_APPLY),
     outputDir: trim(env.SONDE_RESTORE_OUTPUT_DIR) || "production-backup-restore",
     keepTemp: parseBooleanFlag(env.SONDE_BACKUP_KEEP_TEMP),
   };
+}
+
+function storageErrorMessage(error) {
+  if (!error) return "";
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return String(error.message ?? error.error ?? error.statusCode ?? error.status ?? error);
+}
+
+export function isRetryableStorageError(error) {
+  const status = Number(error?.statusCode ?? error?.status ?? 0);
+  if ([408, 425, 429, 500, 502, 503, 504].includes(status)) return true;
+  const message = storageErrorMessage(error).toLowerCase();
+  return [
+    "timeout",
+    "timed out",
+    "gateway",
+    "temporarily",
+    "rate limit",
+    "too many requests",
+    "econnreset",
+    "etimedout",
+    "fetch failed",
+    "network",
+  ].some((fragment) => message.includes(fragment));
+}
+
+export async function withStorageRetry(operation, description, options = {}) {
+  const attempts = Math.max(1, options.attempts ?? DEFAULT_STORAGE_RETRY_ATTEMPTS);
+  const delayMs = Math.max(0, options.delayMs ?? DEFAULT_STORAGE_RETRY_DELAY_MS);
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (attempt >= attempts || !isRetryableStorageError(error)) {
+        throw error;
+      }
+
+      const waitMs = delayMs * 2 ** (attempt - 1);
+      console.warn(
+        `${description} failed transiently (${attempt}/${attempts}): ${storageErrorMessage(error)}. Retrying in ${waitMs}ms.`,
+      );
+      if (waitMs > 0) {
+        await sleep(waitMs);
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+async function storageRequest(request, description, options) {
+  return withStorageRetry(async () => {
+    const { data, error } = await request();
+    if (error) {
+      throw error;
+    }
+    return data;
+  }, description, options);
 }
 
 function ensureLinkedProject(config) {
@@ -265,20 +349,22 @@ function dumpProductionDatabase(config, bundleDir) {
   return { rolesPath, schemaPath, dataPath };
 }
 
-async function listStorageObjects(client, bucketName) {
+async function listStorageObjects(client, bucketName, retryOptions) {
   const objects = [];
 
   async function visit(prefix = "") {
     let offset = 0;
     while (true) {
-      const { data, error } = await client.storage.from(bucketName).list(prefix, {
-        limit: 1000,
-        offset,
-        sortBy: { column: "name", order: "asc" },
-      });
-      if (error) {
-        throw new Error(`Could not list ${bucketName}/${prefix}: ${error.message}`);
-      }
+      const data = await storageRequest(
+        () =>
+          client.storage.from(bucketName).list(prefix, {
+            limit: 1000,
+            offset,
+            sortBy: { column: "name", order: "asc" },
+          }),
+        `List ${bucketName}/${prefix || "(root)"}`,
+        retryOptions,
+      );
       if (!Array.isArray(data) || data.length === 0) {
         return;
       }
@@ -311,13 +397,18 @@ async function downloadArtifactBucket(config, bundleDir) {
   });
   const storageRoot = path.join(bundleDir, "storage", ARTIFACT_BUCKET);
   mkdirSync(storageRoot, { recursive: true });
-  const objects = await listStorageObjects(client, ARTIFACT_BUCKET);
+  const retryOptions = {
+    attempts: config.storageRetryAttempts,
+    delayMs: config.storageRetryDelayMs,
+  };
+  const objects = await listStorageObjects(client, ARTIFACT_BUCKET, retryOptions);
 
   for (const object of objects) {
-    const { data, error } = await client.storage.from(ARTIFACT_BUCKET).download(object.path);
-    if (error) {
-      throw new Error(`Could not download artifact ${object.path}: ${error.message}`);
-    }
+    const data = await storageRequest(
+      () => client.storage.from(ARTIFACT_BUCKET).download(object.path),
+      `Download artifact ${object.path}`,
+      retryOptions,
+    );
     const destination = path.join(storageRoot, object.path);
     mkdirSync(path.dirname(destination), { recursive: true });
     writeFileSync(destination, Buffer.from(await data.arrayBuffer()));
@@ -450,24 +541,26 @@ export function splitFile(filePath, partsDir, snapshotId, partSizeBytes) {
 }
 
 async function uploadFile(client, bucketName, objectPath, localPath, contentType) {
-  const { error } = await client.storage.from(bucketName).upload(objectPath, createReadStream(localPath), {
-    contentType,
-    upsert: false,
-    duplex: "half",
-  });
-  if (error) {
-    throw new Error(`Could not upload ${objectPath}: ${error.message}`);
-  }
+  await storageRequest(
+    () =>
+      client.storage.from(bucketName).upload(objectPath, createReadStream(localPath), {
+        contentType,
+        upsert: false,
+        duplex: "half",
+      }),
+    `Upload ${objectPath}`,
+  );
 }
 
 async function uploadText(client, bucketName, objectPath, text, contentType, upsert = false) {
-  const { error } = await client.storage.from(bucketName).upload(objectPath, text, {
-    contentType,
-    upsert,
-  });
-  if (error) {
-    throw new Error(`Could not upload ${objectPath}: ${error.message}`);
-  }
+  await storageRequest(
+    () =>
+      client.storage.from(bucketName).upload(objectPath, text, {
+        contentType,
+        upsert,
+      }),
+    `Upload ${objectPath}`,
+  );
 }
 
 async function uploadBackupArchive(config, manifest, partFiles, outputDir) {
@@ -517,22 +610,28 @@ async function uploadBackupArchive(config, manifest, partFiles, outputDir) {
 }
 
 async function listBackupSnapshots(client, bucketName, environmentName) {
-  const { data, error } = await client.storage.from(bucketName).list(environmentName, {
-    limit: 1000,
-    sortBy: { column: "name", order: "asc" },
-  });
-  if (error) {
-    throw new Error(`Could not list backup snapshots: ${error.message}`);
-  }
+  const data = await storageRequest(
+    () =>
+      client.storage.from(bucketName).list(environmentName, {
+        limit: 1000,
+        sortBy: { column: "name", order: "asc" },
+      }),
+    "List backup snapshots",
+  );
 
   const snapshots = [];
   for (const item of data ?? []) {
     if (item.name === "latest.json" || item.metadata !== null) continue;
     const manifestPath = `${environmentName}/${item.name}/manifest.json`;
-    const { data: manifestBlob, error: manifestError } = await client.storage
-      .from(bucketName)
-      .download(manifestPath);
-    if (manifestError) continue;
+    let manifestBlob = null;
+    try {
+      manifestBlob = await storageRequest(
+        () => client.storage.from(bucketName).download(manifestPath),
+        `Download backup manifest ${manifestPath}`,
+      );
+    } catch {
+      continue;
+    }
     const manifest = JSON.parse(await manifestBlob.text());
     snapshots.push({
       snapshotId: item.name,
@@ -556,26 +655,50 @@ async function pruneExpiredSnapshots(config) {
 
   for (const snapshotId of pruneIds) {
     const prefix = `${config.environmentName}/${snapshotId}`;
-    const { data, error } = await client.storage.from(config.backupBucket).list(prefix, {
-      limit: 1000,
-      sortBy: { column: "name", order: "asc" },
-    });
-    if (error) {
-      throw new Error(`Could not list expired backup ${prefix}: ${error.message}`);
-    }
+    const data = await storageRequest(
+      () =>
+        client.storage.from(config.backupBucket).list(prefix, {
+          limit: 1000,
+          sortBy: { column: "name", order: "asc" },
+        }),
+      `List expired backup ${prefix}`,
+    );
     const paths = (data ?? [])
       .filter((item) => item.metadata !== null)
       .map((item) => `${prefix}/${item.name}`);
     if (paths.length > 0) {
-      const { error: removeError } = await client.storage.from(config.backupBucket).remove(paths);
-      if (removeError) {
-        throw new Error(`Could not prune expired backup ${prefix}: ${removeError.message}`);
-      }
+      await storageRequest(
+        () => client.storage.from(config.backupBucket).remove(paths),
+        `Prune expired backup ${prefix}`,
+      );
     }
     pruned.push(snapshotId);
   }
 
   return pruned;
+}
+
+function writeFailureSummary(outputDir, error, snapshotId) {
+  mkdirSync(outputDir, { recursive: true });
+  const message = error instanceof Error ? error.message : String(error);
+  const summary = [
+    `# Production Backup Failed${snapshotId ? `: ${snapshotId}` : ""}`,
+    "",
+    `Failed at: \`${new Date().toISOString()}\``,
+    "",
+    "The workflow did not complete a restorable backup snapshot.",
+    "",
+    "## Error",
+    "",
+    "```text",
+    message,
+    "```",
+    "",
+  ].join("\n");
+  writeFileSync(path.join(outputDir, "failure.md"), summary);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+  }
 }
 
 function writeSummary(outputDir, manifest, prunedSnapshots) {
@@ -651,6 +774,9 @@ async function runBackup() {
     writeSummary(config.outputDir, manifest, prunedSnapshots);
     console.log(`Uploaded production backup snapshot ${config.snapshotId}`);
     console.log(`Backup prefix: ${manifest.backup.prefix}`);
+  } catch (error) {
+    writeFailureSummary(config.outputDir, error, config.snapshotId);
+    throw error;
   } finally {
     if (!config.keepTemp && existsSync(tempRoot)) {
       rmSync(tempRoot, { recursive: true, force: true });
@@ -659,10 +785,10 @@ async function runBackup() {
 }
 
 async function downloadObjectText(client, bucketName, objectPath) {
-  const { data, error } = await client.storage.from(bucketName).download(objectPath);
-  if (error) {
-    throw new Error(`Could not download ${objectPath}: ${error.message}`);
-  }
+  const data = await storageRequest(
+    () => client.storage.from(bucketName).download(objectPath),
+    `Download ${objectPath}`,
+  );
   return data.text();
 }
 
@@ -699,11 +825,16 @@ async function downloadSnapshot(config, tempRoot) {
 
   const encryptedArchivePath = path.join(tempRoot, `${snapshotId}.tar.gz.age`);
   const writeStream = createWriteStream(encryptedArchivePath);
+  const retryOptions = {
+    attempts: config.storageRetryAttempts,
+    delayMs: config.storageRetryDelayMs,
+  };
   for (const part of manifest.archive.encrypted.parts) {
-    const { data, error } = await client.storage.from(config.backupBucket).download(part.path);
-    if (error) {
-      throw new Error(`Could not download ${part.path}: ${error.message}`);
-    }
+    const data = await storageRequest(
+      () => client.storage.from(config.backupBucket).download(part.path),
+      `Download ${part.path}`,
+      retryOptions,
+    );
     writeStream.write(Buffer.from(await data.arrayBuffer()));
   }
   await new Promise((resolve, reject) => {
@@ -775,12 +906,21 @@ function restoreDatabase(config, extractDir) {
 }
 
 async function ensureBucket(client, bucketName, options) {
-  const { error } = await client.storage.getBucket(bucketName);
-  if (!error) return;
-  const { error: createError } = await client.storage.createBucket(bucketName, options);
-  if (createError) {
-    throw new Error(`Could not create bucket ${bucketName}: ${createError.message}`);
+  try {
+    await storageRequest(() => client.storage.getBucket(bucketName), `Read bucket ${bucketName}`);
+    return;
+  } catch (error) {
+    const status = Number(error?.statusCode ?? error?.status ?? 0);
+    const message = storageErrorMessage(error).toLowerCase();
+    const missing = status === 404 || message.includes("not found");
+    if (!missing) {
+      throw error;
+    }
   }
+  await storageRequest(
+    () => client.storage.createBucket(bucketName, options),
+    `Create bucket ${bucketName}`,
+  );
 }
 
 function collectFiles(rootDir) {
@@ -811,16 +951,22 @@ async function restoreArtifactStorage(config, extractDir) {
   });
   const storageRoot = path.join(extractDir, "storage", ARTIFACT_BUCKET);
   const files = collectFiles(storageRoot);
+  const retryOptions = {
+    attempts: config.storageRetryAttempts,
+    delayMs: config.storageRetryDelayMs,
+  };
   for (const filePath of files) {
     const objectPath = path.relative(storageRoot, filePath).split(path.sep).join("/");
-    const { error } = await client.storage.from(ARTIFACT_BUCKET).upload(
-      objectPath,
-      createReadStream(filePath),
-      { upsert: true, duplex: "half" },
+    await storageRequest(
+      () =>
+        client.storage.from(ARTIFACT_BUCKET).upload(
+          objectPath,
+          createReadStream(filePath),
+          { upsert: true, duplex: "half" },
+        ),
+      `Upload restored artifact ${objectPath}`,
+      retryOptions,
     );
-    if (error) {
-      throw new Error(`Could not upload restored artifact ${objectPath}: ${error.message}`);
-    }
   }
   return `applied ${files.length} artifact object(s)`;
 }

--- a/server/scripts/supabase-production-backup.mjs
+++ b/server/scripts/supabase-production-backup.mjs
@@ -1002,11 +1002,52 @@ async function runRestore() {
 }
 
 function printUsage() {
-  console.error("Usage: node server/scripts/supabase-production-backup.mjs <backup|restore>");
+  console.error(`
+Usage:
+  node server/scripts/supabase-production-backup.mjs backup
+  node server/scripts/supabase-production-backup.mjs restore
+
+Backup:
+  Creates an encrypted production backup archive and uploads it to the separate
+  backup Supabase project. The GitHub workflow "Production Backup Archive" runs
+  this automatically from main.
+
+  Required environment:
+    SUPABASE_ACCESS_TOKEN
+    SUPABASE_PROJECT_REF
+    SUPABASE_SERVICE_ROLE_KEY
+    SUPABASE_BACKUP_PROJECT_REF
+    SUPABASE_BACKUP_SERVICE_ROLE_KEY
+    SONDE_BACKUP_AGE_RECIPIENT
+
+Restore:
+  Downloads, decrypts, and prepares a backup snapshot. Restore is dry-run by
+  default. It applies database and storage restore only when SONDE_RESTORE_APPLY=1.
+
+  Required environment:
+    SUPABASE_BACKUP_PROJECT_REF
+    SUPABASE_BACKUP_SERVICE_ROLE_KEY
+    SONDE_RESTORE_TARGET_PROJECT_REF
+    SONDE_RESTORE_TARGET_SERVICE_ROLE_KEY
+    SONDE_RESTORE_TARGET_DB_URL
+    SONDE_BACKUP_AGE_IDENTITY or SONDE_BACKUP_AGE_IDENTITY_FILE
+
+Safety:
+  Restore into a fresh recovery project first. The script refuses to restore over
+  the source production project unless SONDE_RESTORE_ALLOW_SOURCE_OVERWRITE=1 is
+  explicitly set.
+
+Runbook:
+  docs/ops/production-backup-recovery.md
+`.trim());
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   const command = process.argv[2] ?? "backup";
+  if (command === "--help" || command === "-h" || command === "help") {
+    printUsage();
+    process.exit(0);
+  }
   const run =
     command === "backup" ? runBackup : command === "restore" ? runRestore : null;
 

--- a/server/scripts/supabase-production-backup.test.mjs
+++ b/server/scripts/supabase-production-backup.test.mjs
@@ -5,11 +5,13 @@ import path from "node:path";
 import { describe, it } from "node:test";
 import {
   buildLatestPointer,
+  isRetryableStorageError,
   partObjectName,
   snapshotPrefix,
   snapshotsToPrune,
   splitFile,
   validateProjectSeparation,
+  withStorageRetry,
 } from "./supabase-production-backup.mjs";
 
 describe("supabase production backup helpers", () => {
@@ -80,6 +82,52 @@ describe("supabase production backup helpers", () => {
         },
       ],
     });
+  });
+
+  it("classifies transient storage failures as retryable", () => {
+    assert.equal(isRetryableStorageError({ message: "Gateway Timeout" }), true);
+    assert.equal(isRetryableStorageError({ statusCode: 504, message: "upstream" }), true);
+    assert.equal(isRetryableStorageError({ status: 429, message: "rate limited" }), true);
+    assert.equal(isRetryableStorageError({ statusCode: 404, message: "not found" }), false);
+    assert.equal(isRetryableStorageError({ message: "row already exists" }), false);
+  });
+
+  it("retries transient storage operations with bounded attempts", async () => {
+    let attempts = 0;
+
+    const value = await withStorageRetry(
+      async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new Error("Gateway Timeout");
+        }
+        return "ok";
+      },
+      "test storage operation",
+      { attempts: 4, delayMs: 0 },
+    );
+
+    assert.equal(value, "ok");
+    assert.equal(attempts, 3);
+  });
+
+  it("does not retry non-transient storage failures", async () => {
+    let attempts = 0;
+
+    await assert.rejects(
+      () =>
+        withStorageRetry(
+          async () => {
+            attempts += 1;
+            throw Object.assign(new Error("not found"), { statusCode: 404 });
+          },
+          "test missing object",
+          { attempts: 4, delayMs: 0 },
+        ),
+      /not found/,
+    );
+
+    assert.equal(attempts, 1);
   });
 
   it("splits an encrypted archive into deterministic bounded parts", () => {

--- a/supabase/migrations/20260420000001_search_all_fuzzy.sql
+++ b/supabase/migrations/20260420000001_search_all_fuzzy.sql
@@ -1,0 +1,381 @@
+-- search_all: smarter ranking for less-direct queries.
+--
+-- Changes vs. 20260331120000_search_all_id_match.sql:
+--   1. parser: plainto_tsquery → websearch_to_tsquery (handles quoted phrases,
+--      OR, -negation, and tolerates unknown tokens instead of failing the match)
+--   2. weights: setweight() per field (A = title-like, B = summary, D = body),
+--      scored with ts_rank_cd(…, 32) so rank stays in [0,1) regardless of body
+--      length. Matches in hypothesis/topic/title/question/name rank above
+--      matches buried in long bodies.
+--   3. fuzzy fallback: pg_trgm similarity on the primary (A-weighted) field
+--      so typos and partial terms ("hurric", "hurricne seedng") still surface
+--      candidates. Capped at 0.4 so trigram never outranks a real FTS hit or
+--      an ID exact match (0.9 / 0.88).
+--
+-- Rank invariants preserved from the id_match overlay:
+--   - ID exact contains           → 0.90
+--   - ID digit-substring (≥2)     → 0.88
+--   - FTS ts_rank_cd (normalized) → [0, 1)
+--   - Trigram similarity * 0.4    → [0, 0.4]
+--   GREATEST() keeps the strongest signal per row.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Trigram indexes on short, high-value fields. Skipped for long bodies
+-- (content / finding / context / objective) — seq-scan fallback is fine at
+-- current scale and the index size isn't worth it.
+CREATE INDEX IF NOT EXISTS idx_experiments_hypothesis_trgm
+    ON experiments USING GIN (hypothesis gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_findings_topic_trgm
+    ON findings USING GIN (topic gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_directions_title_trgm
+    ON directions USING GIN (title gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_questions_question_trgm
+    ON questions USING GIN (question gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_projects_name_trgm
+    ON projects USING GIN (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_artifacts_filename_trgm
+    ON artifacts USING GIN (filename gin_trgm_ops);
+
+CREATE OR REPLACE FUNCTION search_all(
+    query text,
+    filter_program text DEFAULT NULL,
+    max_results integer DEFAULT 30
+)
+RETURNS SETOF search_result
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+    WITH
+    q AS (SELECT websearch_to_tsquery('english', query) AS tsq),
+    digits AS (SELECT regexp_replace(query, '\D', '', 'g') AS digits_only),
+    ranked AS (
+        -- Experiments ---------------------------------------------------
+        SELECT
+            e.id,
+            'experiment'::text AS record_type,
+            coalesce(left(e.hypothesis, 120), left(e.content, 120), e.id) AS title,
+            left(e.finding, 200) AS subtitle,
+            e.program,
+            NULL::text AS parent_id,
+            GREATEST(
+                CASE
+                    WHEN (
+                        setweight(to_tsvector('english', coalesce(e.hypothesis, '')), 'A') ||
+                        setweight(to_tsvector('english', coalesce(e.finding,    '')), 'B') ||
+                        setweight(to_tsvector('english', coalesce(e.content,    '')), 'D')
+                    ) @@ (SELECT tsq FROM q)
+                    THEN ts_rank_cd(
+                        setweight(to_tsvector('english', coalesce(e.hypothesis, '')), 'A') ||
+                        setweight(to_tsvector('english', coalesce(e.finding,    '')), 'B') ||
+                        setweight(to_tsvector('english', coalesce(e.content,    '')), 'D'),
+                        (SELECT tsq FROM q),
+                        32)
+                    ELSE 0::real
+                END,
+                CASE WHEN e.id ILIKE '%' || query || '%' THEN 0.9::real ELSE 0::real END,
+                CASE
+                    WHEN length((SELECT digits_only FROM digits)) >= 2
+                        AND regexp_replace(e.id, '\D', '', 'g')
+                            LIKE '%' || (SELECT digits_only FROM digits) || '%'
+                    THEN 0.88::real
+                    ELSE 0::real
+                END,
+                CASE
+                    WHEN similarity(coalesce(e.hypothesis, ''), query) > 0.2
+                    THEN similarity(coalesce(e.hypothesis, ''), query) * 0.4::real
+                    ELSE 0::real
+                END
+            ) AS rank,
+            e.created_at
+        FROM experiments e
+        WHERE (filter_program IS NULL OR e.program = filter_program)
+          AND (
+              (setweight(to_tsvector('english', coalesce(e.hypothesis, '')), 'A') ||
+               setweight(to_tsvector('english', coalesce(e.finding,    '')), 'B') ||
+               setweight(to_tsvector('english', coalesce(e.content,    '')), 'D'))
+                @@ (SELECT tsq FROM q)
+              OR e.id ILIKE '%' || query || '%'
+              OR (
+                  length((SELECT digits_only FROM digits)) >= 2
+                  AND regexp_replace(e.id, '\D', '', 'g')
+                      LIKE '%' || (SELECT digits_only FROM digits) || '%'
+              )
+              OR similarity(coalesce(e.hypothesis, ''), query) > 0.2
+          )
+
+        UNION ALL
+
+        -- Findings ------------------------------------------------------
+        SELECT
+            f.id,
+            'finding'::text,
+            f.topic,
+            left(f.finding, 200),
+            f.program,
+            NULL::text,
+            GREATEST(
+                CASE
+                    WHEN (
+                        setweight(to_tsvector('english', coalesce(f.topic,   '')), 'A') ||
+                        setweight(to_tsvector('english', coalesce(f.finding, '')), 'B')
+                    ) @@ (SELECT tsq FROM q)
+                    THEN ts_rank_cd(
+                        setweight(to_tsvector('english', coalesce(f.topic,   '')), 'A') ||
+                        setweight(to_tsvector('english', coalesce(f.finding, '')), 'B'),
+                        (SELECT tsq FROM q),
+                        32)
+                    ELSE 0::real
+                END,
+                CASE WHEN f.id ILIKE '%' || query || '%' THEN 0.9::real ELSE 0::real END,
+                CASE
+                    WHEN length((SELECT digits_only FROM digits)) >= 2
+                        AND regexp_replace(f.id, '\D', '', 'g')
+                            LIKE '%' || (SELECT digits_only FROM digits) || '%'
+                    THEN 0.88::real
+                    ELSE 0::real
+                END,
+                CASE
+                    WHEN similarity(coalesce(f.topic, ''), query) > 0.2
+                    THEN similarity(coalesce(f.topic, ''), query) * 0.4::real
+                    ELSE 0::real
+                END
+            ),
+            f.created_at
+        FROM findings f
+        WHERE (filter_program IS NULL OR f.program = filter_program)
+          AND (
+              (setweight(to_tsvector('english', coalesce(f.topic,   '')), 'A') ||
+               setweight(to_tsvector('english', coalesce(f.finding, '')), 'B'))
+                @@ (SELECT tsq FROM q)
+              OR f.id ILIKE '%' || query || '%'
+              OR (
+                  length((SELECT digits_only FROM digits)) >= 2
+                  AND regexp_replace(f.id, '\D', '', 'g')
+                      LIKE '%' || (SELECT digits_only FROM digits) || '%'
+              )
+              OR similarity(coalesce(f.topic, ''), query) > 0.2
+          )
+
+        UNION ALL
+
+        -- Directions ----------------------------------------------------
+        SELECT
+            d.id,
+            'direction'::text,
+            d.title,
+            left(d.question, 200),
+            d.program,
+            d.project_id,
+            GREATEST(
+                CASE
+                    WHEN (
+                        setweight(to_tsvector('english', coalesce(d.title,    '')), 'A') ||
+                        setweight(to_tsvector('english', coalesce(d.question, '')), 'B')
+                    ) @@ (SELECT tsq FROM q)
+                    THEN ts_rank_cd(
+                        setweight(to_tsvector('english', coalesce(d.title,    '')), 'A') ||
+                        setweight(to_tsvector('english', coalesce(d.question, '')), 'B'),
+                        (SELECT tsq FROM q),
+                        32)
+                    ELSE 0::real
+                END,
+                CASE WHEN d.id ILIKE '%' || query || '%' THEN 0.9::real ELSE 0::real END,
+                CASE
+                    WHEN length((SELECT digits_only FROM digits)) >= 2
+                        AND regexp_replace(d.id, '\D', '', 'g')
+                            LIKE '%' || (SELECT digits_only FROM digits) || '%'
+                    THEN 0.88::real
+                    ELSE 0::real
+                END,
+                CASE
+                    WHEN similarity(coalesce(d.title, ''), query) > 0.2
+                    THEN similarity(coalesce(d.title, ''), query) * 0.4::real
+                    ELSE 0::real
+                END
+            ),
+            d.created_at
+        FROM directions d
+        WHERE (filter_program IS NULL OR d.program = filter_program)
+          AND (
+              (setweight(to_tsvector('english', coalesce(d.title,    '')), 'A') ||
+               setweight(to_tsvector('english', coalesce(d.question, '')), 'B'))
+                @@ (SELECT tsq FROM q)
+              OR d.id ILIKE '%' || query || '%'
+              OR (
+                  length((SELECT digits_only FROM digits)) >= 2
+                  AND regexp_replace(d.id, '\D', '', 'g')
+                      LIKE '%' || (SELECT digits_only FROM digits) || '%'
+              )
+              OR similarity(coalesce(d.title, ''), query) > 0.2
+          )
+
+        UNION ALL
+
+        -- Questions -----------------------------------------------------
+        SELECT
+            qu.id,
+            'question'::text,
+            left(qu.question, 120),
+            left(qu.context, 200),
+            qu.program,
+            NULL::text,
+            GREATEST(
+                CASE
+                    WHEN (
+                        setweight(to_tsvector('english', coalesce(qu.question, '')), 'A') ||
+                        setweight(to_tsvector('english', coalesce(qu.context,  '')), 'B')
+                    ) @@ (SELECT tsq FROM q)
+                    THEN ts_rank_cd(
+                        setweight(to_tsvector('english', coalesce(qu.question, '')), 'A') ||
+                        setweight(to_tsvector('english', coalesce(qu.context,  '')), 'B'),
+                        (SELECT tsq FROM q),
+                        32)
+                    ELSE 0::real
+                END,
+                CASE WHEN qu.id ILIKE '%' || query || '%' THEN 0.9::real ELSE 0::real END,
+                CASE
+                    WHEN length((SELECT digits_only FROM digits)) >= 2
+                        AND regexp_replace(qu.id, '\D', '', 'g')
+                            LIKE '%' || (SELECT digits_only FROM digits) || '%'
+                    THEN 0.88::real
+                    ELSE 0::real
+                END,
+                CASE
+                    WHEN similarity(coalesce(qu.question, ''), query) > 0.2
+                    THEN similarity(coalesce(qu.question, ''), query) * 0.4::real
+                    ELSE 0::real
+                END
+            ),
+            qu.created_at
+        FROM questions qu
+        WHERE (filter_program IS NULL OR qu.program = filter_program)
+          AND (
+              (setweight(to_tsvector('english', coalesce(qu.question, '')), 'A') ||
+               setweight(to_tsvector('english', coalesce(qu.context,  '')), 'B'))
+                @@ (SELECT tsq FROM q)
+              OR qu.id ILIKE '%' || query || '%'
+              OR (
+                  length((SELECT digits_only FROM digits)) >= 2
+                  AND regexp_replace(qu.id, '\D', '', 'g')
+                      LIKE '%' || (SELECT digits_only FROM digits) || '%'
+              )
+              OR similarity(coalesce(qu.question, ''), query) > 0.2
+          )
+
+        UNION ALL
+
+        -- Projects ------------------------------------------------------
+        SELECT
+            p.id,
+            'project'::text,
+            p.name,
+            left(p.objective, 200),
+            p.program,
+            NULL::text,
+            GREATEST(
+                CASE
+                    WHEN (
+                        setweight(to_tsvector('english', coalesce(p.name,      '')), 'A') ||
+                        setweight(to_tsvector('english', coalesce(p.objective, '')), 'B')
+                    ) @@ (SELECT tsq FROM q)
+                    THEN ts_rank_cd(
+                        setweight(to_tsvector('english', coalesce(p.name,      '')), 'A') ||
+                        setweight(to_tsvector('english', coalesce(p.objective, '')), 'B'),
+                        (SELECT tsq FROM q),
+                        32)
+                    ELSE 0::real
+                END,
+                CASE WHEN p.id ILIKE '%' || query || '%' THEN 0.9::real ELSE 0::real END,
+                CASE
+                    WHEN length((SELECT digits_only FROM digits)) >= 2
+                        AND regexp_replace(p.id, '\D', '', 'g')
+                            LIKE '%' || (SELECT digits_only FROM digits) || '%'
+                    THEN 0.88::real
+                    ELSE 0::real
+                END,
+                CASE
+                    WHEN similarity(coalesce(p.name, ''), query) > 0.2
+                    THEN similarity(coalesce(p.name, ''), query) * 0.4::real
+                    ELSE 0::real
+                END
+            ),
+            p.created_at
+        FROM projects p
+        WHERE (filter_program IS NULL OR p.program = filter_program)
+          AND (
+              (setweight(to_tsvector('english', coalesce(p.name,      '')), 'A') ||
+               setweight(to_tsvector('english', coalesce(p.objective, '')), 'B'))
+                @@ (SELECT tsq FROM q)
+              OR p.id ILIKE '%' || query || '%'
+              OR (
+                  length((SELECT digits_only FROM digits)) >= 2
+                  AND regexp_replace(p.id, '\D', '', 'g')
+                      LIKE '%' || (SELECT digits_only FROM digits) || '%'
+              )
+              OR similarity(coalesce(p.name, ''), query) > 0.2
+          )
+
+        UNION ALL
+
+        -- Artifacts (filename ILIKE + id match + trigram fallback) ------
+        SELECT
+            a.id,
+            'artifact'::text,
+            a.filename,
+            a.type || ' · ' || coalesce(a.description, a.mime_type, ''),
+            coalesce(
+                (SELECT e.program FROM experiments e WHERE e.id = a.experiment_id),
+                (SELECT f.program FROM findings f WHERE f.id = a.finding_id),
+                (SELECT dir.program FROM directions dir WHERE dir.id = a.direction_id)
+            ),
+            coalesce(a.experiment_id, a.finding_id, a.direction_id),
+            GREATEST(
+                CASE WHEN a.filename ILIKE '%' || query || '%' THEN 0.5::real ELSE 0::real END,
+                CASE WHEN a.id ILIKE '%' || query || '%' THEN 0.9::real ELSE 0::real END,
+                CASE
+                    WHEN length((SELECT digits_only FROM digits)) >= 2
+                        AND regexp_replace(a.id, '\D', '', 'g')
+                            LIKE '%' || (SELECT digits_only FROM digits) || '%'
+                    THEN 0.88::real
+                    ELSE 0::real
+                END,
+                CASE
+                    WHEN similarity(coalesce(a.filename, ''), query) > 0.2
+                    THEN similarity(coalesce(a.filename, ''), query) * 0.4::real
+                    ELSE 0::real
+                END
+            ),
+            a.created_at
+        FROM artifacts a
+        WHERE (
+              filter_program IS NULL
+              OR EXISTS (
+                  SELECT 1 FROM experiments e WHERE e.id = a.experiment_id AND e.program = filter_program
+              )
+              OR EXISTS (
+                  SELECT 1 FROM findings f WHERE f.id = a.finding_id AND f.program = filter_program
+              )
+              OR EXISTS (
+                  SELECT 1 FROM directions dir WHERE dir.id = a.direction_id AND dir.program = filter_program
+              )
+          )
+          AND (
+              a.filename ILIKE '%' || query || '%'
+              OR a.id ILIKE '%' || query || '%'
+              OR (
+                  length((SELECT digits_only FROM digits)) >= 2
+                  AND regexp_replace(a.id, '\D', '', 'g')
+                      LIKE '%' || (SELECT digits_only FROM digits) || '%'
+              )
+              OR similarity(coalesce(a.filename, ''), query) > 0.2
+          )
+    )
+    SELECT * FROM ranked
+    ORDER BY rank DESC, created_at DESC
+    LIMIT max_results;
+$$;
+
+GRANT EXECUTE ON FUNCTION search_all TO authenticated;
+NOTIFY pgrst, 'reload schema';

--- a/ui/src/components/artifacts/embedded-document-preview.tsx
+++ b/ui/src/components/artifacts/embedded-document-preview.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import { useEffect, useRef, useState } from "react";
-import { Download, ExternalLink, FileWarning } from "lucide-react";
+import { Download, ExternalLink, FileWarning, Maximize2, Minimize2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 function DownloadLink({ url, filename }: { url: string; filename: string }) {
@@ -40,6 +40,7 @@ export function EmbeddedDocumentPreview({
   // the Open/Download links below this gives the user a working path
   // out when the preview itself can't render.
   const [hasError, setHasError] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
 
   useEffect(() => {
@@ -53,35 +54,55 @@ export function EmbeddedDocumentPreview({
     return () => iframe.removeEventListener("error", handleError);
   }, [embedUrl]);
 
+  const sizeClass = expanded ? "h-[85vh] min-h-[500px]" : "h-[500px]";
+
   return (
     <div className="space-y-2">
-      {hasError ? (
-        <div
-          role="alert"
-          data-testid="embedded-preview-fallback"
-          className={cn(
-            "flex h-[500px] w-full flex-col items-center justify-center gap-2 rounded-[8px] border border-border-subtle bg-surface-raised text-text-tertiary",
-            iframeClassName,
-          )}
-        >
-          <FileWarning className="h-6 w-6" aria-hidden="true" />
-          <p className="text-[12px]">Preview unavailable. Use Open or Download.</p>
-        </div>
-      ) : (
-        <iframe
-          ref={iframeRef}
-          src={embedUrl}
-          onError={() => setHasError(true)}
-          className={cn(
-            "h-[500px] w-full rounded-[8px] border border-border-subtle",
-            iframeClassName,
-          )}
-          title={title}
-        />
-      )}
+      <div
+        className={cn(
+          "w-full overflow-hidden rounded-[8px] border border-border-subtle transition-[height] duration-150",
+          sizeClass,
+        )}
+      >
+        {hasError ? (
+          <div
+            role="alert"
+            data-testid="embedded-preview-fallback"
+            className={cn(
+              "flex h-full w-full flex-col items-center justify-center gap-2 bg-surface-raised text-text-tertiary",
+              iframeClassName,
+            )}
+          >
+            <FileWarning className="h-6 w-6" aria-hidden="true" />
+            <p className="text-[12px]">Preview unavailable. Use Open or Download.</p>
+          </div>
+        ) : (
+          <iframe
+            ref={iframeRef}
+            src={embedUrl}
+            onError={() => setHasError(true)}
+            className={cn("h-full w-full", iframeClassName)}
+            title={title}
+          />
+        )}
+      </div>
       <div
         className={cn("flex items-center justify-center gap-3", footerClassName)}
       >
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-pressed={expanded}
+          aria-label={expanded ? "Collapse preview" : "Expand preview"}
+          className="inline-flex items-center gap-1 rounded-[5.5px] px-2 py-1 text-[11px] text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text"
+        >
+          {expanded ? (
+            <Minimize2 className="h-3 w-3" />
+          ) : (
+            <Maximize2 className="h-3 w-3" />
+          )}
+          {expanded ? "Collapse" : "Expand"}
+        </button>
         <a
           href={fileUrl}
           target="_blank"

--- a/ui/src/components/command-palette/command-palette.tsx
+++ b/ui/src/components/command-palette/command-palette.tsx
@@ -9,6 +9,7 @@ import {
   MessageCircleQuestion,
   Paperclip,
   FolderKanban,
+  GripHorizontal,
 } from "lucide-react";
 import { supabase } from "@/lib/supabase";
 import { useUIStore } from "@/stores/ui";
@@ -49,6 +50,31 @@ function useSearchAll(query: string) {
   });
 }
 
+const SIZE_STORAGE_KEY = "sonde.commandPalette.size";
+const MIN_WIDTH = 520;
+const MIN_HEIGHT = 380;
+const DEFAULT_WIDTH = 960;
+const DEFAULT_HEIGHT = 640;
+
+function loadSavedSize(): { width: number; height: number } {
+  if (typeof window === "undefined") {
+    return { width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT };
+  }
+  try {
+    const raw = window.localStorage.getItem(SIZE_STORAGE_KEY);
+    if (!raw) return { width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT };
+    const parsed = JSON.parse(raw) as { width?: number; height?: number };
+    const width = Number.isFinite(parsed.width) ? (parsed.width as number) : DEFAULT_WIDTH;
+    const height = Number.isFinite(parsed.height) ? (parsed.height as number) : DEFAULT_HEIGHT;
+    return {
+      width: Math.max(MIN_WIDTH, width),
+      height: Math.max(MIN_HEIGHT, height),
+    };
+  } catch {
+    return { width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT };
+  }
+}
+
 function CommandPalette() {
   const navigate = useNavigate();
   const close = useUIStore((s) => s.setCommandPaletteOpen);
@@ -58,6 +84,66 @@ function CommandPalette() {
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState(loadSavedSize);
+  const resizeRef = useRef<{
+    startX: number;
+    startY: number;
+    startWidth: number;
+    startHeight: number;
+    axis: "both" | "x" | "y";
+  } | null>(null);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(SIZE_STORAGE_KEY, JSON.stringify(size));
+    } catch {
+      // storage unavailable — size will reset next session
+    }
+  }, [size]);
+
+  const startResize = useCallback(
+    (axis: "both" | "x" | "y") => (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      resizeRef.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        startWidth: size.width,
+        startHeight: size.height,
+        axis,
+      };
+      const target = e.currentTarget;
+      target.setPointerCapture(e.pointerId);
+
+      const maxWidth = window.innerWidth - 32;
+      const maxHeight = window.innerHeight - 32;
+
+      const handleMove = (ev: PointerEvent) => {
+        const state = resizeRef.current;
+        if (!state) return;
+        const dx = ev.clientX - state.startX;
+        const dy = ev.clientY - state.startY;
+        setSize((prev) => ({
+          width:
+            state.axis === "y"
+              ? prev.width
+              : Math.min(maxWidth, Math.max(MIN_WIDTH, state.startWidth + dx)),
+          height:
+            state.axis === "x"
+              ? prev.height
+              : Math.min(maxHeight, Math.max(MIN_HEIGHT, state.startHeight + dy)),
+        }));
+      };
+      const handleUp = () => {
+        resizeRef.current = null;
+        window.removeEventListener("pointermove", handleMove);
+        window.removeEventListener("pointerup", handleUp);
+      };
+      window.addEventListener("pointermove", handleMove);
+      window.addEventListener("pointerup", handleUp);
+    },
+    [size.width, size.height],
+  );
 
   // Debounced query for server search
   const [debouncedQuery, setDebouncedQuery] = useState("");
@@ -167,41 +253,42 @@ function CommandPalette() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-scrim pt-[15vh] backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-scrim pt-[12vh] backdrop-blur-sm"
       onClick={() => close(false)}
     >
       <div
-        className="w-full max-w-[min(92vw,880px)] overflow-hidden rounded-[10px] border border-border bg-surface shadow-2xl"
+        className="relative flex max-h-[85vh] max-w-[95vw] flex-col overflow-hidden rounded-[10px] border border-border bg-surface shadow-2xl"
+        style={{ width: size.width, height: size.height }}
         onClick={(e) => e.stopPropagation()}
         onKeyDown={handleKeyDown}
       >
         {/* Input */}
-        <div className="flex items-center gap-2.5 border-b border-border px-3">
-          <Search className="h-4 w-4 shrink-0 text-text-tertiary" />
+        <div className="flex shrink-0 items-center gap-3 border-b border-border px-4">
+          <Search className="h-[18px] w-[18px] shrink-0 text-text-tertiary" />
           <input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search all programs — experiments, findings, directions…"
             autoFocus
-            className="h-11 w-full bg-transparent text-[14px] text-text placeholder:text-text-quaternary focus:outline-none"
+            className="h-14 w-full bg-transparent text-[16px] text-text placeholder:text-text-quaternary focus:outline-none"
           />
           {isLoading && debouncedQuery && (
-            <span className="shrink-0 text-[10px] text-text-quaternary">searching…</span>
+            <span className="shrink-0 text-[11px] text-text-quaternary">searching…</span>
           )}
-          <kbd className="shrink-0 rounded-[3px] border border-border px-1.5 py-0.5 text-[10px] text-text-quaternary">
+          <kbd className="shrink-0 rounded-[3px] border border-border px-1.5 py-0.5 text-[11px] text-text-quaternary">
             esc
           </kbd>
         </div>
 
         {/* Results */}
-        <div ref={listRef} className="max-h-[min(55vh,520px)] overflow-y-auto py-1.5">
+        <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto py-2">
           {results.length === 0 && query.trim() && !isLoading && (
-            <div className="px-3 py-8 text-center text-[13px] text-text-quaternary">
+            <div className="px-4 py-10 text-center text-[14px] text-text-quaternary">
               No results for &ldquo;{query}&rdquo;
             </div>
           )}
           {results.length === 0 && !query.trim() && recentItems.length === 0 && (
-            <div className="px-3 py-8 text-center text-[13px] text-text-quaternary">
+            <div className="px-4 py-10 text-center text-[14px] text-text-quaternary">
               Type to search records and artifacts across every program you can access
             </div>
           )}
@@ -214,22 +301,22 @@ function CommandPalette() {
                 key={`${rt}-${result.id}-${i}`}
                 onClick={() => selectResult(result)}
                 onMouseEnter={() => setSelectedIndex(i)}
-                className={`flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors ${
+                className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${
                   isSelected ? "bg-surface-hover" : ""
                 }`}
               >
-                <Icon className="h-4 w-4 shrink-0 text-text-tertiary" />
+                <Icon className="h-[18px] w-[18px] shrink-0 text-text-tertiary" />
                 <div className="min-w-0 flex-1">
                   <div className="flex min-w-0 flex-wrap items-center gap-2">
-                    <span className="truncate text-[13px] font-medium text-text">
+                    <span className="truncate text-[14px] font-medium text-text">
                       {result.title}
                     </span>
                     {result.program && (
-                      <span className="shrink-0 rounded-[3px] border border-border-subtle bg-surface-raised px-1.5 py-0.5 font-mono text-[10px] text-text-tertiary">
+                      <span className="shrink-0 rounded-[3px] border border-border-subtle bg-surface-raised px-1.5 py-0.5 font-mono text-[11px] text-text-tertiary">
                         {result.program}
                       </span>
                     )}
-                    <span className="shrink-0 rounded-[3px] bg-surface-raised px-1 py-0.5 font-mono text-[10px] text-text-quaternary">
+                    <span className="shrink-0 rounded-[3px] bg-surface-raised px-1.5 py-0.5 font-mono text-[11px] text-text-quaternary">
                       {result.id}
                     </span>
                     {rt === "artifact" && (
@@ -237,7 +324,7 @@ function CommandPalette() {
                     )}
                   </div>
                   {result.subtitle && (
-                    <p className="mt-0.5 truncate text-[12px] text-text-tertiary">
+                    <p className="mt-1 truncate text-[13px] text-text-tertiary">
                       {result.subtitle}
                     </p>
                   )}
@@ -248,13 +335,35 @@ function CommandPalette() {
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between border-t border-border px-3 py-1.5 text-[11px] text-text-quaternary">
+        <div className="flex shrink-0 items-center justify-between border-t border-border px-4 py-2 text-[11px] text-text-quaternary">
           <span>
             <kbd className="rounded-[2px] border border-border px-1">&uarr;&darr;</kbd> navigate{" "}
             <kbd className="ml-1 rounded-[2px] border border-border px-1">&crarr;</kbd> open{" "}
             <kbd className="ml-1 rounded-[2px] border border-border px-1">esc</kbd> close
           </span>
           <span>{results.length} results</span>
+        </div>
+
+        {/* Resize handles */}
+        <div
+          onPointerDown={startResize("x")}
+          className="absolute inset-y-0 right-0 w-1.5 cursor-ew-resize hover:bg-accent/20"
+          aria-label="Resize width"
+          role="separator"
+        />
+        <div
+          onPointerDown={startResize("y")}
+          className="absolute inset-x-0 bottom-0 h-1.5 cursor-ns-resize hover:bg-accent/20"
+          aria-label="Resize height"
+          role="separator"
+        />
+        <div
+          onPointerDown={startResize("both")}
+          className="absolute bottom-0 right-0 flex h-4 w-4 cursor-se-resize items-end justify-end pb-0.5 pr-0.5 text-text-quaternary hover:text-text-tertiary"
+          aria-label="Resize"
+          role="separator"
+        >
+          <GripHorizontal className="h-3 w-3 rotate-45" />
         </div>
       </div>
     </div>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -16,6 +16,9 @@
   --palette-accent: #d97c5d;
   --palette-accent-hover: #c96a4f;
   --palette-accent-muted: color-mix(in srgb, #d97c5d 19%, transparent);
+  --palette-review: #b85f2a;
+  --palette-review-border: color-mix(in srgb, #b85f2a 34%, var(--palette-border-subtle));
+  --palette-review-muted: color-mix(in srgb, #b85f2a 12%, transparent);
   --palette-on-accent: #fafaf8;
   --palette-scrim: color-mix(in srgb, #1b1a18 45%, transparent);
   --palette-scrim-strong: color-mix(in srgb, #1b1a18 72%, transparent);
@@ -50,6 +53,9 @@ html.dark {
   --palette-accent: #b86548;
   --palette-accent-hover: #c97a5c;
   --palette-accent-muted: color-mix(in srgb, #b86548 22%, transparent);
+  --palette-review: #d0895f;
+  --palette-review-border: color-mix(in srgb, #d0895f 30%, var(--palette-border-subtle));
+  --palette-review-muted: color-mix(in srgb, #d0895f 14%, transparent);
   --palette-on-accent: #fafaf8;
   --palette-scrim: color-mix(in srgb, #000000 58%, transparent);
   --palette-scrim-strong: color-mix(in srgb, #000000 82%, transparent);
@@ -83,6 +89,9 @@ html.dark {
   --color-accent: var(--palette-accent);
   --color-accent-hover: var(--palette-accent-hover);
   --color-accent-muted: var(--palette-accent-muted);
+  --color-review: var(--palette-review);
+  --color-review-border: var(--palette-review-border);
+  --color-review-muted: var(--palette-review-muted);
   --color-on-accent: var(--palette-on-accent);
   --color-scrim: var(--palette-scrim);
   --color-scrim-strong: var(--palette-scrim-strong);

--- a/ui/src/routes/pages/experiment-detail.tsx
+++ b/ui/src/routes/pages/experiment-detail.tsx
@@ -276,8 +276,8 @@ export default function ExperimentDetailPage() {
             >
               <div className="space-y-3">
                 {review.status === "resolved" && (
-                  <div className="rounded-[5.5px] border border-border-subtle bg-surface-raised px-2.5 py-2">
-                    <p className="text-[11px] font-medium uppercase tracking-wide text-text-quaternary">
+                  <div className="rounded-[5.5px] border border-review-border bg-review-muted px-2.5 py-2">
+                    <p className="text-[11px] font-medium uppercase tracking-wide text-review">
                       Resolved
                     </p>
                     {review.resolution && (
@@ -290,11 +290,11 @@ export default function ExperimentDetailPage() {
                 {review.entries.map((entry) => (
                   <div
                     key={entry.id}
-                    className="border-b border-border-subtle pb-3 last:border-0 last:pb-0"
+                    className="rounded-[5.5px] border border-l-2 border-review-border border-l-review bg-review-muted px-2.5 py-2"
                   >
                     <div className="mb-1.5 flex items-center gap-2">
-                      <MessagesSquare className="h-3 w-3 text-accent" />
-                      <span className="text-[11px] font-medium text-text-secondary">
+                      <MessagesSquare className="h-3 w-3 text-review" />
+                      <span className="text-[11px] font-medium text-review">
                         {entry.source}
                       </span>
                       <span


### PR DESCRIPTION
## Summary
- add dedicated review color tokens for light/dark mode
- make experiment review entries read as warmer, darker cards distinct from notes
- keep notes on the existing accent styling
- harden production backup storage listing/download/upload with bounded retry/backoff after the first scheduled run hit a transient Supabase Storage Gateway Timeout
- write a sanitized failure summary artifact when a backup fails before producing a manifest
- add `docs/ops/production-backup-recovery.md` so manual backup, verification, safe restore, schema deployment, and emergency rules are clear
- expand `server/scripts/supabase-production-backup.mjs --help` with backup/restore env requirements and safety guidance

## Backup note
The production backup workflow is installed on main, but the first scheduled run on 2026-04-20 failed while listing one artifacts prefix (`artifacts/EXP-0205`) due to a Supabase Storage Gateway Timeout. The DB dump completed. This PR adds retry/backoff around storage operations so transient storage failures do not abort the whole backup immediately.

## Schema note
Schema deployment is handled separately by the staging/production infra workflows. Backups capture the live schema/data/artifacts at runtime; they do not apply migrations. Migrations under `supabase/**` are automatically pushed by Sync Staging Infra on staging and Sync Production Infra on main.

## Validation
- `node server/scripts/supabase-production-backup.mjs --help`
- `node --check server/scripts/supabase-production-backup.mjs`
- `node --test server/scripts/supabase-production-backup.test.mjs`
- `node --test server/scripts/supabase-backup-drill.test.mjs`
- `npm test --prefix server`
- `npm run build --prefix server`
- `npm run lint --prefix ui`
- `npm run build --prefix ui`
