### PR TITLE
Home-page background redesign + palette, search, and tree polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ vendor/stac-db/
 .claude/scheduled_tasks.lock
 .cursor/rules/
 .agents/skills/
+.codex/config.toml
 # --- /sonde managed: runtime-assets ---

--- a/cli/src/sonde/ignore.py
+++ b/cli/src/sonde/ignore.py
@@ -67,7 +67,9 @@ def ensure_runtime_asset_ignore(project_root: Path) -> bool:
         entries=[
             ".claude/skills/",
             ".claude/agents/",
+            ".claude/scheduled_tasks.lock",
             ".cursor/rules/",
             ".agents/skills/",
+            ".codex/config.toml",
         ],
     )

--- a/cli/src/sonde/runtimes.py
+++ b/cli/src/sonde/runtimes.py
@@ -8,6 +8,7 @@ to the RUNTIMES dict.
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import tomllib
@@ -73,10 +74,27 @@ def detect_runtimes(project_root: Path) -> list[RuntimeSpec]:
             candidates.add(spec.mcp_config.split("/")[0])
         if any((project_root / candidate).exists() for candidate in candidates):
             found.append(spec)
+
+    if _is_codex_environment() and all(spec.name != "codex" for spec in found):
+        found.append(RUNTIMES["codex"])
+
     # Always include claude-code as default
     if not found:
         found.append(RUNTIMES["claude-code"])
     return found
+
+
+def _is_codex_environment() -> bool:
+    """Return True when setup is being run from a Codex-managed process."""
+    return any(
+        os.environ.get(name)
+        for name in (
+            "CODEX_CI",
+            "CODEX_HOME",
+            "CODEX_MANAGED_BY_NPM",
+            "CODEX_THREAD_ID",
+        )
+    )
 
 
 def resolve_runtimes(project_root: Path, names: str | None) -> list[RuntimeSpec]:

--- a/cli/tests/test_setup_runtimes.py
+++ b/cli/tests/test_setup_runtimes.py
@@ -33,6 +33,11 @@ from sonde.skills import (
 
 
 class TestDetectRuntimes:
+    @pytest.fixture(autouse=True)
+    def clear_codex_env(self, monkeypatch: pytest.MonkeyPatch):
+        for name in ("CODEX_CI", "CODEX_HOME", "CODEX_MANAGED_BY_NPM", "CODEX_THREAD_ID"):
+            monkeypatch.delenv(name, raising=False)
+
     def test_claude_only(self, tmp_path: Path):
         (tmp_path / ".claude").mkdir()
         found = detect_runtimes(tmp_path)
@@ -53,6 +58,14 @@ class TestDetectRuntimes:
         found = detect_runtimes(tmp_path)
         assert len(found) == 1
         assert found[0].name == "claude-code"
+
+    def test_codex_environment_detected_without_project_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("CODEX_THREAD_ID", "thread-123")
+        found = detect_runtimes(tmp_path)
+        names = {rt.name for rt in found}
+        assert names == {"codex"}
 
 
 class TestResolveRuntimes:
@@ -412,6 +425,10 @@ class TestSetupCommand:
         skill_files = list(codex_dir.glob("*/SKILL.md"))
         assert len(skill_files) >= 1
         assert ".agents/skills/" in (tmp_path / ".gitignore").read_text(encoding="utf-8")
+        assert ".claude/scheduled_tasks.lock" in (tmp_path / ".gitignore").read_text(
+            encoding="utf-8"
+        )
+        assert ".codex/config.toml" in (tmp_path / ".gitignore").read_text(encoding="utf-8")
         codex_config = (tmp_path / ".codex" / "config.toml").read_text(encoding="utf-8")
         assert "[mcp_servers.sonde]" in codex_config
         assert 'command = "sonde"' in codex_config

--- a/ui/src/components/assistant/canvas-experiment-card.tsx
+++ b/ui/src/components/assistant/canvas-experiment-card.tsx
@@ -1,0 +1,148 @@
+import { memo, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { Paperclip } from "lucide-react";
+import type { AssistantCanvasCardPlacement } from "@/lib/assistant-canvas-layout";
+import type { ExperimentSummary, ExperimentStatus } from "@/types/sonde";
+import { cn } from "@/lib/utils";
+
+function statusDotClass(status: ExperimentStatus, dark: boolean): string {
+  switch (status) {
+    case "running":
+      return dark ? "bg-sky-400" : "bg-sky-500";
+    case "complete":
+      return dark ? "bg-emerald-400" : "bg-emerald-500";
+    case "failed":
+      return dark ? "bg-rose-400" : "bg-rose-500";
+    case "superseded":
+      return dark ? "bg-amber-400" : "bg-amber-500";
+    case "open":
+    default:
+      return dark ? "bg-white/40" : "bg-text-quaternary";
+  }
+}
+
+function relativeAge(iso: string | null): string {
+  if (!iso) return "";
+  const ms = Date.now() - new Date(iso).getTime();
+  if (Number.isNaN(ms) || ms < 0) return "";
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}w ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
+}
+
+export const CanvasExperimentCard = memo(function CanvasExperimentCard({
+  experiment,
+  slot,
+  dark,
+  reduceMotion,
+}: {
+  experiment: ExperimentSummary;
+  slot: AssistantCanvasCardPlacement;
+  dark: boolean;
+  reduceMotion: boolean;
+}) {
+  const [hovered, setHovered] = useState(false);
+
+  const labelTone = dark ? "text-white/55" : "text-text-tertiary";
+  const bodyTone = dark ? "text-white/70" : "text-text-secondary";
+  const footerTone = dark ? "text-white/40" : "text-text-quaternary";
+
+  const lifted = !reduceMotion && hovered;
+  const transform = `translate3d(0,${lifted ? -6 : 0}px,0) rotate(${slot.rotate}deg) scale(${lifted ? 1.025 : 1})`;
+
+  const hypothesis = (experiment.hypothesis ?? "").trim();
+  const age = relativeAge(experiment.created_at);
+
+  return (
+    <Link
+      to="/experiments/$id"
+      params={{ id: experiment.id }}
+      className={cn(
+        "pointer-events-auto absolute cursor-pointer touch-manipulation select-none overflow-hidden rounded-[10px] shadow-lg",
+        "will-change-[transform,opacity] transition-[transform,opacity,border-color] duration-200 ease-out",
+        "motion-reduce:transition-opacity",
+        "hover:opacity-100 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
+        dark
+          ? "border border-white/[0.12] bg-black/55 opacity-[0.62] outline-white/30 hover:border-white/25"
+          : "border border-border bg-surface-raised/95 opacity-[0.75] outline-accent hover:border-border",
+      )}
+      style={{
+        top: `${slot.top}px`,
+        left: `${slot.left}px`,
+        width: `${slot.width}px`,
+        transform,
+        zIndex: 8 + slot.z,
+      }}
+      onPointerEnter={() => setHovered(true)}
+      onPointerLeave={() => setHovered(false)}
+      onFocus={() => setHovered(true)}
+      onBlur={() => setHovered(false)}
+      aria-label={`Open experiment ${experiment.id}`}
+      draggable={false}
+    >
+      <div className="flex flex-col gap-1.5 px-3 pt-2 pb-2.5">
+        <div className="flex items-center gap-1.5">
+          <span
+            className={cn(
+              "inline-block shrink-0 rounded-[3px] px-1 py-[1px] text-[8px] font-bold uppercase leading-none tracking-[0.08em]",
+              dark ? "bg-white/10 text-white/50" : "bg-accent/10 text-accent/75",
+            )}
+          >
+            exp
+          </span>
+          <span
+            className={cn(
+              "min-w-0 flex-1 truncate font-mono text-[10px] font-medium uppercase tracking-[0.14em]",
+              labelTone,
+            )}
+          >
+            {experiment.id}
+          </span>
+          <span
+            className={cn(
+              "h-1.5 w-1.5 shrink-0 rounded-full",
+              statusDotClass(experiment.status, dark),
+            )}
+            aria-label={`status: ${experiment.status}`}
+          />
+        </div>
+
+        <p
+          className={cn(
+            "line-clamp-3 text-[12px] leading-snug",
+            bodyTone,
+            !hypothesis && "italic opacity-70",
+          )}
+        >
+          {hypothesis || "No hypothesis recorded"}
+        </p>
+
+        <div
+          className={cn(
+            "flex items-center justify-between gap-2 text-[10px] leading-none",
+            footerTone,
+          )}
+        >
+          <span className="inline-flex items-center gap-1">
+            <Paperclip className="h-2.5 w-2.5" aria-hidden />
+            <span>
+              {experiment.artifact_count}{" "}
+              {experiment.artifact_count === 1 ? "artifact" : "artifacts"}
+            </span>
+          </span>
+          {age && <span className="truncate">{age}</span>}
+        </div>
+      </div>
+    </Link>
+  );
+});

--- a/ui/src/components/assistant/canvas-project-card.tsx
+++ b/ui/src/components/assistant/canvas-project-card.tsx
@@ -1,0 +1,134 @@
+import { memo, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { GitBranch, FlaskConical } from "lucide-react";
+import type { AssistantCanvasCardPlacement } from "@/lib/assistant-canvas-layout";
+import type { ProjectSummary, ProjectStatus } from "@/types/sonde";
+import { cn } from "@/lib/utils";
+
+function statusDotClass(status: ProjectStatus, dark: boolean): string {
+  switch (status) {
+    case "active":
+      return dark ? "bg-emerald-400" : "bg-emerald-500";
+    case "completed":
+      return dark ? "bg-sky-400" : "bg-sky-500";
+    case "paused":
+      return dark ? "bg-amber-400" : "bg-amber-500";
+    case "archived":
+      return dark ? "bg-white/25" : "bg-text-quaternary";
+    case "proposed":
+    default:
+      return dark ? "bg-white/40" : "bg-text-tertiary";
+  }
+}
+
+export const CanvasProjectCard = memo(function CanvasProjectCard({
+  project,
+  slot,
+  dark,
+  reduceMotion,
+}: {
+  project: ProjectSummary;
+  slot: AssistantCanvasCardPlacement;
+  dark: boolean;
+  reduceMotion: boolean;
+}) {
+  const [hovered, setHovered] = useState(false);
+
+  const labelTone = dark ? "text-white/55" : "text-text-tertiary";
+  const titleTone = dark ? "text-white/85" : "text-text";
+  const bodyTone = dark ? "text-white/65" : "text-text-secondary";
+  const footerTone = dark ? "text-white/45" : "text-text-quaternary";
+
+  const lifted = !reduceMotion && hovered;
+  const transform = `translate3d(0,${lifted ? -6 : 0}px,0) rotate(${slot.rotate}deg) scale(${lifted ? 1.025 : 1})`;
+
+  const objective = (project.objective ?? "").trim();
+
+  return (
+    <Link
+      to="/projects/$id"
+      params={{ id: project.id }}
+      className={cn(
+        "pointer-events-auto absolute cursor-pointer touch-manipulation select-none overflow-hidden rounded-[10px] shadow-lg",
+        "will-change-[transform,opacity] transition-[transform,opacity,border-color] duration-200 ease-out",
+        "motion-reduce:transition-opacity",
+        "hover:opacity-100 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
+        dark
+          ? "border border-amber-400/20 bg-black/55 opacity-[0.62] outline-amber-400/40 hover:border-amber-400/40"
+          : "border border-amber-500/20 bg-surface-raised/95 opacity-[0.78] outline-amber-500 hover:border-amber-500/40",
+      )}
+      style={{
+        top: `${slot.top}px`,
+        left: `${slot.left}px`,
+        width: `${slot.width}px`,
+        transform,
+        zIndex: 8 + slot.z,
+      }}
+      onPointerEnter={() => setHovered(true)}
+      onPointerLeave={() => setHovered(false)}
+      onFocus={() => setHovered(true)}
+      onBlur={() => setHovered(false)}
+      aria-label={`Open project ${project.name}`}
+      draggable={false}
+    >
+      <div className="flex flex-col gap-1.5 px-3 pt-2 pb-2.5">
+        <div className="flex items-center gap-1.5">
+          <span
+            className={cn(
+              "inline-block shrink-0 rounded-[3px] px-1 py-[1px] text-[8px] font-bold uppercase leading-none tracking-[0.08em]",
+              dark
+                ? "bg-amber-400/15 text-amber-400/60"
+                : "bg-amber-500/15 text-amber-700/80",
+            )}
+          >
+            proj
+          </span>
+          <span
+            className={cn(
+              "min-w-0 flex-1 truncate text-[11px] font-semibold",
+              titleTone,
+            )}
+          >
+            {project.name}
+          </span>
+          <span
+            className={cn(
+              "h-1.5 w-1.5 shrink-0 rounded-full",
+              statusDotClass(project.status, dark),
+            )}
+            aria-label={`status: ${project.status}`}
+          />
+        </div>
+
+        <p
+          className={cn(
+            "line-clamp-3 text-[11.5px] leading-snug",
+            bodyTone,
+            !objective && "italic opacity-70",
+          )}
+        >
+          {objective || "No objective recorded"}
+        </p>
+
+        <div
+          className={cn(
+            "flex items-center justify-between gap-2 pt-0.5 text-[10px] leading-none",
+            footerTone,
+          )}
+        >
+          <span className={cn("inline-flex items-center gap-1", labelTone)}>
+            <GitBranch className="h-2.5 w-2.5" aria-hidden />
+            <span>
+              {project.direction_count}{" "}
+              {project.direction_count === 1 ? "direction" : "directions"}
+            </span>
+          </span>
+          <span className={cn("inline-flex items-center gap-1", labelTone)}>
+            <FlaskConical className="h-2.5 w-2.5" aria-hidden />
+            <span>{project.experiment_count}</span>
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+});

--- a/ui/src/components/assistant/research-canvas-background.tsx
+++ b/ui/src/components/assistant/research-canvas-background.tsx
@@ -8,10 +8,12 @@ import {
   useLayoutEffect,
   useSyncExternalStore,
 } from "react";
-import { Link } from "@tanstack/react-router";
-import { Film } from "lucide-react";
-import { useArtifactUrl, useBatchArtifactUrls } from "@/hooks/use-artifacts";
-import { useAssistantCanvasArtifacts } from "@/hooks/use-assistant-canvas-artifacts";
+import {
+  useAssistantCanvasFeed,
+  type AssistantCanvasFeedRow,
+} from "@/hooks/use-assistant-canvas-artifacts";
+import { CanvasExperimentCard } from "./canvas-experiment-card";
+import { CanvasProjectCard } from "./canvas-project-card";
 import {
   ASSISTANT_CANVAS_LAYER_SCALE,
   computeAssistantCanvasCardPlacements,
@@ -22,9 +24,13 @@ import { useActiveProgram } from "@/stores/program";
 import { useCanvasBubbleRect } from "@/stores/assistant-canvas-layout";
 import { useChatStore } from "@/stores/chat";
 import { cn } from "@/lib/utils";
-import { isVideo } from "@/lib/artifact-kind";
-import { CanvasHierarchyFlow } from "./canvas-hierarchy-flow";
-import type { AssistantCanvasArtifactRow } from "@/hooks/use-assistant-canvas-artifacts";
+
+/**
+ * Toggle to hide the scattered experiment/project cards. Flip to `true` to
+ * restore rendering — all data fetching, card components, and layout code
+ * remain wired up so this is a single-line re-enable.
+ */
+const CARDS_VISIBLE = false;
 
 /** Layer is 155% × viewport; centering leaves ~27.5% overhang each side — pan must stay within that. */
 const MAX_PAN_FRACTION = (ASSISTANT_CANVAS_LAYER_SCALE - 1) / 2;
@@ -44,165 +50,12 @@ function getReducedMotion(): boolean {
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
 
-function canvasLinkProps(link: AssistantCanvasArtifactRow["linkTo"]) {
-  if (link.kind === "experiment") {
-    return { to: "/experiments/$id" as const, params: { id: link.id } };
-  }
-  if (link.kind === "direction") {
-    return { to: "/directions/$id" as const, params: { id: link.id } };
-  }
-  return { to: "/projects/$id" as const, params: { id: link.id } };
-}
-
-const CanvasArtifactCard = memo(function CanvasArtifactCard({
-  artifact,
-  slot,
-  dark,
-  reduceMotion,
-}: {
-  artifact: AssistantCanvasArtifactRow;
-  slot: AssistantCanvasCardPlacement;
-  dark: boolean;
-  reduceMotion: boolean;
-}) {
-  const link = canvasLinkProps(artifact.linkTo);
-  const recordLabel = artifact.linkTo.id;
-  const { data: url, isLoading: loading } = useArtifactUrl(artifact.storage_path);
-  const video = isVideo(artifact);
-  const [interactiveHover, setInteractiveHover] = useState(false);
-
-  const labelClass = dark
-    ? "text-[10px] font-medium uppercase tracking-[0.14em] text-white/45"
-    : "text-[10px] font-medium uppercase tracking-[0.14em] text-text-tertiary";
-  const hovered = !reduceMotion && interactiveHover;
-  const transform = `translate3d(0,${hovered ? -6 : 0}px,0) rotate(${slot.rotate}deg) scale(${hovered ? 1.025 : 1})`;
-
-  return (
-    <Link
-      to={link.to}
-      params={link.params}
-      className={cn(
-        "pointer-events-auto absolute cursor-pointer touch-manipulation select-none overflow-hidden rounded-[10px] shadow-lg",
-        "will-change-[transform,opacity] transition-[transform,opacity,border-color] duration-200 ease-out",
-        "motion-reduce:transition-opacity",
-        "hover:opacity-100 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
-        dark
-          ? "border border-white/[0.12] bg-black/40 opacity-[0.42] outline-white/30 hover:border-white/25"
-          : "border border-border bg-surface-raised/90 opacity-[0.55] outline-accent hover:border-border",
-      )}
-      style={{
-        top: `${slot.top}px`,
-        left: `${slot.left}px`,
-        width: `${slot.width}px`,
-        transform,
-        zIndex: 8 + slot.z,
-      }}
-      onPointerEnter={() => setInteractiveHover(true)}
-      onPointerLeave={() => setInteractiveHover(false)}
-      onFocus={() => setInteractiveHover(true)}
-      onBlur={() => setInteractiveHover(false)}
-      aria-label={`Open ${artifact.linkTo.kind} ${recordLabel}, ${artifact.filename}`}
-      draggable={false}
-    >
-      <div className="flex flex-col gap-0 px-2 pt-1.5 pb-1">
-        <div className="flex items-center gap-1 overflow-hidden">
-          <span
-            className={cn(
-              "inline-block shrink-0 rounded-[3px] px-1 py-[1px] text-[8px] font-bold uppercase leading-none tracking-[0.08em]",
-              artifact.linkTo.kind === "experiment"
-                ? dark ? "bg-white/10 text-white/40" : "bg-accent/10 text-accent/70"
-                : artifact.linkTo.kind === "direction"
-                  ? dark ? "bg-emerald-400/15 text-emerald-400/50" : "bg-emerald-500/10 text-emerald-600/70"
-                  : dark ? "bg-amber-400/15 text-amber-400/50" : "bg-amber-500/10 text-amber-600/70",
-            )}
-          >
-            {artifact.linkTo.kind === "experiment" ? "exp" : artifact.linkTo.kind === "direction" ? "dir" : "proj"}
-          </span>
-          <span className={cn(labelClass, "min-w-0 truncate font-mono")}>{recordLabel}</span>
-        </div>
-        <span className={cn(labelClass, "truncate normal-case tracking-normal")}>
-          {artifact.filename}
-        </span>
-      </div>
-      <div
-        className={cn(
-          "relative aspect-[4/3] w-full overflow-hidden",
-          dark ? "bg-black/50" : "bg-surface-hover/80",
-        )}
-      >
-        {loading && (
-          <div
-            className={cn(
-              "absolute inset-0 animate-shimmer",
-              !dark && "opacity-60",
-            )}
-          />
-        )}
-        {!loading && url && video && !reduceMotion && (
-          <video
-            src={url}
-            muted
-            playsInline
-            loop
-            autoPlay
-            preload="metadata"
-            className="h-full w-full object-cover"
-          />
-        )}
-        {!loading && url && video && reduceMotion && (
-          <div className="flex h-full w-full flex-col items-center justify-center gap-1 bg-black/45 px-2">
-            <Film className={cn("h-7 w-7", dark ? "text-white/35" : "text-text-quaternary")} aria-hidden />
-            <span
-              className={cn(
-                "line-clamp-2 text-center text-[10px] leading-tight",
-                dark ? "text-white/50" : "text-text-tertiary",
-              )}
-            >
-              {artifact.filename}
-            </span>
-          </div>
-        )}
-        {!loading && url && !video && (
-          <img
-            src={url}
-            alt=""
-            className="h-full w-full object-cover"
-            loading="lazy"
-            decoding="async"
-            draggable={false}
-          />
-        )}
-        {!loading && !url && (
-          <div className="flex h-full w-full flex-col items-center justify-center gap-1.5 px-3">
-            <span className={cn(
-              "text-[24px]",
-              dark ? "opacity-30" : "opacity-20",
-            )}>
-              {artifact.filename?.endsWith(".csv") ? "📊"
-                : artifact.filename?.endsWith(".pdf") ? "📄"
-                : artifact.filename?.endsWith(".py") ? "🐍"
-                : artifact.filename?.endsWith(".jl") ? "📐"
-                : "📎"}
-            </span>
-            <span className={cn(
-              "line-clamp-2 text-center text-[10px] leading-tight",
-              dark ? "text-white/40" : "text-text-quaternary",
-            )}>
-              {artifact.filename}
-            </span>
-          </div>
-        )}
-      </div>
-    </Link>
-  );
-});
-
 export const ResearchCanvasBackground = memo(function ResearchCanvasBackground() {
   const theme = useTheme();
   const dark = theme === "dark";
   const program = useActiveProgram();
   const reduceMotion = useSyncExternalStore(subscribeReducedMotion, getReducedMotion, () => false);
-  const { data: artifacts } = useAssistantCanvasArtifacts();
+  const { data: feed } = useAssistantCanvasFeed();
   const bubbleRect = useCanvasBubbleRect();
 
   const hasConversation = useChatStore((s) =>
@@ -310,26 +163,15 @@ export const ResearchCanvasBackground = memo(function ResearchCanvasBackground()
     [bubbleRect, viewportPx],
   );
 
-  const placed = useMemo(() => {
-    if (!artifacts?.length) {
-      console.log("[canvas] No artifacts to render");
-      return [];
-    }
-    console.log(`[canvas] Rendering ${artifacts.length} artifact cards:`,
-      artifacts.map(a => `${a.linkTo.kind}:${a.linkTo.id} ${a.filename}`).join(", "));
-    return artifacts.slice(0, cardSlots.length).map((artifact, i) => ({
-      artifact,
+  const placed = useMemo<
+    { row: AssistantCanvasFeedRow; slot: AssistantCanvasCardPlacement }[]
+  >(() => {
+    if (!feed?.length) return [];
+    return feed.slice(0, cardSlots.length).map((row, i) => ({
+      row,
       slot: cardSlots[i],
     }));
-  }, [artifacts, cardSlots]);
-
-  const batchPaths = useMemo(
-    () => placed.map((p) => p.artifact.storage_path),
-    [placed],
-  );
-  const urlBatch = useBatchArtifactUrls(batchPaths);
-  const urlsReady =
-    batchPaths.length === 0 || urlBatch.isSuccess || urlBatch.isError;
+  }, [feed, cardSlots]);
 
   const canvasInteractive = !hasConversation;
 
@@ -383,18 +225,26 @@ export const ResearchCanvasBackground = memo(function ResearchCanvasBackground()
             />
           )}
 
-          {urlsReady &&
-            placed.map(({ artifact, slot }) => (
-              <CanvasArtifactCard
-                key={artifact.id}
-                artifact={artifact}
-                slot={slot}
-                dark={dark}
-                reduceMotion={reduceMotion}
-              />
-            ))}
-
-          <CanvasHierarchyFlow dark={dark} />
+          {CARDS_VISIBLE &&
+            placed.map(({ row, slot }) =>
+              row.kind === "experiment" ? (
+                <CanvasExperimentCard
+                  key={`experiment-${row.experiment.id}`}
+                  experiment={row.experiment}
+                  slot={slot}
+                  dark={dark}
+                  reduceMotion={reduceMotion}
+                />
+              ) : (
+                <CanvasProjectCard
+                  key={`project-${row.project.id}`}
+                  project={row.project}
+                  slot={slot}
+                  dark={dark}
+                  reduceMotion={reduceMotion}
+                />
+              ),
+            )}
         </div>
       </div>
     </div>

--- a/ui/src/hooks/use-assistant-canvas-artifacts.ts
+++ b/ui/src/hooks/use-assistant-canvas-artifacts.ts
@@ -3,11 +3,17 @@ import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabase";
 import { queryKeys } from "@/lib/query-keys";
 import { usePrograms } from "@/hooks/use-programs";
+import { useExperiments } from "@/hooks/use-experiments";
+import { useProjects } from "@/hooks/use-projects";
 import { isImage, isVideo } from "@/lib/artifact-kind";
-import type { Artifact } from "@/types/sonde";
+import type {
+  Artifact,
+  ExperimentSummary,
+  ProjectSummary,
+} from "@/types/sonde";
 
 const FETCH_LIMIT_PER_SOURCE = 90;
-export const ASSISTANT_CANVAS_CARD_COUNT = 10;
+export const ASSISTANT_CANVAS_CARD_COUNT = 16;
 
 const STALE_MS = 2 * 60_000;
 
@@ -221,4 +227,84 @@ export function useAssistantCanvasArtifacts() {
     staleTime: STALE_MS,
     gcTime: 5 * 60_000,
   });
+}
+
+// ── Canvas feed: experiments + projects ─────────────────────────────────
+
+export type AssistantCanvasFeedRow =
+  | { kind: "experiment"; experiment: ExperimentSummary }
+  | { kind: "project"; project: ProjectSummary };
+
+/**
+ * Feed used by ResearchCanvasBackground. Returns up to
+ * ASSISTANT_CANVAS_CARD_COUNT rows: experiments fill the inner ring
+ * around the chat bubble (indices 0–11), projects fill the outer corners
+ * (indices 12–15). If one source runs dry, the other backfills.
+ */
+export function useAssistantCanvasFeed() {
+  const experimentsQ = useExperiments();
+  const projectsQ = useProjects();
+
+  const feed = useMemo<AssistantCanvasFeedRow[]>(() => {
+    const experiments = experimentsQ.data ?? [];
+    const projects = projectsQ.data ?? [];
+
+    if (experiments.length === 0 && projects.length === 0) return [];
+
+    // Prefer experiments with a hypothesis for the inner ring; fall back to
+    // any experiment if we don't have 12 with hypotheses.
+    const withHypothesis = experiments.filter(
+      (e) => (e.hypothesis ?? "").trim().length > 0,
+    );
+    const withoutHypothesis = experiments.filter(
+      (e) => !((e.hypothesis ?? "").trim().length > 0),
+    );
+    const orderedExperiments = [...withHypothesis, ...withoutHypothesis];
+
+    const innerCount = 12;
+    const outerCount = 4;
+    const inner = orderedExperiments.slice(0, innerCount);
+    const outer = projects.slice(0, outerCount);
+
+    // Backfill: if we have fewer projects than outer slots, use more
+    // experiments; if fewer experiments than inner slots, use more projects.
+    const rows: AssistantCanvasFeedRow[] = [
+      ...inner.map(
+        (e): AssistantCanvasFeedRow => ({ kind: "experiment", experiment: e }),
+      ),
+      ...outer.map(
+        (p): AssistantCanvasFeedRow => ({ kind: "project", project: p }),
+      ),
+    ];
+
+    if (rows.length < ASSISTANT_CANVAS_CARD_COUNT) {
+      const usedExpIds = new Set(inner.map((e) => e.id));
+      const usedProjIds = new Set(outer.map((p) => p.id));
+      const extraExperiments = orderedExperiments.filter(
+        (e) => !usedExpIds.has(e.id),
+      );
+      const extraProjects = projects.filter((p) => !usedProjIds.has(p.id));
+      while (
+        rows.length < ASSISTANT_CANVAS_CARD_COUNT &&
+        (extraExperiments.length > 0 || extraProjects.length > 0)
+      ) {
+        if (extraExperiments.length > 0) {
+          rows.push({ kind: "experiment", experiment: extraExperiments.shift()! });
+          if (rows.length >= ASSISTANT_CANVAS_CARD_COUNT) break;
+        }
+        if (extraProjects.length > 0) {
+          rows.push({ kind: "project", project: extraProjects.shift()! });
+        }
+      }
+    }
+
+    return rows.slice(0, ASSISTANT_CANVAS_CARD_COUNT);
+  }, [experimentsQ.data, projectsQ.data]);
+
+  return {
+    data: feed,
+    isLoading: experimentsQ.isLoading || projectsQ.isLoading,
+    isSuccess: experimentsQ.isSuccess && projectsQ.isSuccess,
+    isError: experimentsQ.isError || projectsQ.isError,
+  };
 }

--- a/ui/src/lib/assistant-canvas-layout.test.ts
+++ b/ui/src/lib/assistant-canvas-layout.test.ts
@@ -46,7 +46,7 @@ describe("assistant canvas layout", () => {
       bubbleRect: bubble,
     });
 
-    expect(placements).toHaveLength(10);
+    expect(placements).toHaveLength(16);
 
     for (const placement of placements) {
       const rect = cardViewportRect(placement, viewport);
@@ -77,7 +77,7 @@ describe("assistant canvas layout", () => {
     const viewport = { w: 960, h: 640 };
     const placements = computeAssistantCanvasCardPlacements({ viewport });
 
-    expect(placements).toHaveLength(10);
+    expect(placements).toHaveLength(16);
     for (const placement of placements) {
       const rect = cardViewportRect(placement, viewport);
       expect(rect.top).toBeGreaterThanOrEqual(16);

--- a/ui/src/lib/assistant-canvas-layout.ts
+++ b/ui/src/lib/assistant-canvas-layout.ts
@@ -21,12 +21,15 @@ export interface CanvasLayerFrame {
   height: number;
 }
 
+export type CanvasSlotKind = "experiment" | "project" | "any";
+
 export interface AssistantCanvasCardPlacement {
   left: number;
   top: number;
   width: number;
   rotate: number;
   z: number;
+  preferredKind: CanvasSlotKind;
 }
 
 interface HierarchyLevels {
@@ -46,6 +49,7 @@ interface SlotBlueprint {
   width: WidthSpec;
   rotate: number;
   z: number;
+  preferredKind: CanvasSlotKind;
   place: (ctx: PlacementContext, width: number, height: number) => { x: number; y: number };
   fallback: "above" | "below";
 }
@@ -139,6 +143,80 @@ function applyFallbackY(
   return clampRectToViewport(x, rawY, width, height, ctx.viewport, ctx.insetX, ctx.insetY);
 }
 
+interface PlacedRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function intersectsAny(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  placed: readonly PlacedRect[],
+  pad: number,
+): boolean {
+  for (const r of placed) {
+    if (
+      x < r.x + r.width + pad &&
+      x + width + pad > r.x &&
+      y < r.y + r.height + pad &&
+      y + height + pad > r.y
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Try to find a non-overlapping position near `start` by nudging in widening
+ * rings. Respects the viewport inset and the bubble collision. Returns the
+ * first position that doesn't overlap any already-placed card, or `start` if
+ * no clearance found within the search budget.
+ */
+function avoidCardCollisions(
+  start: { x: number; y: number },
+  ctx: PlacementContext,
+  width: number,
+  height: number,
+  placed: readonly PlacedRect[],
+  pad: number,
+): { x: number; y: number } {
+  if (placed.length === 0) return start;
+  if (!intersectsAny(start.x, start.y, width, height, placed, pad)) return start;
+
+  // Widening ring search: try offsets in 8 directions at increasing radii.
+  const step = Math.max(24, Math.min(width, height) * 0.3);
+  const directions: Array<[number, number]> = [
+    [0, -1], [0, 1], [-1, 0], [1, 0],
+    [-1, -1], [1, -1], [-1, 1], [1, 1],
+  ];
+
+  for (let ring = 1; ring <= 6; ring++) {
+    for (const [dx, dy] of directions) {
+      const candidate = clampRectToViewport(
+        start.x + dx * step * ring,
+        start.y + dy * step * ring,
+        width,
+        height,
+        ctx.viewport,
+        ctx.insetX,
+        ctx.insetY,
+      );
+      if (intersectsBubble(candidate.x, candidate.y, width, height, ctx.bubble, ctx.bubblePad)) {
+        continue;
+      }
+      if (!intersectsAny(candidate.x, candidate.y, width, height, placed, pad)) {
+        return candidate;
+      }
+    }
+  }
+  return start;
+}
+
 function avoidBubbleCollision(
   next: { x: number; y: number },
   ctx: PlacementContext,
@@ -185,105 +263,145 @@ function avoidBubbleCollision(
   return candidate;
 }
 
+/**
+ * Slot layout: 16 cards arranged in concentric rings around the chat bubble.
+ *
+ *   - Inner ring (experiments): top band (4), bottom band (4), left column (2),
+ *     right column (2).
+ *   - Outer corners (projects): 4 cards in the far corners.
+ *
+ * All cards are similar-sized (170–210px). Rotation is capped at ±1.5°.
+ * Overlap between slots is resolved by a separate pass in
+ * `computeAssistantCanvasCardPlacements` below — blueprints only declare
+ * the *preferred* placement; the algorithm nudges late-added cards that
+ * collide with earlier ones.
+ */
+const EXP_WIDTH: WidthSpec = { min: 160, preferredVw: 0.14, max: 205 };
+const PROJ_WIDTH: WidthSpec = { min: 175, preferredVw: 0.15, max: 225 };
+
 const SLOT_BLUEPRINTS: readonly SlotBlueprint[] = [
+  // ── Top band above bubble: 4 cards spaced across ──
   {
-    width: { min: 130, preferredVw: 0.16, max: 220 },
-    rotate: -3.2,
-    z: 2,
-    fallback: "above",
-    place: ({ bubble, sideGap, topGap }, width, height) => ({
-      x: bubble.left - width * 0.72 - sideGap,
-      y: bubble.top - height - topGap * 1.3,
-    }),
-  },
-  {
-    width: { min: 110, preferredVw: 0.12, max: 175 },
-    rotate: 1.8,
-    z: 1,
-    fallback: "above",
+    width: EXP_WIDTH, rotate: -1.3, z: 2, preferredKind: "experiment", fallback: "above",
     place: ({ bubble, topGap }, width, height) => ({
-      x: bubble.left + bubble.width * 0.14 - width * 0.18,
-      y: bubble.top - height - topGap * 0.9,
+      x: bubble.left + bubble.width * 0.05 - width * 0.45,
+      y: bubble.top - height - topGap * 1.2,
     }),
   },
   {
-    width: { min: 115, preferredVw: 0.13, max: 185 },
-    rotate: -1.4,
-    z: 1,
-    fallback: "above",
-    place: ({ bubble, topGap }, _width, height) => ({
-      x: bubble.right - bubble.width * 0.42,
+    width: EXP_WIDTH, rotate: 1.1, z: 2, preferredKind: "experiment", fallback: "above",
+    place: ({ bubble, topGap }, width, height) => ({
+      x: bubble.left + bubble.width * 0.32 - width * 0.5,
       y: bubble.top - height - topGap * 1.1,
     }),
   },
   {
-    width: { min: 135, preferredVw: 0.17, max: 230 },
-    rotate: 2.4,
-    z: 2,
-    fallback: "above",
-    place: ({ bubble, sideGap, topGap }, _width, height) => ({
-      x: bubble.right + sideGap * 0.9,
-      y: bubble.top - height - topGap,
+    width: EXP_WIDTH, rotate: -1.0, z: 2, preferredKind: "experiment", fallback: "above",
+    place: ({ bubble, topGap }, width, height) => ({
+      x: bubble.left + bubble.width * 0.62 - width * 0.5,
+      y: bubble.top - height - topGap * 1.1,
     }),
   },
   {
-    width: { min: 125, preferredVw: 0.15, max: 210 },
-    rotate: 2.1,
-    z: 3,
-    fallback: "above",
-    place: ({ bubble, sideFarGap }, width, height) => ({
-      x: bubble.left - width - sideFarGap,
-      y: bubble.top + bubble.height * 0.12 - height * 0.4,
+    width: EXP_WIDTH, rotate: 1.4, z: 2, preferredKind: "experiment", fallback: "above",
+    place: ({ bubble, topGap }, width, height) => ({
+      x: bubble.left + bubble.width * 0.92 - width * 0.55,
+      y: bubble.top - height - topGap * 1.2,
+    }),
+  },
+
+  // ── Bottom band below bubble: 4 cards spaced across ──
+  {
+    width: EXP_WIDTH, rotate: 1.2, z: 2, preferredKind: "experiment", fallback: "below",
+    place: ({ bubble, bottomGap }, width) => ({
+      x: bubble.left + bubble.width * 0.05 - width * 0.45,
+      y: bubble.bottom + bottomGap * 1.1,
     }),
   },
   {
-    width: { min: 120, preferredVw: 0.14, max: 195 },
-    rotate: -1.5,
-    z: 1,
-    fallback: "below",
+    width: EXP_WIDTH, rotate: -1.4, z: 2, preferredKind: "experiment", fallback: "below",
+    place: ({ bubble, bottomGap }, width) => ({
+      x: bubble.left + bubble.width * 0.32 - width * 0.5,
+      y: bubble.bottom + bottomGap * 1.2,
+    }),
+  },
+  {
+    width: EXP_WIDTH, rotate: 1.0, z: 2, preferredKind: "experiment", fallback: "below",
+    place: ({ bubble, bottomGap }, width) => ({
+      x: bubble.left + bubble.width * 0.62 - width * 0.5,
+      y: bubble.bottom + bottomGap * 1.2,
+    }),
+  },
+  {
+    width: EXP_WIDTH, rotate: -1.1, z: 2, preferredKind: "experiment", fallback: "below",
+    place: ({ bubble, bottomGap }, width) => ({
+      x: bubble.left + bubble.width * 0.92 - width * 0.55,
+      y: bubble.bottom + bottomGap * 1.1,
+    }),
+  },
+
+  // ── Left column: 2 cards stacked at left of bubble ──
+  {
+    width: EXP_WIDTH, rotate: -1.2, z: 2, preferredKind: "experiment", fallback: "above",
+    place: ({ bubble, sideGap }, width) => ({
+      x: bubble.left - width - sideGap,
+      y: bubble.top + bubble.height * 0.05,
+    }),
+  },
+  {
+    width: EXP_WIDTH, rotate: 1.3, z: 2, preferredKind: "experiment", fallback: "below",
     place: ({ bubble, sideGap }, width, height) => ({
-      x: bubble.left - width - sideGap * 1.1,
-      y: bubble.top + bubble.height * 0.62 - height * 0.45,
+      x: bubble.left - width - sideGap,
+      y: bubble.bottom - height - bubble.height * 0.05,
+    }),
+  },
+
+  // ── Right column: 2 cards stacked at right of bubble ──
+  {
+    width: EXP_WIDTH, rotate: 1.1, z: 2, preferredKind: "experiment", fallback: "above",
+    place: ({ bubble, sideGap }) => ({
+      x: bubble.right + sideGap,
+      y: bubble.top + bubble.height * 0.05,
     }),
   },
   {
-    width: { min: 140, preferredVw: 0.18, max: 245 },
-    rotate: -2.8,
-    z: 2,
-    fallback: "above",
-    place: ({ bubble, sideFarGap }, _width, height) => ({
-      x: bubble.right + sideFarGap,
-      y: bubble.top + bubble.height * 0.1 - height * 0.35,
-    }),
-  },
-  {
-    width: { min: 118, preferredVw: 0.13, max: 190 },
-    rotate: 3,
-    z: 4,
-    fallback: "below",
+    width: EXP_WIDTH, rotate: -1.4, z: 2, preferredKind: "experiment", fallback: "below",
     place: ({ bubble, sideGap }, _width, height) => ({
       x: bubble.right + sideGap,
-      y: bubble.top + bubble.height * 0.58 - height * 0.35,
+      y: bubble.bottom - height - bubble.height * 0.05,
     }),
   },
+
+  // ── Outer corner: upper-left (project) ──
   {
-    width: { min: 128, preferredVw: 0.15, max: 215 },
-    rotate: 2.6,
-    z: 2,
-    fallback: "below",
-    place: ({ bubble, bottomGap }, width) => ({
-      x: bubble.left + bubble.width * 0.06 - width * 0.08,
-      y: bubble.bottom + bottomGap,
+    width: PROJ_WIDTH, rotate: -1.5, z: 1, preferredKind: "project", fallback: "above",
+    place: ({ bubble, sideFarGap, topGap }, width, height) => ({
+      x: bubble.left - width * 1.4 - sideFarGap,
+      y: bubble.top - height - topGap * 1.6,
     }),
   },
+  // ── Outer corner: upper-right (project) ──
   {
-    width: { min: 122, preferredVw: 0.14, max: 200 },
-    rotate: -2.2,
-    z: 1,
-    fallback: "below",
-    place: ({ bubble, bottomGap }) => ({
-      x: bubble.right - bubble.width * 0.52,
-      y: bubble.bottom + bottomGap * 1.15,
+    width: PROJ_WIDTH, rotate: 1.5, z: 1, preferredKind: "project", fallback: "above",
+    place: ({ bubble, sideFarGap, topGap }, _width, height) => ({
+      x: bubble.right + bubble.width * 0.4 + sideFarGap,
+      y: bubble.top - height - topGap * 1.6,
+    }),
+  },
+  // ── Outer corner: lower-left (project) ──
+  {
+    width: PROJ_WIDTH, rotate: 1.2, z: 1, preferredKind: "project", fallback: "below",
+    place: ({ bubble, sideFarGap, bottomGap }, width) => ({
+      x: bubble.left - width * 1.4 - sideFarGap,
+      y: bubble.bottom + bottomGap * 1.6,
+    }),
+  },
+  // ── Outer corner: lower-right (project) ──
+  {
+    width: PROJ_WIDTH, rotate: -1.3, z: 1, preferredKind: "project", fallback: "below",
+    place: ({ bubble, sideFarGap, bottomGap }) => ({
+      x: bubble.right + bubble.width * 0.4 + sideFarGap,
+      y: bubble.bottom + bottomGap * 1.6,
     }),
   },
 ] as const;
@@ -357,6 +475,9 @@ export function computeAssistantCanvasCardPlacements({
     bubblePad: clamp(viewport.w * 0.012, 12, 18),
   };
 
+  const placed: PlacedRect[] = [];
+  const cardPad = clamp(viewport.w * 0.006, 6, 12);
+
   return SLOT_BLUEPRINTS.map((slot) => {
     const width = Math.round(widthFromSpec(slot.width, viewport.w));
     const height = cardHeight(width);
@@ -375,6 +496,9 @@ export function computeAssistantCanvasCardPlacements({
       next = applyFallbackY(slot.fallback, ctx, width, height, next.x);
     }
     next = avoidBubbleCollision(next, ctx, width, height);
+    next = avoidCardCollisions(next, ctx, width, height, placed, cardPad);
+
+    placed.push({ x: next.x, y: next.y, width, height });
 
     return {
       left: Math.round(next.x - frame.left),
@@ -382,6 +506,7 @@ export function computeAssistantCanvasCardPlacements({
       width,
       rotate: slot.rotate,
       z: slot.z,
+      preferredKind: slot.preferredKind,
     };
   });
 }

--- a/ui/src/lib/tree-timeline-visibility.test.ts
+++ b/ui/src/lib/tree-timeline-visibility.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import type {
+  DirectionSummary,
+  ExperimentSummary,
+  Finding,
+  ProjectSummary,
+  QuestionSummary,
+} from "@/types/sonde";
+import { buildTimelineVisibleTreeData } from "./tree-timeline-visibility";
+
+const BEFORE_CUTOFF = "2026-04-12T12:00:00Z";
+const CUTOFF = "2026-04-12T13:00:00Z";
+const AFTER_CUTOFF = "2026-04-12T14:00:00Z";
+
+function project(overrides: Partial<ProjectSummary> = {}): ProjectSummary {
+  return {
+    id: "PROJ-001",
+    program: "prism-development",
+    name: "Project",
+    objective: null,
+    description: null,
+    status: "active",
+    source: "test",
+    report_pdf_artifact_id: null,
+    report_tex_artifact_id: null,
+    report_updated_at: null,
+    created_at: BEFORE_CUTOFF,
+    updated_at: BEFORE_CUTOFF,
+    direction_count: 0,
+    experiment_count: 0,
+    complete_count: 0,
+    open_count: 0,
+    running_count: 0,
+    failed_count: 0,
+    ...overrides,
+  };
+}
+
+function direction(
+  overrides: Partial<DirectionSummary> = {},
+): DirectionSummary {
+  return {
+    id: "DIR-001",
+    program: "prism-development",
+    title: "Direction",
+    question: "Direction question",
+    status: "active",
+    source: "test",
+    project_id: "PROJ-001",
+    parent_direction_id: null,
+    spawned_from_experiment_id: null,
+    created_at: BEFORE_CUTOFF,
+    updated_at: BEFORE_CUTOFF,
+    experiment_count: 0,
+    complete_count: 0,
+    open_count: 0,
+    running_count: 0,
+    child_direction_count: 0,
+    ...overrides,
+  };
+}
+
+function question(overrides: Partial<QuestionSummary> = {}): QuestionSummary {
+  return {
+    id: "Q-001",
+    program: "prism-development",
+    question: "Question?",
+    direction_id: "DIR-001",
+    context: null,
+    status: "open",
+    source: "test",
+    raised_by: null,
+    promoted_to_type: null,
+    promoted_to_id: null,
+    tags: [],
+    created_at: BEFORE_CUTOFF,
+    updated_at: BEFORE_CUTOFF,
+    linked_experiment_count: 0,
+    primary_experiment_count: 0,
+    linked_finding_count: 0,
+    ...overrides,
+  };
+}
+
+function experiment(
+  overrides: Partial<ExperimentSummary> = {},
+): ExperimentSummary {
+  return {
+    id: "EXP-001",
+    program: "prism-development",
+    status: "complete",
+    source: "test",
+    content: null,
+    hypothesis: "Experiment",
+    parameters: {},
+    results: null,
+    finding: null,
+    metadata: {},
+    git_commit: null,
+    git_repo: null,
+    git_branch: null,
+    git_close_commit: null,
+    git_close_branch: null,
+    git_dirty: null,
+    code_context: null,
+    data_sources: [],
+    tags: [],
+    direction_id: "DIR-001",
+    project_id: "PROJ-001",
+    linear_id: null,
+    related: [],
+    parent_id: null,
+    branch_type: null,
+    claimed_by: null,
+    claimed_at: null,
+    run_at: null,
+    created_at: BEFORE_CUTOFF,
+    updated_at: BEFORE_CUTOFF,
+    primary_question_id: "Q-001",
+    artifact_count: 0,
+    artifact_types: null,
+    artifact_filenames: null,
+    ...overrides,
+  };
+}
+
+function finding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: "FIND-001",
+    program: "prism-development",
+    topic: "Finding",
+    finding: "Supported by an experiment",
+    confidence: "medium",
+    importance: "medium",
+    content: null,
+    metadata: {},
+    evidence: ["EXP-001"],
+    source: "test",
+    valid_from: BEFORE_CUTOFF,
+    valid_until: null,
+    supersedes: null,
+    superseded_by: null,
+    created_at: BEFORE_CUTOFF,
+    updated_at: BEFORE_CUTOFF,
+    ...overrides,
+  };
+}
+
+describe("buildTimelineVisibleTreeData", () => {
+  it("keeps structural question ancestors for visible experiments", () => {
+    const visible = buildTimelineVisibleTreeData({
+      projects: [project()],
+      directions: [direction()],
+      questions: [question({ created_at: AFTER_CUTOFF })],
+      experiments: [experiment()],
+      findings: [],
+      cutoff: CUTOFF,
+    });
+
+    expect(visible.experiments.map((item) => item.id)).toEqual(["EXP-001"]);
+    expect(visible.questions.map((item) => item.id)).toEqual(["Q-001"]);
+    expect(visible.directions.map((item) => item.id)).toEqual(["DIR-001"]);
+    expect(visible.projects.map((item) => item.id)).toEqual(["PROJ-001"]);
+  });
+
+  it("keeps structural experiment ancestors for visible child experiments", () => {
+    const visible = buildTimelineVisibleTreeData({
+      projects: [project()],
+      directions: [direction()],
+      questions: [question()],
+      experiments: [
+        experiment({ id: "EXP-001", created_at: AFTER_CUTOFF }),
+        experiment({
+          id: "EXP-002",
+          parent_id: "EXP-001",
+          created_at: BEFORE_CUTOFF,
+        }),
+      ],
+      findings: [],
+      cutoff: CUTOFF,
+    });
+
+    expect(visible.experiments.map((item) => item.id)).toEqual([
+      "EXP-001",
+      "EXP-002",
+    ]);
+  });
+
+  it("does not show unrelated future leaves", () => {
+    const visible = buildTimelineVisibleTreeData({
+      projects: [project()],
+      directions: [direction()],
+      questions: [question()],
+      experiments: [
+        experiment({ id: "EXP-001" }),
+        experiment({ id: "EXP-999", created_at: AFTER_CUTOFF }),
+      ],
+      findings: [
+        finding({ id: "FIND-001" }),
+        finding({ id: "FIND-999", created_at: AFTER_CUTOFF }),
+      ],
+      cutoff: CUTOFF,
+    });
+
+    expect(visible.experiments.map((item) => item.id)).toEqual(["EXP-001"]);
+    expect(visible.findings.map((item) => item.id)).toEqual(["FIND-001"]);
+  });
+
+  it("shows the supporting experiment path for visible findings", () => {
+    const visible = buildTimelineVisibleTreeData({
+      projects: [project()],
+      directions: [direction()],
+      questions: [question()],
+      experiments: [experiment({ created_at: AFTER_CUTOFF })],
+      findings: [finding()],
+      cutoff: CUTOFF,
+    });
+
+    expect(visible.findings.map((item) => item.id)).toEqual(["FIND-001"]);
+    expect(visible.experiments.map((item) => item.id)).toEqual(["EXP-001"]);
+  });
+});

--- a/ui/src/lib/tree-timeline-visibility.ts
+++ b/ui/src/lib/tree-timeline-visibility.ts
@@ -1,0 +1,119 @@
+import type {
+  DirectionSummary,
+  ExperimentSummary,
+  Finding,
+  ProjectSummary,
+  QuestionSummary,
+} from "@/types/sonde";
+
+export interface TimelineTreeData {
+  projects: ProjectSummary[];
+  directions: DirectionSummary[];
+  questions: QuestionSummary[];
+  experiments: ExperimentSummary[];
+  findings: Finding[];
+}
+
+export interface BuildTimelineVisibleTreeDataInput extends TimelineTreeData {
+  cutoff: string | null;
+}
+
+export function isVisibleAt(createdAt: string, cutoff: string | null): boolean {
+  if (!cutoff) return true;
+  return new Date(createdAt).getTime() <= new Date(cutoff).getTime();
+}
+
+export function buildTimelineVisibleTreeData({
+  projects,
+  directions,
+  questions,
+  experiments,
+  findings,
+  cutoff,
+}: BuildTimelineVisibleTreeDataInput): TimelineTreeData {
+  const projectsById = new Map(projects.map((project) => [project.id, project]));
+  const directionsById = new Map(
+    directions.map((direction) => [direction.id, direction]),
+  );
+  const questionsById = new Map(
+    questions.map((question) => [question.id, question]),
+  );
+  const experimentsById = new Map(
+    experiments.map((experiment) => [experiment.id, experiment]),
+  );
+
+  const visibleProjectIds = new Set<string>();
+  const visibleDirectionIds = new Set<string>();
+  const visibleQuestionIds = new Set<string>();
+  const visibleExperimentIds = new Set<string>();
+  const visibleFindingIds = new Set<string>();
+
+  const addProject = (projectId: string | null | undefined): void => {
+    if (!projectId || !projectsById.has(projectId)) return;
+    visibleProjectIds.add(projectId);
+  };
+
+  const addDirection = (directionId: string | null | undefined): void => {
+    if (!directionId || visibleDirectionIds.has(directionId)) return;
+    const direction = directionsById.get(directionId);
+    if (!direction) return;
+
+    visibleDirectionIds.add(directionId);
+    addProject(direction.project_id);
+    addDirection(direction.parent_direction_id);
+    addExperiment(direction.spawned_from_experiment_id);
+  };
+
+  const addQuestion = (questionId: string | null | undefined): void => {
+    if (!questionId || visibleQuestionIds.has(questionId)) return;
+    const question = questionsById.get(questionId);
+    if (!question) return;
+
+    visibleQuestionIds.add(questionId);
+    addDirection(question.direction_id);
+  };
+
+  const addExperiment = (experimentId: string | null | undefined): void => {
+    if (!experimentId || visibleExperimentIds.has(experimentId)) return;
+    const experiment = experimentsById.get(experimentId);
+    if (!experiment) return;
+
+    visibleExperimentIds.add(experimentId);
+    addProject(experiment.project_id);
+    addDirection(experiment.direction_id);
+    addQuestion(experiment.primary_question_id);
+    addExperiment(experiment.parent_id);
+  };
+
+  for (const project of projects) {
+    if (isVisibleAt(project.created_at, cutoff)) addProject(project.id);
+  }
+  for (const direction of directions) {
+    if (isVisibleAt(direction.created_at, cutoff)) addDirection(direction.id);
+  }
+  for (const question of questions) {
+    if (isVisibleAt(question.created_at, cutoff)) addQuestion(question.id);
+  }
+  for (const experiment of experiments) {
+    if (isVisibleAt(experiment.created_at, cutoff)) addExperiment(experiment.id);
+  }
+  for (const finding of findings) {
+    if (!isVisibleAt(finding.created_at, cutoff)) continue;
+    visibleFindingIds.add(finding.id);
+    for (const experimentId of finding.evidence) {
+      addExperiment(experimentId);
+    }
+  }
+
+  return {
+    projects: projects.filter((project) => visibleProjectIds.has(project.id)),
+    directions: directions.filter((direction) =>
+      visibleDirectionIds.has(direction.id),
+    ),
+    questions: questions.filter((question) => visibleQuestionIds.has(question.id)),
+    experiments: experiments.filter((experiment) =>
+      visibleExperimentIds.has(experiment.id),
+    ),
+    findings: findings.filter((finding) => visibleFindingIds.has(finding.id)),
+  };
+}

--- a/ui/src/routes/pages/tree-page.tsx
+++ b/ui/src/routes/pages/tree-page.tsx
@@ -20,6 +20,7 @@ import {
   ResearchTree,
   type TreeNavigateTarget,
 } from "@/components/visualizations/research-tree";
+import { buildTimelineVisibleTreeData } from "@/lib/tree-timeline-visibility";
 import { formatDateTimeShort } from "@/lib/utils";
 import { Pause, Play } from "lucide-react";
 import type {
@@ -72,11 +73,6 @@ function buildTimelineEvents(
     .sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
 
   return all.map((at) => ({ at, label: formatDateTimeShort(at) }));
-}
-
-function isVisibleAt(createdAt: string, cutoff: string | null): boolean {
-  if (!cutoff) return true;
-  return new Date(createdAt).getTime() <= new Date(cutoff).getTime();
 }
 
 export default function TreePage() {
@@ -146,41 +142,24 @@ export default function TreePage() {
   const timelineSpeed =
     TIMELINE_SPEEDS[timelineSpeedIndex] ?? TIMELINE_SPEEDS[1];
 
-  const visibleProjects = useMemo(
+  const visibleTreeData = useMemo(
     () =>
-      (projects ?? []).filter((item) =>
-        isVisibleAt(item.created_at, timelineCutoff),
-      ),
-    [projects, timelineCutoff],
+      buildTimelineVisibleTreeData({
+        projects: projects ?? [],
+        directions: directions ?? [],
+        questions: questions ?? [],
+        experiments: experiments ?? [],
+        findings: findings ?? [],
+        cutoff: timelineCutoff,
+      }),
+    [projects, directions, questions, experiments, findings, timelineCutoff],
   );
-  const visibleDirections = useMemo(
-    () =>
-      (directions ?? []).filter((item) =>
-        isVisibleAt(item.created_at, timelineCutoff),
-      ),
-    [directions, timelineCutoff],
-  );
-  const visibleExperiments = useMemo(
-    () =>
-      (experiments ?? []).filter((item) =>
-        isVisibleAt(item.created_at, timelineCutoff),
-      ),
-    [experiments, timelineCutoff],
-  );
-  const visibleQuestions = useMemo(
-    () =>
-      (questions ?? []).filter((item) =>
-        isVisibleAt(item.created_at, timelineCutoff),
-      ),
-    [questions, timelineCutoff],
-  );
-  const visibleFindings = useMemo(
-    () =>
-      (findings ?? []).filter((item) =>
-        isVisibleAt(item.created_at, timelineCutoff),
-      ),
-    [findings, timelineCutoff],
-  );
+
+  const visibleProjects = visibleTreeData.projects;
+  const visibleDirections = visibleTreeData.directions;
+  const visibleQuestions = visibleTreeData.questions;
+  const visibleExperiments = visibleTreeData.experiments;
+  const visibleFindings = visibleTreeData.findings;
 
   const handleNodeClick = useCallback(
     (id: string) => {
@@ -395,7 +374,7 @@ export default function TreePage() {
               projects={visibleProjects}
               findings={visibleFindings}
               questions={visibleQuestions}
-              expansionResetKey={timelineCutoff}
+              expansionResetKey={activeProgram}
               onNavigate={handleTreeNavigate}
             />
           ) : (


### PR DESCRIPTION
## Summary

Branch rolls up a stack of home-surface visualization work plus a few ops-adjacent fixes:

- **Home-page background redesign** — Replace artifact-pill scatter with a dispatcher for experiment + project cards in a 16-slot ring layout around the chat bubble (pairwise collision-avoided). New `CanvasExperimentCard` and `CanvasProjectCard`. Currently gated off via `CARDS_VISIBLE = false` pending visual iteration; all scaffolding (feed hook, layout math, components) remains wired up so re-enable is a single-line flip.
- **Hierarchy overlay removed** from the home background.
- **Command palette** — larger default size, draggable edges + corner, size persisted to localStorage, bigger result typography.
- **Smarter `search_all` RPC** — new migration (`20260420000001_search_all_fuzzy.sql`) upgrades the parser to `websearch_to_tsquery`, weights fields with `setweight` / `ts_rank_cd` normalization, and adds a `pg_trgm` similarity fallback so typos and partial terms surface candidates.
- **PDF preview** (project reports, artifact gallery) — expand/collapse toggle so the viewer can take over most of the viewport; no more cut-off reports.
- **Review card contrast** polish for the experiment-review workspace.
- **Tree timeline expansion visibility** fix with a small utility + test suite.
- **Production backup** hardening — storage-retry logic, recovery runbook at `docs/ops/production-backup-recovery.md`, and a test pass on the backup script.

## Test plan

- [ ] `cd ui && npm run build` (typecheck)
- [ ] `cd ui && npm test -- src/lib/assistant-canvas-layout.test.ts src/lib/tree-timeline-visibility.test.ts`
- [ ] `cd ui && npm run dev` — verify home page renders (empty background — cards disabled), ⌘K palette resizes and persists, search for a partial/typo term surfaces results
- [ ] Open a project with a PDF report; confirm expand/collapse works
- [ ] Open the tree view; confirm timeline expansion is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)