### PR TITLE
Add prune bulk close and focus mode

### DIFF
--- a/supabase/migrations/20260423000001_ui_prune_bulk_close.sql
+++ b/supabase/migrations/20260423000001_ui_prune_bulk_close.sql
@@ -1,0 +1,502 @@
+-- UI prune and bulk-close helpers.
+-- Powers question/finding deletion and experiment close/archive flows directly from the web UI.
+
+CREATE OR REPLACE FUNCTION public.current_actor_identity()
+RETURNS TABLE (
+    actor text,
+    actor_email text,
+    actor_name text
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    claims jsonb := auth.jwt();
+    app_meta jsonb := coalesce(claims -> 'app_metadata', '{}'::jsonb);
+    user_meta jsonb := coalesce(claims -> 'user_metadata', '{}'::jsonb);
+    caller_id uuid := auth.uid();
+    is_agent boolean := coalesce((app_meta ->> 'agent')::boolean, false);
+    actor_value text;
+    email_value text;
+    name_value text;
+BEGIN
+    IF caller_id IS NULL THEN
+        RAISE EXCEPTION 'Authentication is required'
+            USING ERRCODE = '42501';
+    END IF;
+
+    email_value := nullif(coalesce(claims ->> 'email', user_meta ->> 'email'), '');
+    name_value := nullif(coalesce(user_meta ->> 'full_name', user_meta ->> 'name'), '');
+
+    IF is_agent THEN
+        actor_value := 'agent/' || coalesce(
+            nullif(app_meta ->> 'agent_name', ''),
+            nullif(app_meta ->> 'token_name', ''),
+            nullif(claims ->> 'name', ''),
+            left(caller_id::text, 8)
+        );
+        email_value := NULL;
+    ELSE
+        IF email_value IS NULL THEN
+            actor_value := 'human/' || left(caller_id::text, 8);
+        ELSE
+            actor_value := 'human/' || split_part(email_value, '@', 1);
+        END IF;
+    END IF;
+
+    RETURN QUERY
+    SELECT actor_value, email_value, name_value;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.bulk_delete_questions(target_ids text[])
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    actor_value text;
+    actor_email_value text;
+    actor_name_value text;
+    target_id text;
+    requested_count integer := 0;
+    applied_count integer := 0;
+    skipped_count integer := 0;
+    applied jsonb := '[]'::jsonb;
+    skipped jsonb := '[]'::jsonb;
+    question_row public.questions%ROWTYPE;
+BEGIN
+    SELECT actor, actor_email, actor_name
+    INTO actor_value, actor_email_value, actor_name_value
+    FROM public.current_actor_identity();
+
+    FOR target_id IN
+        SELECT DISTINCT upper(btrim(value))
+        FROM unnest(coalesce(target_ids, ARRAY[]::text[])) AS value
+        WHERE nullif(btrim(value), '') IS NOT NULL
+        ORDER BY 1
+    LOOP
+        requested_count := requested_count + 1;
+
+        BEGIN
+            SELECT *
+            INTO question_row
+            FROM public.questions
+            WHERE id = target_id;
+
+            IF NOT FOUND THEN
+                skipped_count := skipped_count + 1;
+                skipped := skipped || jsonb_build_array(
+                    jsonb_build_object(
+                        'id', target_id,
+                        'reason', 'not_found',
+                        'message', 'Question not found.'
+                    )
+                );
+                CONTINUE;
+            END IF;
+
+            IF NOT public.can_access_record(target_id, 'question') THEN
+                skipped_count := skipped_count + 1;
+                skipped := skipped || jsonb_build_array(
+                    jsonb_build_object(
+                        'id', target_id,
+                        'reason', 'access_denied',
+                        'message', 'You do not have access to this question.'
+                    )
+                );
+                CONTINUE;
+            END IF;
+
+            INSERT INTO public.activity_log (
+                record_id,
+                record_type,
+                action,
+                actor,
+                actor_email,
+                actor_name,
+                details
+            )
+            VALUES (
+                target_id,
+                'question',
+                'deleted',
+                actor_value,
+                actor_email_value,
+                actor_name_value,
+                jsonb_build_object('deleted_by', actor_value)
+            );
+
+            DELETE FROM public.questions
+            WHERE id = target_id;
+
+            applied_count := applied_count + 1;
+            applied := applied || jsonb_build_array(
+                jsonb_build_object('id', target_id)
+            );
+        EXCEPTION
+            WHEN OTHERS THEN
+                skipped_count := skipped_count + 1;
+                skipped := skipped || jsonb_build_array(
+                    jsonb_build_object(
+                        'id', target_id,
+                        'reason', 'delete_failed',
+                        'message', SQLERRM
+                    )
+                );
+        END;
+    END LOOP;
+
+    RETURN jsonb_build_object(
+        'applied', applied,
+        'skipped', skipped,
+        'summary', jsonb_build_object(
+            'requested', requested_count,
+            'applied', applied_count,
+            'skipped', skipped_count
+        )
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.bulk_delete_findings(target_ids text[])
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    actor_value text;
+    actor_email_value text;
+    actor_name_value text;
+    target_id text;
+    requested_count integer := 0;
+    applied_count integer := 0;
+    skipped_count integer := 0;
+    applied jsonb := '[]'::jsonb;
+    skipped jsonb := '[]'::jsonb;
+    finding_row public.findings%ROWTYPE;
+    artifact_count integer := 0;
+BEGIN
+    SELECT actor, actor_email, actor_name
+    INTO actor_value, actor_email_value, actor_name_value
+    FROM public.current_actor_identity();
+
+    FOR target_id IN
+        SELECT DISTINCT upper(btrim(value))
+        FROM unnest(coalesce(target_ids, ARRAY[]::text[])) AS value
+        WHERE nullif(btrim(value), '') IS NOT NULL
+        ORDER BY 1
+    LOOP
+        requested_count := requested_count + 1;
+
+        BEGIN
+            SELECT *
+            INTO finding_row
+            FROM public.findings
+            WHERE id = target_id;
+
+            IF NOT FOUND THEN
+                skipped_count := skipped_count + 1;
+                skipped := skipped || jsonb_build_array(
+                    jsonb_build_object(
+                        'id', target_id,
+                        'reason', 'not_found',
+                        'message', 'Finding not found.'
+                    )
+                );
+                CONTINUE;
+            END IF;
+
+            IF NOT public.can_access_record(target_id, 'finding') THEN
+                skipped_count := skipped_count + 1;
+                skipped := skipped || jsonb_build_array(
+                    jsonb_build_object(
+                        'id', target_id,
+                        'reason', 'access_denied',
+                        'message', 'You do not have access to this finding.'
+                    )
+                );
+                CONTINUE;
+            END IF;
+
+            IF finding_row.supersedes IS NOT NULL AND finding_row.superseded_by IS NOT NULL THEN
+                UPDATE public.findings
+                SET superseded_by = finding_row.superseded_by
+                WHERE id = finding_row.supersedes;
+
+                UPDATE public.findings
+                SET supersedes = finding_row.supersedes
+                WHERE id = finding_row.superseded_by;
+            ELSIF finding_row.supersedes IS NOT NULL THEN
+                UPDATE public.findings
+                SET superseded_by = NULL,
+                    valid_until = NULL
+                WHERE id = finding_row.supersedes;
+            ELSIF finding_row.superseded_by IS NOT NULL THEN
+                UPDATE public.findings
+                SET supersedes = NULL
+                WHERE id = finding_row.superseded_by;
+            END IF;
+
+            WITH deleted_artifacts AS (
+                DELETE FROM public.artifacts
+                WHERE finding_id = target_id
+                RETURNING id
+            )
+            SELECT count(*)
+            INTO artifact_count
+            FROM deleted_artifacts;
+
+            DELETE FROM public.findings
+            WHERE id = target_id;
+
+            INSERT INTO public.activity_log (
+                record_id,
+                record_type,
+                action,
+                actor,
+                actor_email,
+                actor_name,
+                details
+            )
+            VALUES (
+                target_id,
+                'finding',
+                'deleted',
+                actor_value,
+                actor_email_value,
+                actor_name_value,
+                jsonb_build_object(
+                    'deleted_by', actor_value,
+                    'artifact_count', artifact_count,
+                    'supersedes', finding_row.supersedes,
+                    'superseded_by', finding_row.superseded_by
+                )
+            );
+
+            applied_count := applied_count + 1;
+            applied := applied || jsonb_build_array(
+                jsonb_build_object(
+                    'id', target_id,
+                    'artifact_count', artifact_count,
+                    'supersedes', finding_row.supersedes,
+                    'superseded_by', finding_row.superseded_by
+                )
+            );
+        EXCEPTION
+            WHEN OTHERS THEN
+                skipped_count := skipped_count + 1;
+                skipped := skipped || jsonb_build_array(
+                    jsonb_build_object(
+                        'id', target_id,
+                        'reason', 'delete_failed',
+                        'message', SQLERRM
+                    )
+                );
+        END;
+    END LOOP;
+
+    RETURN jsonb_build_object(
+        'applied', applied,
+        'skipped', skipped,
+        'summary', jsonb_build_object(
+            'requested', requested_count,
+            'applied', applied_count,
+            'skipped', skipped_count
+        )
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.bulk_transition_experiments(
+    target_ids text[],
+    target_status text,
+    origin text DEFAULT 'ui_prune'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    actor_value text;
+    actor_email_value text;
+    actor_name_value text;
+    target_id text;
+    requested_count integer := 0;
+    applied_count integer := 0;
+    skipped_count integer := 0;
+    applied jsonb := '[]'::jsonb;
+    skipped jsonb := '[]'::jsonb;
+    experiment_row public.experiments%ROWTYPE;
+    resolved_origin text := nullif(btrim(coalesce(origin, '')), '');
+BEGIN
+    IF target_status NOT IN ('complete', 'failed', 'superseded') THEN
+        RAISE EXCEPTION 'Unsupported experiment target status: %', target_status
+            USING ERRCODE = '22023';
+    END IF;
+
+    IF resolved_origin IS NULL THEN
+        resolved_origin := 'ui_prune';
+    END IF;
+
+    SELECT actor, actor_email, actor_name
+    INTO actor_value, actor_email_value, actor_name_value
+    FROM public.current_actor_identity();
+
+    FOR target_id IN
+        SELECT DISTINCT upper(btrim(value))
+        FROM unnest(coalesce(target_ids, ARRAY[]::text[])) AS value
+        WHERE nullif(btrim(value), '') IS NOT NULL
+        ORDER BY 1
+    LOOP
+        requested_count := requested_count + 1;
+
+        BEGIN
+            SELECT *
+            INTO experiment_row
+            FROM public.experiments
+            WHERE id = target_id;
+
+            IF NOT FOUND THEN
+                skipped_count := skipped_count + 1;
+                skipped := skipped || jsonb_build_array(
+                    jsonb_build_object(
+                        'id', target_id,
+                        'reason', 'not_found',
+                        'message', 'Experiment not found.'
+                    )
+                );
+                CONTINUE;
+            END IF;
+
+            IF NOT public.can_access_record(target_id, 'experiment') THEN
+                skipped_count := skipped_count + 1;
+                skipped := skipped || jsonb_build_array(
+                    jsonb_build_object(
+                        'id', target_id,
+                        'reason', 'access_denied',
+                        'message', 'You do not have access to this experiment.',
+                        'current_status', experiment_row.status
+                    )
+                );
+                CONTINUE;
+            END IF;
+
+            IF experiment_row.status = target_status THEN
+                skipped_count := skipped_count + 1;
+                skipped := skipped || jsonb_build_array(
+                    jsonb_build_object(
+                        'id', target_id,
+                        'reason', 'already_target',
+                        'message', 'Experiment already has the requested status.',
+                        'current_status', experiment_row.status
+                    )
+                );
+                CONTINUE;
+            END IF;
+
+            IF target_status IN ('complete', 'failed')
+               AND experiment_row.status NOT IN ('open', 'running') THEN
+                skipped_count := skipped_count + 1;
+                skipped := skipped || jsonb_build_array(
+                    jsonb_build_object(
+                        'id', target_id,
+                        'reason', 'ineligible_status',
+                        'message', 'Only open or running experiments can be marked complete or failed.',
+                        'current_status', experiment_row.status
+                    )
+                );
+                CONTINUE;
+            END IF;
+
+            IF target_status = 'superseded'
+               AND experiment_row.status NOT IN ('complete', 'failed') THEN
+                skipped_count := skipped_count + 1;
+                skipped := skipped || jsonb_build_array(
+                    jsonb_build_object(
+                        'id', target_id,
+                        'reason', 'ineligible_status',
+                        'message', 'Only complete or failed experiments can be archived.',
+                        'current_status', experiment_row.status
+                    )
+                );
+                CONTINUE;
+            END IF;
+
+            UPDATE public.experiments
+            SET status = target_status,
+                claimed_by = NULL,
+                claimed_at = NULL
+            WHERE id = target_id;
+
+            INSERT INTO public.activity_log (
+                record_id,
+                record_type,
+                action,
+                actor,
+                actor_email,
+                actor_name,
+                details
+            )
+            VALUES (
+                target_id,
+                'experiment',
+                'status_changed',
+                actor_value,
+                actor_email_value,
+                actor_name_value,
+                jsonb_build_object(
+                    'from', experiment_row.status,
+                    'to', target_status,
+                    'origin', resolved_origin
+                )
+            );
+
+            applied_count := applied_count + 1;
+            applied := applied || jsonb_build_array(
+                jsonb_build_object(
+                    'id', target_id,
+                    'from', experiment_row.status,
+                    'to', target_status
+                )
+            );
+        EXCEPTION
+            WHEN OTHERS THEN
+                skipped_count := skipped_count + 1;
+                skipped := skipped || jsonb_build_array(
+                    jsonb_build_object(
+                        'id', target_id,
+                        'reason', 'transition_failed',
+                        'message', SQLERRM,
+                        'current_status', experiment_row.status
+                    )
+                );
+        END;
+    END LOOP;
+
+    RETURN jsonb_build_object(
+        'applied', applied,
+        'skipped', skipped,
+        'summary', jsonb_build_object(
+            'requested', requested_count,
+            'applied', applied_count,
+            'skipped', skipped_count
+        )
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.current_actor_identity() FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.bulk_delete_questions(text[]) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.bulk_delete_findings(text[]) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.bulk_transition_experiments(text[], text, text) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.current_actor_identity() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.bulk_delete_questions(text[]) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.bulk_delete_findings(text[]) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.bulk_transition_experiments(text[], text, text) TO authenticated;

--- a/ui/src/components/prune/prune-action-bar.tsx
+++ b/ui/src/components/prune/prune-action-bar.tsx
@@ -1,0 +1,103 @@
+import { Button } from "@/components/ui/button";
+import { experimentActionButtonLabel } from "@/lib/prune-actions";
+import type { BulkActionIntent } from "@/lib/prune-actions";
+import type { PruneSelection } from "@/types/sonde";
+
+interface PruneActionBarProps {
+  selection: PruneSelection;
+  eligibleExperimentCounts: Record<"complete" | "failed" | "superseded", number>;
+  onAction: (intent: BulkActionIntent) => void;
+  onClear: () => void;
+  onExit: () => void;
+}
+
+export function PruneActionBar({
+  selection,
+  eligibleExperimentCounts,
+  onAction,
+  onClear,
+  onExit,
+}: PruneActionBarProps) {
+  const totalSelected =
+    selection.questions.length +
+    selection.findings.length +
+    selection.experiments.length;
+
+  if (totalSelected === 0) return null;
+
+  return (
+    <div className="sticky bottom-4 z-20 mt-3">
+      <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-3 rounded-[14px] border border-border bg-surface px-4 py-3 shadow-[0_18px_50px_rgba(0,0,0,0.18)]">
+        <div>
+          <p className="text-[12px] font-medium text-text">
+            {totalSelected} selected
+          </p>
+          <p className="mt-1 text-[11px] text-text-quaternary">
+            {selection.questions.length} questions · {selection.findings.length} findings ·{" "}
+            {selection.experiments.length} experiments
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {selection.questions.length > 0 ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              onClick={() => onAction({ kind: "question", action: "delete" })}
+            >
+              Delete questions
+            </Button>
+          ) : null}
+          {selection.findings.length > 0 ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              onClick={() => onAction({ kind: "finding", action: "delete" })}
+            >
+              Delete findings
+            </Button>
+          ) : null}
+          {selection.experiments.length > 0 ? (
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => onAction({ kind: "experiment", action: "complete" })}
+              disabled={eligibleExperimentCounts.complete === 0}
+            >
+              {experimentActionButtonLabel("complete")}
+            </Button>
+          ) : null}
+          {selection.experiments.length > 0 ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={() => onAction({ kind: "experiment", action: "failed" })}
+              disabled={eligibleExperimentCounts.failed === 0}
+            >
+              {experimentActionButtonLabel("failed")}
+            </Button>
+          ) : null}
+          {selection.experiments.length > 0 ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={() => onAction({ kind: "experiment", action: "superseded" })}
+              disabled={eligibleExperimentCounts.superseded === 0}
+            >
+              {experimentActionButtonLabel("superseded")}
+            </Button>
+          ) : null}
+          <Button type="button" size="sm" variant="ghost" onClick={onClear}>
+            Clear
+          </Button>
+          <Button type="button" size="sm" variant="ghost" onClick={onExit}>
+            Exit manage mode
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/prune/prune-confirm-dialog.tsx
+++ b/ui/src/components/prune/prune-confirm-dialog.tsx
@@ -1,0 +1,149 @@
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+import { experimentActionButtonLabel, isDeleteAction } from "@/lib/prune-actions";
+import type {
+  BulkActionPreview,
+  ExperimentPruneAction,
+  PruneAction,
+  PruneableRecordKind,
+} from "@/types/sonde";
+
+interface PruneConfirmDialogProps {
+  open: boolean;
+  kind: PruneableRecordKind;
+  action: PruneAction;
+  title: string;
+  description: string;
+  preview: BulkActionPreview;
+  onClose: () => void;
+  onConfirm: () => void;
+  isPending?: boolean;
+}
+
+function confirmLabel(action: PruneAction): string {
+  if (isDeleteAction(action)) return "Delete selected";
+  return experimentActionButtonLabel(action as ExperimentPruneAction);
+}
+
+export function PruneConfirmDialog({
+  open,
+  kind,
+  action,
+  title,
+  description,
+  preview,
+  onClose,
+  onConfirm,
+  isPending = false,
+}: PruneConfirmDialogProps) {
+  const totalSelected = preview.eligibleIds.length + preview.skipped.length;
+  const sampleIds =
+    preview.sampleIds.length > 0
+      ? preview.sampleIds
+      : preview.skipped.slice(0, 6).map((item) => item.id);
+
+  return (
+    <Dialog
+      open={open}
+      title={title}
+      description={description}
+      onClose={isPending ? () => {} : onClose}
+      footer={
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-[11px] text-text-quaternary">
+            {preview.eligibleIds.length} eligible
+            {preview.skipped.length > 0
+              ? ` · ${preview.skipped.length} skipped in preview`
+              : ""}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onClose}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant={isDeleteAction(action) ? "destructive" : "default"}
+              onClick={onConfirm}
+              disabled={isPending || preview.eligibleIds.length === 0}
+            >
+              {isPending ? "Working..." : confirmLabel(action)}
+            </Button>
+          </div>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        <div className="rounded-[10px] border border-border-subtle bg-surface-raised px-3 py-3">
+          <div className="flex flex-wrap items-center gap-2 text-[12px] text-text-secondary">
+            <span className="font-medium text-text">
+              {totalSelected} {kind}
+              {totalSelected === 1 ? "" : "s"} selected
+            </span>
+            <span className="text-text-quaternary">·</span>
+            <span>{preview.eligibleIds.length} ready to apply</span>
+          </div>
+          {isDeleteAction(action) ? (
+            <p className="mt-2 text-[12px] leading-relaxed text-text-secondary">
+              This permanently removes the selected records from the UI and
+              activity history will keep the audit trail.
+            </p>
+          ) : action === "superseded" ? (
+            <p className="mt-2 text-[12px] leading-relaxed text-text-secondary">
+              Archive keeps the experiment record but moves it to the superseded
+              state.
+            </p>
+          ) : (
+            <p className="mt-2 text-[12px] leading-relaxed text-text-secondary">
+              Closing experiments clears any active claim and records a status
+              change in the activity log.
+            </p>
+          )}
+        </div>
+
+        {sampleIds.length > 0 ? (
+          <div>
+            <p className="text-[12px] font-medium text-text-secondary">
+              Sample IDs
+            </p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {sampleIds.map((id) => (
+                <span
+                  key={id}
+                  className="rounded-[999px] border border-border-subtle bg-surface-raised px-2 py-1 font-mono text-[11px] text-text-secondary"
+                >
+                  {id}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {preview.skipped.length > 0 ? (
+          <div>
+            <p className="text-[12px] font-medium text-text-secondary">
+              Skipped in preview
+            </p>
+            <div className="mt-2 space-y-2 rounded-[10px] border border-border-subtle bg-bg px-3 py-3">
+              {preview.skipped.map((item) => (
+                <div key={`${item.id}-${item.reason}`}>
+                  <p className="font-mono text-[11px] text-text">{item.id}</p>
+                  <p className="text-[11px] leading-relaxed text-text-quaternary">
+                    {item.message}
+                    {item.current_status
+                      ? ` Current status: ${item.current_status}.`
+                      : ""}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </Dialog>
+  );
+}

--- a/ui/src/components/shared/focus-toggle.tsx
+++ b/ui/src/components/shared/focus-toggle.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from "react";
+import { Tooltip } from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const ACTIVE_BRAILLE_FRAMES = ["⠂", "⠒", "⠶", "⠷", "⠿"] as const;
+const INACTIVE_BRAILLE_FRAMES = [...ACTIVE_BRAILLE_FRAMES].reverse();
+
+interface FocusToggleProps {
+  enabled: boolean;
+  canFocus: boolean;
+  description: string;
+  disabledReason?: string | null;
+  onToggle: () => void;
+  className?: string;
+  compact?: boolean;
+}
+
+export function FocusToggle({
+  enabled,
+  canFocus,
+  description,
+  disabledReason,
+  onToggle,
+  className,
+  compact = false,
+}: FocusToggleProps) {
+  const helperText = canFocus ? description : disabledReason ?? description;
+  const buttonLabel = enabled ? "Focused" : "Focus";
+  const [brailleGlyph, setBrailleGlyph] = useState(
+    enabled
+      ? ACTIVE_BRAILLE_FRAMES[ACTIVE_BRAILLE_FRAMES.length - 1]
+      : ACTIVE_BRAILLE_FRAMES[0],
+  );
+
+  useEffect(() => {
+    if (typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      setBrailleGlyph(
+        enabled
+          ? ACTIVE_BRAILLE_FRAMES[ACTIVE_BRAILLE_FRAMES.length - 1]
+          : ACTIVE_BRAILLE_FRAMES[0],
+      );
+      return;
+    }
+
+    const frames = enabled ? ACTIVE_BRAILLE_FRAMES : INACTIVE_BRAILLE_FRAMES;
+    let nextFrameIndex = 0;
+    setBrailleGlyph(frames[0]);
+
+    const animation = window.setInterval(() => {
+      nextFrameIndex += 1;
+      if (nextFrameIndex >= frames.length) {
+        window.clearInterval(animation);
+        return;
+      }
+      setBrailleGlyph(frames[nextFrameIndex]);
+    }, 65);
+
+    return () => window.clearInterval(animation);
+  }, [enabled]);
+
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 items-center",
+        compact ? "justify-start" : "justify-end",
+        className,
+      )}
+    >
+      <Tooltip
+        content={
+          <div className="space-y-1">
+            <p className="font-medium text-text">Focus mode</p>
+            <p>{helperText}</p>
+            <p className="text-text-quaternary">
+              {enabled ? "Currently on." : "Currently off."}
+            </p>
+          </div>
+        }
+        side="bottom"
+      >
+        <span className="inline-flex">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={onToggle}
+            disabled={!canFocus}
+            aria-pressed={enabled}
+            aria-label={`${buttonLabel}. ${helperText}`}
+            className={cn(
+              "group h-8 rounded-full border px-2 py-0 leading-none shadow-sm transition-all duration-150",
+              enabled
+                ? "border-accent/35 bg-[linear-gradient(135deg,color-mix(in_srgb,var(--color-accent)_18%,var(--color-surface-raised)),color-mix(in_srgb,var(--color-bg)_72%,var(--color-accent)_8%))] text-text hover:border-accent/55 hover:bg-[linear-gradient(135deg,color-mix(in_srgb,var(--color-accent)_24%,var(--color-surface-raised)),color-mix(in_srgb,var(--color-bg)_66%,var(--color-accent)_12%))] shadow-[0_8px_20px_-12px_color-mix(in_srgb,var(--color-accent)_55%,transparent)]"
+                : "border-border-subtle bg-surface-raised/90 text-text-secondary hover:border-border hover:bg-surface-hover",
+            )}
+          >
+            <span className="grid min-w-0 grid-cols-[1.25rem_auto_1.25rem] items-center gap-2">
+              <span
+                className={cn(
+                  "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border transition-colors",
+                  enabled
+                    ? "border-accent/10 bg-accent text-on-accent"
+                    : "border-border-subtle bg-bg text-text-tertiary group-hover:text-text-secondary",
+                )}
+              >
+                <span
+                  aria-hidden
+                  className={cn(
+                    "font-mono text-[13px] leading-none transition-transform duration-200",
+                    enabled ? "scale-105" : "scale-100",
+                  )}
+                >
+                  {brailleGlyph}
+                </span>
+              </span>
+              <span className="flex h-5 min-w-0 items-center justify-center px-0.5 text-center text-[12px] leading-none tracking-[-0.01em]">
+                {buttonLabel}
+              </span>
+              <span
+                className={cn(
+                  "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border transition-all",
+                  enabled
+                    ? "border-status-complete/20 bg-status-complete/10"
+                    : "border-border-subtle bg-bg/80",
+                )}
+                aria-hidden
+              >
+                <span
+                  className={cn(
+                    "h-2.5 w-2.5 rounded-full transition-all",
+                    enabled
+                      ? "bg-status-complete shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-status-complete)_20%,transparent)]"
+                      : "bg-border-subtle group-hover:bg-text-quaternary",
+                  )}
+                />
+              </span>
+            </span>
+          </Button>
+        </span>
+      </Tooltip>
+    </div>
+  );
+}

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -1,0 +1,132 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface DialogProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  children?: ReactNode;
+  footer?: ReactNode;
+  onClose: () => void;
+  size?: "md" | "lg";
+}
+
+const sizeClassName = {
+  md: "max-w-xl",
+  lg: "max-w-2xl",
+} as const;
+
+export function Dialog({
+  open,
+  title,
+  description,
+  children,
+  footer,
+  onClose,
+  size = "md",
+}: DialogProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const mounted = useMemo(
+    () => typeof window !== "undefined" && typeof document !== "undefined",
+    [],
+  );
+
+  useEffect(() => {
+    if (!open || !mounted) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.requestAnimationFrame(() => {
+      const focusable = panelRef.current?.querySelector<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      (focusable ?? panelRef.current)?.focus();
+    });
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [mounted, onClose, open]);
+
+  if (!open || !mounted) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[120] flex items-center justify-center p-4">
+      <button
+        type="button"
+        aria-label="Close dialog"
+        className="absolute inset-0 bg-bg/70 backdrop-blur-[2px]"
+        onClick={onClose}
+      />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={description ? descriptionId : undefined}
+        tabIndex={-1}
+        className={cn(
+          "relative z-[1] flex max-h-[85vh] w-full flex-col overflow-hidden rounded-[14px] border border-border bg-surface shadow-[0_24px_80px_rgba(0,0,0,0.28)] outline-none",
+          sizeClassName[size],
+        )}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-border px-5 py-4">
+          <div className="space-y-1">
+            <h2
+              id={titleId}
+              className="text-[15px] font-semibold tracking-[-0.015em] text-text"
+            >
+              {title}
+            </h2>
+            {description ? (
+              <p
+                id={descriptionId}
+                className="max-w-[62ch] text-[12px] leading-relaxed text-text-secondary"
+              >
+                {description}
+              </p>
+            ) : null}
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Close dialog"
+            onClick={onClose}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">{children}</div>
+        {footer ? (
+          <div className="border-t border-border bg-surface-raised px-5 py-3">
+            {footer}
+          </div>
+        ) : null}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/ui/src/components/visualizations/experiment-graph.tsx
+++ b/ui/src/components/visualizations/experiment-graph.tsx
@@ -16,6 +16,7 @@ import type {
   DirectionSummary,
   ExperimentSummary,
   Finding,
+  PruneSelection,
   ProjectSummary,
   QuestionSummary,
 } from "@/types/sonde";
@@ -29,6 +30,7 @@ import {
   type HandlerFactories,
 } from "./experiment-graph/graph-builder";
 import { nodeTypes } from "./experiment-graph/node-types";
+import type { FocusReasonMaps } from "@/lib/focus-mode";
 
 /**
  * MiniMap iterates every node on every viewport change and renders a
@@ -81,6 +83,13 @@ interface ExperimentGraphProps {
   onProjectNavigate?: (projectId: string) => void;
   onDirectionNavigate?: (directionId: string) => void;
   onFindingNavigate?: (findingId: string) => void;
+  manageMode?: boolean;
+  selection?: PruneSelection;
+  focusMode?: boolean;
+  focusReasons?: FocusReasonMaps | null;
+  onToggleQuestionSelection?: (questionId: string) => void;
+  onToggleExperimentSelection?: (experimentId: string) => void;
+  onToggleFindingSelection?: (findingId: string) => void;
 }
 
 export const ExperimentGraph = memo(function ExperimentGraph({
@@ -94,6 +103,13 @@ export const ExperimentGraph = memo(function ExperimentGraph({
   onProjectNavigate,
   onDirectionNavigate,
   onFindingNavigate,
+  manageMode = false,
+  selection = { questions: [], findings: [], experiments: [] },
+  focusMode = false,
+  focusReasons = null,
+  onToggleQuestionSelection,
+  onToggleExperimentSelection,
+  onToggleFindingSelection,
 }: ExperimentGraphProps) {
   const colors = useThemeCssColors();
   const statusColor = useStatusChartColors();
@@ -185,6 +201,9 @@ export const ExperimentGraph = memo(function ExperimentGraph({
   const openDirectionFor = useIdKeyedCallback(onDirectionNavigate);
   const openFindingFor = useIdKeyedCallback(onFindingNavigate);
   const openProjectFor = useIdKeyedCallback(onProjectNavigate);
+  const selectQuestionFor = useIdKeyedCallback(onToggleQuestionSelection);
+  const selectExperimentFor = useIdKeyedCallback(onToggleExperimentSelection);
+  const selectFindingFor = useIdKeyedCallback(onToggleFindingSelection);
 
   const handlers = useMemo<HandlerFactories>(
     () => ({
@@ -194,6 +213,9 @@ export const ExperimentGraph = memo(function ExperimentGraph({
       openDirectionFor,
       openFindingFor,
       openProjectFor,
+      selectExperimentFor,
+      selectQuestionFor,
+      selectFindingFor,
     }),
     [
       toggleFor,
@@ -202,6 +224,9 @@ export const ExperimentGraph = memo(function ExperimentGraph({
       openDirectionFor,
       openFindingFor,
       openProjectFor,
+      selectExperimentFor,
+      selectQuestionFor,
+      selectFindingFor,
     ],
   );
 
@@ -224,6 +249,12 @@ export const ExperimentGraph = memo(function ExperimentGraph({
           borderColor: colors.border,
           projectEdgeColor: colors.textTertiary,
           knownProjectIds,
+          manageMode,
+          focusMode,
+          focusReasons,
+          selectedExperimentIds: new Set(selection.experiments),
+          selectedQuestionIds: new Set(selection.questions),
+          selectedFindingIds: new Set(selection.findings),
         }),
       [
         projects,
@@ -237,6 +268,12 @@ export const ExperimentGraph = memo(function ExperimentGraph({
         colors.border,
         colors.textTertiary,
         handlers,
+        manageMode,
+        focusMode,
+        focusReasons,
+        selection.experiments,
+        selection.findings,
+        selection.questions,
       ],
     );
 

--- a/ui/src/components/visualizations/experiment-graph/graph-builder.test.ts
+++ b/ui/src/components/visualizations/experiment-graph/graph-builder.test.ts
@@ -19,6 +19,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { emptyFocusReasonMaps } from "@/lib/focus-mode";
 
 import type {
   DirectionSummary,
@@ -53,6 +54,9 @@ function makeStableHandlers(): HandlerFactories {
     direction: new Map<string, () => void>(),
     finding: new Map<string, () => void>(),
     project: new Map<string, () => void>(),
+    selectExperiment: new Map<string, () => void>(),
+    selectQuestion: new Map<string, () => void>(),
+    selectFinding: new Map<string, () => void>(),
   };
   const factory = (cache: Map<string, () => void>) => (id: string) => {
     const cached = cache.get(id);
@@ -68,6 +72,9 @@ function makeStableHandlers(): HandlerFactories {
     openDirectionFor: factory(caches.direction),
     openFindingFor: factory(caches.finding),
     openProjectFor: factory(caches.project),
+    selectExperimentFor: factory(caches.selectExperiment),
+    selectQuestionFor: factory(caches.selectQuestion),
+    selectFindingFor: factory(caches.selectFinding),
   };
 }
 
@@ -305,6 +312,37 @@ describe("buildExperimentGraph: no orphan edges", () => {
       expect(nodeIds.has(edge.target)).toBe(true);
     }
     expect(out.droppedOrphanEdges).toBe(0);
+  });
+});
+
+describe("buildExperimentGraph: focus mode", () => {
+  it("marks context nodes as muted and non-selectable", () => {
+    const focusReasons = emptyFocusReasonMaps();
+    focusReasons.projects.set("proj-1", "context");
+    focusReasons.directions.set("DIR-0001", "context");
+    focusReasons.questions.set("Q-0001", "context");
+    focusReasons.experiments.set("EXP-0001", "context");
+    focusReasons.findings.set("FIND-0001", "created");
+
+    const out = buildExperimentGraph(
+      makeRealisticInput({
+        expanded: new Set(["proj-proj-1", "dir-DIR-0001", "question-Q-0001", "EXP-0001"]),
+        focusMode: true,
+        focusReasons,
+      }),
+    );
+
+    const experimentNode = out.nodes.find((node) => node.id === "EXP-0001");
+    const questionNode = out.nodes.find((node) => node.id === "question-Q-0001");
+    const projectNode = out.nodes.find((node) => node.id === "proj-proj-1");
+    const findingNode = out.nodes.find((node) =>
+      node.id.startsWith("finding-FIND-0001"),
+    );
+
+    expect(experimentNode?.data).toMatchObject({ muted: true, selectable: false });
+    expect(questionNode?.data).toMatchObject({ muted: true, selectable: false });
+    expect(projectNode?.data).toMatchObject({ muted: true });
+    expect(findingNode?.data).toMatchObject({ muted: false, selectable: true });
   });
 });
 

--- a/ui/src/components/visualizations/experiment-graph/graph-builder.ts
+++ b/ui/src/components/visualizations/experiment-graph/graph-builder.ts
@@ -39,6 +39,10 @@
 import dagre from "@dagrejs/dagre";
 import type { Edge, Node } from "@xyflow/react";
 
+import {
+  type FocusReasonMaps,
+  isDirectFocusReason,
+} from "@/lib/focus-mode";
 import { sortFindingsByImportanceAndRecency } from "@/lib/finding-importance";
 import type {
   DirectionSummary,
@@ -122,6 +126,9 @@ export interface HandlerFactories {
   openDirectionFor: (id: string) => () => void;
   openFindingFor: (id: string) => () => void;
   openProjectFor: (id: string) => () => void;
+  selectExperimentFor: (id: string) => () => void;
+  selectQuestionFor: (id: string) => () => void;
+  selectFindingFor: (id: string) => () => void;
 }
 
 export interface BuildGraphInput {
@@ -136,6 +143,12 @@ export interface BuildGraphInput {
   borderColor: string;
   projectEdgeColor: string;
   knownProjectIds: Set<string>;
+  manageMode?: boolean;
+  focusMode?: boolean;
+  focusReasons?: FocusReasonMaps | null;
+  selectedExperimentIds?: Set<string>;
+  selectedQuestionIds?: Set<string>;
+  selectedFindingIds?: Set<string>;
 }
 
 export interface BuildGraphOutput {
@@ -501,6 +514,12 @@ interface BuildContext {
   handlers: HandlerFactories;
   statusColor: StatusColorMap;
   borderColor: string;
+  manageMode: boolean;
+  focusMode: boolean;
+  focusReasons: FocusReasonMaps | null;
+  selectedExperimentIds: Set<string>;
+  selectedQuestionIds: Set<string>;
+  selectedFindingIds: Set<string>;
 }
 
 function addExperimentSubtree(
@@ -524,6 +543,9 @@ function addExperimentSubtree(
   const hasChildren =
     children.length > 0 || spawnedDirections.length > 0 || findings.length > 0;
   const isExpanded = ctx.expanded.has(exp.id);
+  const selectable =
+    !ctx.focusMode ||
+    isDirectFocusReason(ctx.focusReasons?.experiments.get(exp.id));
 
   nodes.push({
     id: exp.id,
@@ -543,8 +565,13 @@ function addExperimentSubtree(
         findings.length,
       isExpanded,
       depth,
+      manageMode: ctx.manageMode,
+      muted: ctx.focusMode && !selectable,
+      selectable,
+      selected: ctx.selectedExperimentIds.has(exp.id),
       onToggle: hasChildren ? ctx.handlers.toggleFor(exp.id) : undefined,
       onOpen: ctx.handlers.openExperimentFor(exp.id),
+      onSelect: ctx.handlers.selectExperimentFor(exp.id),
     } as Record<string, unknown>,
     draggable: true,
   });
@@ -562,13 +589,21 @@ function addExperimentSubtree(
 
   for (const finding of findings) {
     const findingNodeId = `finding-${finding.id}-for-${exp.id}`;
+    const findingSelectable =
+      !ctx.focusMode ||
+      isDirectFocusReason(ctx.focusReasons?.findings.get(finding.id));
     nodes.push({
       id: findingNodeId,
       type: "finding",
       position: { x: 0, y: 0 },
       data: {
         ...finding,
+        manageMode: ctx.manageMode,
+        muted: ctx.focusMode && !findingSelectable,
+        selectable: findingSelectable,
+        selected: ctx.selectedFindingIds.has(finding.id),
         onOpen: ctx.handlers.openFindingFor(finding.id),
+        onSelect: ctx.handlers.selectFindingFor(finding.id),
       } as Record<string, unknown>,
       draggable: true,
     });
@@ -610,6 +645,9 @@ function addQuestionSubtree(
   const questionExperiments = ctx.experimentsByQuestion.get(question.id) ?? [];
   const questionRoots = rootExperimentsForGroup(questionExperiments);
   const findingCount = question.linked_finding_count ?? 0;
+  const selectable =
+    !ctx.focusMode ||
+    isDirectFocusReason(ctx.focusReasons?.questions.get(question.id));
 
   nodes.push({
     id: headerId,
@@ -621,8 +659,13 @@ function addQuestionSubtree(
       count: questionExperiments.length,
       findingCount,
       expanded: isExpanded,
+      manageMode: ctx.manageMode,
+      muted: ctx.focusMode && !selectable,
+      selectable,
+      selected: ctx.selectedQuestionIds.has(question.id),
       onToggle: ctx.handlers.toggleFor(headerId),
       onOpen: ctx.handlers.openQuestionFor(question.id),
+      onSelect: ctx.handlers.selectQuestionFor(question.id),
     } as Record<string, unknown>,
     draggable: true,
   });
@@ -659,6 +702,9 @@ function addDirectionSubtree(
   const directionQuestions = ctx.questionsByDirection.get(direction.id) ?? [];
   const directionRoots =
     rootUnlinkedExperimentsForDirection(directionExperiments);
+  const muted =
+    ctx.focusMode &&
+    !isDirectFocusReason(ctx.focusReasons?.directions.get(direction.id));
 
   nodes.push({
     id: headerId,
@@ -671,6 +717,7 @@ function addDirectionSubtree(
       expanded: isExpanded,
       statusCounts: countStatuses(directionExperiments),
       statusColors: ctx.statusColor,
+      muted,
       onToggle: ctx.handlers.toggleFor(headerId),
       onOpen: ctx.handlers.openDirectionFor(direction.id),
     } as Record<string, unknown>,
@@ -735,6 +782,12 @@ function buildExperimentGraphImpl(input: BuildGraphInput): BuildGraphOutput {
     borderColor,
     projectEdgeColor,
     knownProjectIds,
+    manageMode = false,
+    focusMode = false,
+    focusReasons = null,
+    selectedExperimentIds = new Set<string>(),
+    selectedQuestionIds = new Set<string>(),
+    selectedFindingIds = new Set<string>(),
   } = input;
 
   // Derive all the lookup indexes in one place, then bundle them into
@@ -764,6 +817,12 @@ function buildExperimentGraphImpl(input: BuildGraphInput): BuildGraphOutput {
     handlers,
     statusColor,
     borderColor,
+    manageMode,
+    focusMode,
+    focusReasons,
+    selectedExperimentIds,
+    selectedQuestionIds,
+    selectedFindingIds,
   };
 
   const isRoot = (e: ExperimentSummary): boolean =>
@@ -824,6 +883,12 @@ function buildExperimentGraphImpl(input: BuildGraphInput): BuildGraphOutput {
         count: allInProject.length,
         directionCount: dirsInProj.length,
         expanded: isProjExpanded,
+        muted:
+          focusMode &&
+          !(
+            p.id !== null &&
+            isDirectFocusReason(focusReasons?.projects.get(p.id))
+          ),
         onToggle: handlers.toggleFor(pid),
         onOpen: p.id === null ? undefined : handlers.openProjectFor(p.id),
       } as Record<string, unknown>,
@@ -857,6 +922,7 @@ function buildExperimentGraphImpl(input: BuildGraphInput): BuildGraphOutput {
         expanded: isNodirExpanded,
         statusCounts: countStatuses(noDirExps),
         statusColors: statusColor,
+        muted: focusMode,
         onToggle: handlers.toggleFor(nodirId),
       } as Record<string, unknown>,
       draggable: true,

--- a/ui/src/components/visualizations/experiment-graph/node-types/direction-node.tsx
+++ b/ui/src/components/visualizations/experiment-graph/node-types/direction-node.tsx
@@ -13,6 +13,7 @@ export type DirectionNodeData = {
   expanded: boolean;
   statusCounts: Record<string, number>;
   statusColors: StatusColorMap;
+  muted?: boolean;
   onToggle?: NodeAction;
   onOpen?: NodeAction;
 };
@@ -20,7 +21,11 @@ export type DirectionNodeData = {
 export function DirectionNode({ data }: NodeProps) {
   const d = data as unknown as DirectionNodeData;
   return (
-    <div className="flex w-[260px] items-center gap-2.5 rounded-[8px] border border-accent/20 bg-accent/5 px-3 py-2.5 transition-colors hover:border-accent/40">
+    <div
+      className={d.muted
+        ? "flex w-[260px] items-center gap-2.5 rounded-[8px] border border-accent/20 bg-accent/5 px-3 py-2.5 opacity-60 transition-colors hover:border-accent/40"
+        : "flex w-[260px] items-center gap-2.5 rounded-[8px] border border-accent/20 bg-accent/5 px-3 py-2.5 transition-colors hover:border-accent/40"}
+    >
       <Handle
         type="target"
         position={Position.Top}

--- a/ui/src/components/visualizations/experiment-graph/node-types/experiment-node.tsx
+++ b/ui/src/components/visualizations/experiment-graph/node-types/experiment-node.tsx
@@ -1,8 +1,15 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import { ChevronDown, ChevronRight, GitFork } from "lucide-react";
+import {
+  CheckSquare2,
+  ChevronDown,
+  ChevronRight,
+  GitFork,
+  Square,
+} from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { InlineMarkdownText } from "@/components/shared/inline-markdown-text";
+import { cn } from "@/lib/utils";
 import type { ExperimentSummary } from "@/types/sonde";
 
 import type { StatusColorMap } from "../graph-builder";
@@ -14,15 +21,26 @@ export type ExperimentNodeData = ExperimentSummary & {
   childCount: number;
   isExpanded: boolean;
   depth: number;
+  manageMode?: boolean;
+  muted?: boolean;
+  selectable?: boolean;
+  selected?: boolean;
   onToggle?: NodeAction;
   onOpen?: NodeAction;
+  onSelect?: NodeAction;
 };
 
 export function ExperimentNode({ data }: NodeProps) {
   const d = data as unknown as ExperimentNodeData;
   return (
     <div
-      className="w-[220px] rounded-[8px] border border-border bg-surface transition-shadow hover:shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-accent)_30%,transparent)]"
+      className={cn(
+        "w-[220px] rounded-[8px] border bg-surface transition-shadow hover:shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-accent)_30%,transparent)]",
+        d.selected
+          ? "border-accent shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-accent)_35%,transparent)]"
+          : "border-border",
+        d.muted && "opacity-60",
+      )}
       style={{ borderLeftWidth: 3, borderLeftColor: d.statusColors[d.status] }}
     >
       <Handle
@@ -55,12 +73,24 @@ export function ExperimentNode({ data }: NodeProps) {
             type="button"
             onClick={(event) => {
               event.stopPropagation();
+              if (d.manageMode) {
+                if (d.selectable === false) return;
+                d.onSelect?.();
+                return;
+              }
               d.onOpen?.();
             }}
             className="min-w-0 flex-1 text-left"
           >
             <div className="flex items-center justify-between gap-1">
               <div className="min-w-0 flex items-center gap-1.5">
+                {d.manageMode && d.selectable !== false ? (
+                  d.selected ? (
+                    <CheckSquare2 className="h-3.5 w-3.5 shrink-0 text-accent" />
+                  ) : (
+                    <Square className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
+                  )
+                ) : null}
                 <span className="truncate font-mono text-[11px] font-medium text-text">
                   {d.id}
                 </span>
@@ -85,6 +115,18 @@ export function ExperimentNode({ data }: NodeProps) {
               </p>
             )}
           </button>
+          {d.manageMode ? (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                d.onOpen?.();
+              }}
+              className="rounded-[4px] px-1.5 py-1 text-[10px] text-text-tertiary transition-colors hover:bg-surface-raised hover:text-text-secondary"
+            >
+              Open
+            </button>
+          ) : null}
         </div>
       </div>
       <Handle

--- a/ui/src/components/visualizations/experiment-graph/node-types/finding-node.tsx
+++ b/ui/src/components/visualizations/experiment-graph/node-types/finding-node.tsx
@@ -1,15 +1,21 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import { Lightbulb } from "lucide-react";
+import { CheckSquare2, Lightbulb, Square } from "lucide-react";
 
 import { FindingImportanceBadge } from "@/components/shared/finding-importance-badge";
 import { Badge } from "@/components/ui/badge";
 import { findingConfidenceLabel } from "@/lib/finding-confidence";
+import { cn } from "@/lib/utils";
 import type { Finding, FindingConfidence } from "@/types/sonde";
 
 import type { NodeAction } from "./types";
 
 export type FindingNodeData = Finding & {
+  manageMode?: boolean;
+  muted?: boolean;
+  selectable?: boolean;
+  selected?: boolean;
   onOpen?: NodeAction;
+  onSelect?: NodeAction;
 };
 
 /**
@@ -23,46 +29,82 @@ function confidenceVariant(confidence: FindingConfidence): FindingConfidence {
 export function FindingNode({ data }: NodeProps) {
   const d = data as unknown as FindingNodeData;
   return (
-    <div className="w-[220px] rounded-[8px] border border-border-subtle bg-surface-raised transition-shadow hover:shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-accent)_22%,transparent)]">
+    <div
+      className={cn(
+        "w-[220px] rounded-[8px] border bg-surface-raised transition-shadow hover:shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-accent)_22%,transparent)]",
+        d.selected
+          ? "border-accent bg-accent/10"
+          : "border-border-subtle",
+        d.muted && "opacity-60",
+      )}
+    >
       <Handle
         type="target"
         position={Position.Top}
         className="!h-1.5 !w-1.5 !bg-border"
       />
-      <button
-        type="button"
-        onClick={(event) => {
-          event.stopPropagation();
-          d.onOpen?.();
-        }}
-        className="flex w-full items-start gap-2 px-2.5 py-2 text-left"
-      >
-        <div className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-[4px] border border-border-subtle bg-bg text-text-tertiary">
-          <Lightbulb className="h-3 w-3" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center justify-between gap-2">
-            <span className="truncate font-mono text-[11px] font-medium text-text">
-              {d.id}
-            </span>
-            <div className="flex items-center gap-1.5">
-              <FindingImportanceBadge
-                importance={d.importance}
-                className="px-1.5 py-0.5"
-              />
-              <Badge variant={confidenceVariant(d.confidence)}>
-                {findingConfidenceLabel(d.confidence)}
-              </Badge>
-            </div>
+      <div className="px-2.5 py-2">
+        <div className="flex items-start gap-2">
+          <div className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-[4px] border border-border-subtle bg-bg text-text-tertiary">
+            <Lightbulb className="h-3 w-3" />
           </div>
-          <p className="mt-0.5 truncate text-[10px] font-medium text-text-secondary">
-            {d.topic}
-          </p>
-          <p className="mt-1 line-clamp-2 text-[10px] leading-snug text-text-tertiary">
-            {d.finding}
-          </p>
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              if (d.manageMode) {
+                if (d.selectable === false) return;
+                d.onSelect?.();
+                return;
+              }
+              d.onOpen?.();
+            }}
+            className="min-w-0 flex-1 text-left"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex min-w-0 items-center gap-1.5">
+                {d.manageMode && d.selectable !== false ? (
+                  d.selected ? (
+                    <CheckSquare2 className="h-3.5 w-3.5 shrink-0 text-accent" />
+                  ) : (
+                    <Square className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
+                  )
+                ) : null}
+                <span className="truncate font-mono text-[11px] font-medium text-text">
+                  {d.id}
+                </span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <FindingImportanceBadge
+                  importance={d.importance}
+                  className="px-1.5 py-0.5"
+                />
+                <Badge variant={confidenceVariant(d.confidence)}>
+                  {findingConfidenceLabel(d.confidence)}
+                </Badge>
+              </div>
+            </div>
+            <p className="mt-0.5 truncate text-[10px] font-medium text-text-secondary">
+              {d.topic}
+            </p>
+            <p className="mt-1 line-clamp-2 text-[10px] leading-snug text-text-tertiary">
+              {d.finding}
+            </p>
+          </button>
+          {d.manageMode ? (
+            <button
+              type="button"
+              className="rounded-[4px] px-1.5 py-1 text-[10px] text-text-tertiary transition-colors hover:bg-surface hover:text-text-secondary"
+              onClick={(event) => {
+                event.stopPropagation();
+                d.onOpen?.();
+              }}
+            >
+              Open
+            </button>
+          ) : null}
         </div>
-      </button>
+      </div>
     </div>
   );
 }

--- a/ui/src/components/visualizations/experiment-graph/node-types/project-node.tsx
+++ b/ui/src/components/visualizations/experiment-graph/node-types/project-node.tsx
@@ -9,6 +9,7 @@ export type ProjectNodeData = {
   count: number;
   expanded: boolean;
   directionCount: number;
+  muted?: boolean;
   onToggle?: NodeAction;
   onOpen?: NodeAction;
 };
@@ -16,7 +17,13 @@ export type ProjectNodeData = {
 export function ProjectNode({ data }: NodeProps) {
   const d = data as unknown as ProjectNodeData;
   return (
-    <div className="relative w-[280px] rounded-[8px] border-2 border-border bg-bg px-3 py-2.5 shadow-sm transition-colors hover:border-border-subtle">
+    <div
+      className={
+        d.muted
+          ? "relative w-[280px] rounded-[8px] border-2 border-border bg-bg px-3 py-2.5 opacity-60 shadow-sm transition-colors hover:border-border-subtle"
+          : "relative w-[280px] rounded-[8px] border-2 border-border bg-bg px-3 py-2.5 shadow-sm transition-colors hover:border-border-subtle"
+      }
+    >
       <Handle
         type="target"
         position={Position.Top}

--- a/ui/src/components/visualizations/experiment-graph/node-types/question-node.tsx
+++ b/ui/src/components/visualizations/experiment-graph/node-types/question-node.tsx
@@ -1,5 +1,12 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import { ChevronDown, ChevronRight, CircleHelp } from "lucide-react";
+import {
+  CheckSquare2,
+  ChevronDown,
+  ChevronRight,
+  CircleHelp,
+  Square,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
 
 import type { NodeAction } from "./types";
 
@@ -9,14 +16,27 @@ export type QuestionNodeData = {
   count: number;
   findingCount: number;
   expanded: boolean;
+  manageMode?: boolean;
+  muted?: boolean;
+  selectable?: boolean;
+  selected?: boolean;
   onToggle?: NodeAction;
   onOpen?: NodeAction;
+  onSelect?: NodeAction;
 };
 
 export function QuestionNode({ data }: NodeProps) {
   const d = data as unknown as QuestionNodeData;
   return (
-    <div className="flex w-[240px] items-center gap-2.5 rounded-[8px] border border-border-subtle bg-surface-raised px-3 py-2.5 transition-colors hover:border-border">
+    <div
+      className={cn(
+        "flex w-[240px] items-center gap-2.5 rounded-[8px] border px-3 py-2.5 transition-colors",
+        d.selected
+          ? "border-accent bg-accent/10 shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-accent)_28%,transparent)]"
+          : "border-border-subtle bg-surface-raised hover:border-border",
+        d.muted && "opacity-60",
+      )}
+    >
       <Handle
         type="target"
         position={Position.Top}
@@ -48,6 +68,11 @@ export function QuestionNode({ data }: NodeProps) {
         type="button"
         onClick={(event) => {
           event.stopPropagation();
+          if (d.manageMode) {
+            if (d.selectable === false) return;
+            d.onSelect?.();
+            return;
+          }
           d.onOpen?.();
         }}
         className="min-w-0 flex-1 text-left"
@@ -64,7 +89,27 @@ export function QuestionNode({ data }: NodeProps) {
           </span>
         </div>
       </button>
-      <CircleHelp className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
+      {d.manageMode && d.selectable !== false ? (
+        d.selected ? (
+          <CheckSquare2 className="h-3.5 w-3.5 shrink-0 text-accent" />
+        ) : (
+          <Square className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
+        )
+      ) : (
+        <CircleHelp className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
+      )}
+      {d.manageMode ? (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            d.onOpen?.();
+          }}
+          className="rounded-[4px] px-1.5 py-1 text-[10px] text-text-tertiary transition-colors hover:bg-surface hover:text-text-secondary"
+        >
+          Open
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/ui/src/components/visualizations/experiment-graph/node-types/ungrouped-node.tsx
+++ b/ui/src/components/visualizations/experiment-graph/node-types/ungrouped-node.tsx
@@ -11,13 +11,20 @@ export type UngroupedNodeData = {
   expanded: boolean;
   statusCounts: Record<string, number>;
   statusColors: StatusColorMap;
+  muted?: boolean;
   onToggle?: NodeAction;
 };
 
 export function UngroupedNode({ data }: NodeProps) {
   const d = data as unknown as UngroupedNodeData;
   return (
-    <div className="flex w-[260px] items-center gap-2.5 rounded-[8px] border border-border-subtle bg-surface-raised px-3 py-2.5 transition-colors hover:border-border">
+    <div
+      className={
+        d.muted
+          ? "flex w-[260px] items-center gap-2.5 rounded-[8px] border border-border-subtle bg-surface-raised px-3 py-2.5 opacity-60 transition-colors hover:border-border"
+          : "flex w-[260px] items-center gap-2.5 rounded-[8px] border border-border-subtle bg-surface-raised px-3 py-2.5 transition-colors hover:border-border"
+      }
+    >
       <Handle
         type="target"
         position={Position.Top}

--- a/ui/src/components/visualizations/research-tree.tsx
+++ b/ui/src/components/visualizations/research-tree.tsx
@@ -9,15 +9,18 @@ import {
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
+  CheckSquare2,
   CircleHelp,
   ChevronDown,
   ChevronRight,
   Compass,
   FolderKanban,
   GitFork,
+  Square,
 } from "lucide-react";
 import { FindingImportanceBadge } from "@/components/shared/finding-importance-badge";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { InlineMarkdownText } from "@/components/shared/inline-markdown-text";
 import { Input } from "@/components/ui/input";
 import {
@@ -29,6 +32,10 @@ import {
   parseExperimentSearchTokens,
 } from "@/lib/experiment-search-match";
 import { sortFindingsByImportanceAndRecency } from "@/lib/finding-importance";
+import {
+  type FocusReasonMaps,
+  isDirectFocusReason,
+} from "@/lib/focus-mode";
 import { cn } from "@/lib/utils";
 import type {
   DirectionSummary,
@@ -36,6 +43,7 @@ import type {
   ExperimentSummary,
   Finding,
   FindingConfidence,
+  PruneSelection,
   ProjectSummary,
   QuestionSummary,
 } from "@/types/sonde";
@@ -799,8 +807,21 @@ export interface ResearchTreeProps {
   findings: Finding[];
   questions: QuestionSummary[];
   expansionResetKey?: string | null;
+  manageMode?: boolean;
+  selection?: PruneSelection;
+  focusMode?: boolean;
+  focusReasons?: FocusReasonMaps | null;
+  onToggleQuestionSelection?: (questionId: string) => void;
+  onToggleExperimentSelection?: (experimentId: string) => void;
+  onToggleFindingSelection?: (findingId: string) => void;
   onNavigate: (target: TreeNavigateTarget) => void;
 }
+
+const EMPTY_SELECTION: PruneSelection = {
+  questions: [],
+  findings: [],
+  experiments: [],
+};
 
 export const ResearchTree = memo(function ResearchTree({
   experiments,
@@ -809,6 +830,13 @@ export const ResearchTree = memo(function ResearchTree({
   findings,
   questions,
   expansionResetKey,
+  manageMode = false,
+  selection = EMPTY_SELECTION,
+  focusMode = false,
+  focusReasons = null,
+  onToggleQuestionSelection,
+  onToggleExperimentSelection,
+  onToggleFindingSelection,
   onNavigate,
 }: ResearchTreeProps) {
   const colors = useThemeCssColors();
@@ -827,6 +855,47 @@ export const ResearchTree = memo(function ResearchTree({
   const knownProjectIds = useMemo(
     () => new Set(projects.map((p) => p.id)),
     [projects],
+  );
+  const selectedQuestions = useMemo(
+    () => new Set(selection.questions),
+    [selection.questions],
+  );
+  const selectedFindings = useMemo(
+    () => new Set(selection.findings),
+    [selection.findings],
+  );
+  const selectedExperiments = useMemo(
+    () => new Set(selection.experiments),
+    [selection.experiments],
+  );
+  const isDirectProject = useCallback(
+    (projectId: string | null) =>
+      !focusMode ||
+      (projectId !== null &&
+        isDirectFocusReason(focusReasons?.projects.get(projectId))),
+    [focusMode, focusReasons],
+  );
+  const isDirectDirection = useCallback(
+    (directionId: string) =>
+      !focusMode ||
+      isDirectFocusReason(focusReasons?.directions.get(directionId)),
+    [focusMode, focusReasons],
+  );
+  const isDirectQuestion = useCallback(
+    (questionId: string) =>
+      !focusMode || isDirectFocusReason(focusReasons?.questions.get(questionId)),
+    [focusMode, focusReasons],
+  );
+  const isDirectExperiment = useCallback(
+    (experimentId: string) =>
+      !focusMode ||
+      isDirectFocusReason(focusReasons?.experiments.get(experimentId)),
+    [focusMode, focusReasons],
+  );
+  const isDirectFinding = useCallback(
+    (findingId: string) =>
+      !focusMode || isDirectFocusReason(focusReasons?.findings.get(findingId)),
+    [focusMode, focusReasons],
   );
 
   const isRoot = useCallback(
@@ -917,8 +986,16 @@ export const ResearchTree = memo(function ResearchTree({
     virtualizer.scrollToIndex(focusedIndex, { align: "auto" });
   }, [focusedIndex, virtualizer]);
 
-  const navigateForRow = useCallback(
+  const activateRow = useCallback(
     (row: TreeRowData) => {
+      if (manageMode && row.kind === "question" && isDirectQuestion(row.question.id)) {
+        onToggleQuestionSelection?.(row.question.id);
+        return;
+      }
+      if (manageMode && row.kind === "experiment" && isDirectExperiment(row.exp.id)) {
+        onToggleExperimentSelection?.(row.exp.id);
+        return;
+      }
       if (row.kind === "project") {
         if (row.projectId) onNavigate({ kind: "project", id: row.projectId });
       } else if (row.kind === "direction" || row.kind === "sub-direction") {
@@ -931,7 +1008,14 @@ export const ResearchTree = memo(function ResearchTree({
         onNavigate({ kind: "experiment", id: row.exp.id });
       }
     },
-    [onNavigate],
+    [
+      manageMode,
+      onNavigate,
+      onToggleExperimentSelection,
+      onToggleQuestionSelection,
+      isDirectExperiment,
+      isDirectQuestion,
+    ],
   );
 
   const onKeyDown = useCallback(
@@ -956,7 +1040,7 @@ export const ResearchTree = memo(function ResearchTree({
         setFocusedIndex((i) => Math.max((i < 0 ? 0 : i) - 1, 0));
       } else if (e.key === "Enter" && focusedIndex >= 0) {
         e.preventDefault();
-        navigateForRow(rows[focusedIndex]);
+        activateRow(rows[focusedIndex]);
       } else if (e.key === "ArrowRight" && focusedIndex >= 0) {
         e.preventDefault();
         const row = rows[focusedIndex];
@@ -993,13 +1077,29 @@ export const ResearchTree = memo(function ResearchTree({
         }
       }
     },
-    [flatRows, focusedIndex, navigateForRow],
+    [activateRow, flatRows, focusedIndex],
   );
 
   const pad = (depth: number) => ({ paddingLeft: 8 + depth * 20 });
 
   const renderRow = (row: TreeRowData, index: number) => {
     const focused = focusedIndex === index;
+    const questionSelected =
+      row.kind === "question" && selectedQuestions.has(row.question.id);
+    const experimentSelected =
+      row.kind === "experiment" && selectedExperiments.has(row.exp.id);
+    const projectContext =
+      row.kind === "project" && focusMode && !isDirectProject(row.projectId);
+    const directionContext =
+      (row.kind === "direction" || row.kind === "sub-direction") &&
+      focusMode &&
+      !isDirectDirection(row.dir.id);
+    const questionContext =
+      row.kind === "question" && focusMode && !isDirectQuestion(row.question.id);
+    const experimentContext =
+      row.kind === "experiment" &&
+      focusMode &&
+      !isDirectExperiment(row.exp.id);
 
     if (row.kind === "project") {
       const expanded = !collapsed.has(row.toggleKey);
@@ -1028,6 +1128,7 @@ export const ResearchTree = memo(function ResearchTree({
             focused
               ? "bg-surface-hover ring-1 ring-inset ring-accent"
               : "hover:bg-surface-hover/80",
+            projectContext && "opacity-60",
           )}
           style={{ ...pad(row.depth), minHeight: ROW_H }}
         >
@@ -1086,6 +1187,7 @@ export const ResearchTree = memo(function ResearchTree({
             focused
               ? "bg-surface-hover ring-1 ring-inset ring-accent"
               : "hover:bg-surface-hover/80",
+            directionContext && "opacity-60",
           )}
           style={{ ...pad(row.depth), minHeight: ROW_H }}
         >
@@ -1153,6 +1255,7 @@ export const ResearchTree = memo(function ResearchTree({
             focused
               ? "bg-surface-hover ring-1 ring-inset ring-accent"
               : "hover:bg-surface-hover/80",
+            directionContext && "opacity-60",
           )}
           style={{ ...pad(row.depth), minHeight: ROW_H }}
         >
@@ -1208,6 +1311,11 @@ export const ResearchTree = memo(function ResearchTree({
           tabIndex={0}
           onClick={() => {
             setFocusedIndex(index);
+            if (manageMode) {
+              if (questionContext) return;
+              onToggleQuestionSelection?.(row.question.id);
+              return;
+            }
             toggle(row.toggleKey);
           }}
           onDoubleClick={(event) => {
@@ -1215,6 +1323,12 @@ export const ResearchTree = memo(function ResearchTree({
             onNavigate({ kind: "question", id: row.question.id });
           }}
           onKeyDown={(event) => {
+            if (manageMode && (event.key === " " || event.key === "Enter")) {
+              event.preventDefault();
+              if (questionContext) return;
+              onToggleQuestionSelection?.(row.question.id);
+              return;
+            }
             if (event.key === " ") {
               event.preventDefault();
               toggle(row.toggleKey);
@@ -1222,19 +1336,38 @@ export const ResearchTree = memo(function ResearchTree({
           }}
           className={cn(
             "flex cursor-pointer items-center gap-2 border-b border-border-subtle pr-2 text-left transition-colors",
-            focused
+            questionSelected
+              ? "bg-accent/10 ring-1 ring-inset ring-accent"
+              : focused
               ? "bg-surface-hover ring-1 ring-inset ring-accent"
               : "hover:bg-surface-hover/80",
+            questionContext && "opacity-60",
           )}
           style={{ ...pad(row.depth), minHeight: ROW_H }}
         >
-          <span className="text-text-tertiary">
+          <button
+            type="button"
+            className="shrink-0 rounded p-0.5 text-text-tertiary hover:bg-surface-raised hover:text-text-secondary"
+            aria-label={expanded ? "Collapse question" : "Expand question"}
+            onClick={(event) => {
+              event.stopPropagation();
+              setFocusedIndex(index);
+              toggle(row.toggleKey);
+            }}
+          >
             {expanded ? (
               <ChevronDown className="h-3.5 w-3.5" />
             ) : (
               <ChevronRight className="h-3.5 w-3.5" />
             )}
-          </span>
+          </button>
+          {manageMode && !questionContext ? (
+            questionSelected ? (
+              <CheckSquare2 className="h-3.5 w-3.5 shrink-0 text-accent" />
+            ) : (
+              <Square className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
+            )
+          ) : null}
           <CircleHelp className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
           <div className="min-w-0 flex-1">
             <div className="truncate text-[12px] font-medium text-text">
@@ -1250,6 +1383,20 @@ export const ResearchTree = memo(function ResearchTree({
               </span>
             </div>
           </div>
+          {manageMode ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="shrink-0"
+              onClick={(event) => {
+                event.stopPropagation();
+                onNavigate({ kind: "question", id: row.question.id });
+              }}
+            >
+              Open
+            </Button>
+          ) : null}
         </div>
       );
     }
@@ -1276,6 +1423,7 @@ export const ResearchTree = memo(function ResearchTree({
             focused
               ? "bg-surface-hover ring-1 ring-inset ring-accent"
               : "hover:bg-surface-hover/80",
+            focusMode && "opacity-60",
           )}
           style={{ ...pad(row.depth), minHeight: ROW_H }}
         >
@@ -1329,20 +1477,33 @@ export const ResearchTree = memo(function ResearchTree({
             toggle(row.toggleKey);
             return;
           }
+          if (manageMode) {
+            if (experimentContext) return;
+            onToggleExperimentSelection?.(exp.id);
+            return;
+          }
           onNavigate({ kind: "experiment", id: exp.id });
         }}
         onDoubleClick={() => onNavigate({ kind: "experiment", id: exp.id })}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
+            if (manageMode) {
+              if (experimentContext) return;
+              onToggleExperimentSelection?.(exp.id);
+              return;
+            }
             onNavigate({ kind: "experiment", id: exp.id });
           }
         }}
         className={cn(
           "flex cursor-pointer items-center gap-1.5 border-b border-border-subtle pr-2 text-left transition-colors",
-          focused
+          experimentSelected
+            ? "bg-accent/10 ring-1 ring-inset ring-accent"
+            : focused
             ? "bg-surface-hover ring-1 ring-inset ring-accent"
             : "hover:bg-surface-hover/80",
+          experimentContext && "opacity-60",
         )}
         style={{
           ...pad(row.depth),
@@ -1375,6 +1536,13 @@ export const ResearchTree = memo(function ResearchTree({
           ) : (
             <span className="w-4 shrink-0" />
           )}
+          {manageMode && !experimentContext ? (
+            experimentSelected ? (
+              <CheckSquare2 className="h-3.5 w-3.5 shrink-0 text-accent" />
+            ) : (
+              <Square className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
+            )
+          ) : null}
           <span className="shrink-0 font-mono text-[11px] font-medium text-text">
             {exp.id}
           </span>
@@ -1395,30 +1563,78 @@ export const ResearchTree = memo(function ResearchTree({
           {row.findings.length > 0 && (
             <div className="flex shrink-0 flex-wrap items-center gap-1">
               {row.findings.map((f) => (
-                <button
+                <div
                   key={f.id}
-                  type="button"
-                  className="inline-flex items-center gap-1 rounded border border-border-subtle bg-surface-raised px-1 py-0.5 text-[10px] text-text-secondary hover:border-accent/40"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onNavigate({ kind: "finding", id: f.id });
-                  }}
+                  className={cn(
+                    "inline-flex items-center gap-1 rounded border px-1 py-0.5 text-[10px]",
+                    manageMode && selectedFindings.has(f.id)
+                      ? "border-accent bg-accent/10 text-accent"
+                      : "border-border-subtle bg-surface-raised text-text-secondary",
+                    focusMode && !isDirectFinding(f.id) && "opacity-60",
+                  )}
                 >
-                  <Badge
-                    variant={confidenceVariant(f.confidence)}
-                    className="text-[9px]"
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (manageMode) {
+                        if (!isDirectFinding(f.id)) return;
+                        onToggleFindingSelection?.(f.id);
+                        return;
+                      }
+                      onNavigate({ kind: "finding", id: f.id });
+                    }}
                   >
-                    {f.id}
-                  </Badge>
-                  <FindingImportanceBadge
-                    importance={f.importance}
-                    className="px-1.5 py-0.5 text-[9px]"
-                  />
-                </button>
+                    {manageMode && isDirectFinding(f.id) ? (
+                      selectedFindings.has(f.id) ? (
+                        <CheckSquare2 className="h-3 w-3 shrink-0 text-accent" />
+                      ) : (
+                        <Square className="h-3 w-3 shrink-0 text-text-tertiary" />
+                      )
+                    ) : null}
+                    <Badge
+                      variant={confidenceVariant(f.confidence)}
+                      className="text-[9px]"
+                    >
+                      {f.id}
+                    </Badge>
+                    <FindingImportanceBadge
+                      importance={f.importance}
+                      className="px-1.5 py-0.5 text-[9px]"
+                    />
+                  </button>
+                  {manageMode ? (
+                    <button
+                      type="button"
+                      className="rounded px-1 text-[9px] text-text-tertiary hover:bg-surface hover:text-text-secondary"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onNavigate({ kind: "finding", id: f.id });
+                      }}
+                    >
+                      Open
+                    </button>
+                  ) : null}
+                </div>
               ))}
             </div>
           )}
         </div>
+        {manageMode ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="shrink-0"
+            onClick={(event) => {
+              event.stopPropagation();
+              onNavigate({ kind: "experiment", id: exp.id });
+            }}
+          >
+            Open
+          </Button>
+        ) : null}
         {!expChildrenExpanded && row.childCount > 0 && (
           <span className="shrink-0 text-[9px] text-text-quaternary">
             +{row.childCount}

--- a/ui/src/hooks/use-focus.ts
+++ b/ui/src/hooks/use-focus.ts
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+import { actorSourceFromEmail, displaySourceLabel } from "@/lib/actor-source";
+import {
+  FOCUS_HELP_TEXT,
+  buildTouchedRecordIds,
+  emptyFocusRecordIds,
+  focusTouchedCutoffIso,
+} from "@/lib/focus-mode";
+import { useAuthStore } from "@/stores/auth";
+import { useFocusEnabled, useSetFocusEnabled } from "@/stores/focus";
+import type { ActivityLogEntry } from "@/types/sonde";
+
+export function useFocusMode() {
+  const user = useAuthStore((state) => state.user);
+  const enabled = useFocusEnabled();
+  const setEnabled = useSetFocusEnabled();
+
+  const actorSource = useMemo(
+    () => actorSourceFromEmail(user?.email ?? null),
+    [user?.email],
+  );
+  const actorLabel = useMemo(
+    () => displaySourceLabel(actorSource, actorSource),
+    [actorSource],
+  );
+  const touchedCutoff = useMemo(() => focusTouchedCutoffIso(), []);
+
+  const touchedQuery = useQuery({
+    queryKey: ["focus", "touched-records", actorSource, touchedCutoff] as const,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("activity_log")
+        .select("*")
+        .eq("actor", actorSource!)
+        .gte("created_at", touchedCutoff)
+        .order("created_at", { ascending: false });
+
+      if (error) throw error;
+      return buildTouchedRecordIds(data as ActivityLogEntry[]);
+    },
+    enabled: !!actorSource,
+  });
+
+  const canFocus = !!actorSource;
+  const disabledReason = canFocus
+    ? null
+    : "Focus mode needs a signed-in Aeolus email so we can resolve your authorship.";
+
+  return {
+    enabled,
+    setEnabled,
+    actorSource,
+    actorLabel,
+    canFocus,
+    disabledReason,
+    description: FOCUS_HELP_TEXT,
+    touchedRecordIds: touchedQuery.data ?? emptyFocusRecordIds(),
+    isLoadingTouched: touchedQuery.isLoading,
+  };
+}

--- a/ui/src/hooks/use-prune-mutations.ts
+++ b/ui/src/hooks/use-prune-mutations.ts
@@ -1,0 +1,196 @@
+import {
+  QueryClient,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+import { useAddToast } from "@/stores/toast";
+import { experimentActionButtonLabel } from "@/lib/prune-actions";
+import type {
+  BulkActionResult,
+  BulkDeleteFindingApplied,
+  BulkDeleteQuestionApplied,
+  BulkTransitionExperimentApplied,
+  ExperimentPruneAction,
+} from "@/types/sonde";
+
+async function invalidatePruneQueries(
+  queryClient: QueryClient,
+) {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["questions"] }),
+    queryClient.invalidateQueries({ queryKey: ["findings"] }),
+    queryClient.invalidateQueries({ queryKey: ["experiments"] }),
+    queryClient.invalidateQueries({ queryKey: ["directions"] }),
+    queryClient.invalidateQueries({ queryKey: ["artifacts"] }),
+    queryClient.invalidateQueries({ queryKey: ["activity"] }),
+  ]);
+}
+
+function normalizeBulkResult<TApplied>(
+  raw: unknown,
+): BulkActionResult<TApplied> {
+  const data = raw as Partial<BulkActionResult<TApplied>> | null;
+  return {
+    applied: Array.isArray(data?.applied) ? data.applied : [],
+    skipped: Array.isArray(data?.skipped) ? data.skipped : [],
+    summary: {
+      requested:
+        typeof data?.summary?.requested === "number"
+          ? data.summary.requested
+          : 0,
+      applied:
+        typeof data?.summary?.applied === "number" ? data.summary.applied : 0,
+      skipped:
+        typeof data?.summary?.skipped === "number" ? data.summary.skipped : 0,
+    },
+  };
+}
+
+export function useDeleteQuestions() {
+  const queryClient = useQueryClient();
+  const addToast = useAddToast();
+
+  return useMutation({
+    mutationFn: async ({
+      ids,
+    }: {
+      ids: string[];
+    }): Promise<BulkActionResult<BulkDeleteQuestionApplied>> => {
+      const { data, error } = await supabase.rpc("bulk_delete_questions", {
+        target_ids: ids,
+      });
+      if (error) throw error;
+      return normalizeBulkResult<BulkDeleteQuestionApplied>(data);
+    },
+    onSuccess: async (result) => {
+      await invalidatePruneQueries(queryClient);
+      addToast({
+        title:
+          result.summary.applied === 1
+            ? "Question deleted"
+            : result.summary.applied > 1
+              ? "Questions deleted"
+              : "No questions deleted",
+        description:
+          result.summary.skipped > 0
+            ? `${result.summary.applied} deleted, ${result.summary.skipped} skipped.`
+            : undefined,
+        variant: result.summary.applied > 0 ? "success" : "info",
+      });
+    },
+    onError: (err: Error) => {
+      addToast({
+        title: "Failed to delete questions",
+        description: err.message,
+        variant: "error",
+      });
+    },
+  });
+}
+
+export function useDeleteFindings() {
+  const queryClient = useQueryClient();
+  const addToast = useAddToast();
+
+  return useMutation({
+    mutationFn: async ({
+      ids,
+    }: {
+      ids: string[];
+    }): Promise<BulkActionResult<BulkDeleteFindingApplied>> => {
+      const { data, error } = await supabase.rpc("bulk_delete_findings", {
+        target_ids: ids,
+      });
+      if (error) throw error;
+      return normalizeBulkResult<BulkDeleteFindingApplied>(data);
+    },
+    onSuccess: async (result) => {
+      await invalidatePruneQueries(queryClient);
+      const artifactCount = result.applied.reduce(
+        (total, item) => total + (item.artifact_count ?? 0),
+        0,
+      );
+      const descriptionParts: string[] = [];
+      if (artifactCount > 0) {
+        descriptionParts.push(
+          `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} queued for cleanup.`,
+        );
+      }
+      if (result.summary.skipped > 0) {
+        descriptionParts.push(
+          `${result.summary.skipped} skipped during delete.`,
+        );
+      }
+      addToast({
+        title:
+          result.summary.applied === 1
+            ? "Finding deleted"
+            : result.summary.applied > 1
+              ? "Findings deleted"
+              : "No findings deleted",
+        description:
+          descriptionParts.length > 0 ? descriptionParts.join(" ") : undefined,
+        variant: result.summary.applied > 0 ? "success" : "info",
+      });
+    },
+    onError: (err: Error) => {
+      addToast({
+        title: "Failed to delete findings",
+        description: err.message,
+        variant: "error",
+      });
+    },
+  });
+}
+
+export function useTransitionExperiments() {
+  const queryClient = useQueryClient();
+  const addToast = useAddToast();
+
+  return useMutation({
+    mutationFn: async ({
+      ids,
+      status,
+    }: {
+      ids: string[];
+      status: ExperimentPruneAction;
+    }): Promise<BulkActionResult<BulkTransitionExperimentApplied>> => {
+      const { data, error } = await supabase.rpc(
+        "bulk_transition_experiments",
+        {
+          target_ids: ids,
+          target_status: status,
+          origin: "ui_prune",
+        },
+      );
+      if (error) throw error;
+      return normalizeBulkResult<BulkTransitionExperimentApplied>(data);
+    },
+    onSuccess: async (result, variables) => {
+      await invalidatePruneQueries(queryClient);
+      addToast({
+        title:
+          result.summary.applied === 1
+            ? "Experiment updated"
+            : result.summary.applied > 1
+              ? "Experiments updated"
+              : "No experiments updated",
+        description:
+          result.summary.applied > 0
+            ? `${experimentActionButtonLabel(variables.status)} applied to ${result.summary.applied}.`
+            : result.summary.skipped > 0
+              ? `${result.summary.skipped} skipped because they were not eligible.`
+              : undefined,
+        variant: result.summary.applied > 0 ? "success" : "info",
+      });
+    },
+    onError: (err: Error) => {
+      addToast({
+        title: "Failed to update experiments",
+        description: err.message,
+        variant: "error",
+      });
+    },
+  });
+}

--- a/ui/src/lib/actor-source.ts
+++ b/ui/src/lib/actor-source.ts
@@ -1,0 +1,22 @@
+export function actorSourceFromEmail(
+  email: string | null | undefined,
+): string | null {
+  const handle = email?.split("@")[0]?.trim().toLowerCase();
+  return handle ? `human/${handle}` : null;
+}
+
+export function actorHandle(source: string | null | undefined): string | null {
+  if (!source) return null;
+  const slashIndex = source.indexOf("/");
+  const handle = slashIndex >= 0 ? source.slice(slashIndex + 1) : source;
+  return handle || null;
+}
+
+export function displaySourceLabel(
+  source: string | null | undefined,
+  currentActorSource?: string | null,
+): string {
+  if (!source) return "unknown";
+  if (currentActorSource && source === currentActorSource) return "you";
+  return actorHandle(source) ?? source;
+}

--- a/ui/src/lib/artifact-delete.ts
+++ b/ui/src/lib/artifact-delete.ts
@@ -1,3 +1,5 @@
+import { actorSourceFromEmail } from "./actor-source";
+
 export type ArtifactParentRecordType = "experiment" | "finding" | "direction" | "project";
 
 export interface ArtifactDeletedActivityRow {
@@ -20,8 +22,7 @@ export function artifactParentRecordType(parentId: string): ArtifactParentRecord
 }
 
 export function activityActorForEmail(email: string | undefined): string {
-  const handle = email?.split("@")[0]?.trim();
-  return `human/${handle || "unknown"}`;
+  return actorSourceFromEmail(email) ?? "human/unknown";
 }
 
 export function artifactDeletedActivityRow({

--- a/ui/src/lib/focus-mode.test.ts
+++ b/ui/src/lib/focus-mode.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it } from "vitest";
+
+import { actorSourceFromEmail, displaySourceLabel } from "./actor-source";
+import {
+  buildDirectFocusReasonMaps,
+  buildFocusedWorkspaceData,
+  buildTouchedRecordIds,
+  filterActivityForFocus,
+} from "./focus-mode";
+import type {
+  ActivityLogEntry,
+  DirectionSummary,
+  ExperimentSummary,
+  Finding,
+  ProjectSummary,
+  QuestionSummary,
+} from "@/types/sonde";
+
+function makeProject(
+  overrides: Partial<ProjectSummary> = {},
+): ProjectSummary {
+  return {
+    id: "PROJ-0001",
+    program: "shared",
+    name: "Project",
+    objective: null,
+    description: null,
+    status: "active",
+    source: "human/other",
+    report_pdf_artifact_id: null,
+    report_tex_artifact_id: null,
+    report_updated_at: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    direction_count: 1,
+    experiment_count: 2,
+    complete_count: 0,
+    open_count: 2,
+    running_count: 0,
+    failed_count: 0,
+    ...overrides,
+  };
+}
+
+function makeDirection(
+  overrides: Partial<DirectionSummary> = {},
+): DirectionSummary {
+  return {
+    id: "DIR-0001",
+    program: "shared",
+    title: "Direction",
+    question: "Direction question",
+    context: null,
+    status: "active",
+    source: "human/other",
+    project_id: "PROJ-0001",
+    parent_direction_id: null,
+    spawned_from_experiment_id: null,
+    primary_question_id: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    question_count: 1,
+    answered_question_count: 0,
+    experiment_count: 2,
+    complete_count: 0,
+    open_count: 2,
+    running_count: 0,
+    child_direction_count: 0,
+    ...overrides,
+  };
+}
+
+function makeQuestion(
+  overrides: Partial<QuestionSummary> = {},
+): QuestionSummary {
+  return {
+    id: "Q-0001",
+    program: "shared",
+    question: "Question",
+    direction_id: "DIR-0001",
+    context: null,
+    status: "open",
+    source: "human/other",
+    raised_by: null,
+    promoted_to_type: null,
+    promoted_to_id: null,
+    tags: [],
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    linked_experiment_count: 1,
+    primary_experiment_count: 1,
+    linked_finding_count: 1,
+    ...overrides,
+  };
+}
+
+function makeExperiment(
+  overrides: Partial<ExperimentSummary> = {},
+): ExperimentSummary {
+  return {
+    id: "EXP-0001",
+    program: "shared",
+    status: "open",
+    source: "human/other",
+    content: null,
+    hypothesis: null,
+    parameters: {},
+    results: null,
+    finding: null,
+    metadata: {},
+    git_commit: null,
+    git_repo: null,
+    git_branch: null,
+    git_close_commit: null,
+    git_close_branch: null,
+    git_dirty: null,
+    code_context: null,
+    data_sources: [],
+    tags: [],
+    direction_id: "DIR-0001",
+    project_id: "PROJ-0001",
+    linear_id: null,
+    related: [],
+    parent_id: null,
+    branch_type: null,
+    claimed_by: null,
+    claimed_at: null,
+    run_at: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    primary_question_id: null,
+    artifact_count: 0,
+    artifact_types: null,
+    artifact_filenames: null,
+    ...overrides,
+  };
+}
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: "FIND-0001",
+    program: "shared",
+    topic: "Topic",
+    finding: "Finding",
+    confidence: "medium",
+    importance: "medium",
+    content: null,
+    metadata: {},
+    evidence: ["EXP-0001"],
+    source: "human/other",
+    valid_from: "2026-04-01T00:00:00Z",
+    valid_until: null,
+    supersedes: null,
+    superseded_by: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("actor-source", () => {
+  it("derives the canonical human source and friendly labels", () => {
+    expect(actorSourceFromEmail("mlee@aeolus.earth")).toBe("human/mlee");
+    expect(actorSourceFromEmail(undefined)).toBeNull();
+    expect(displaySourceLabel("human/mlee", "human/mlee")).toBe("you");
+    expect(displaySourceLabel("agent/reporter", "human/mlee")).toBe("reporter");
+  });
+});
+
+describe("focus-mode", () => {
+  const actorSource = "human/mlee";
+
+  it("marks created and touched records as direct matches", () => {
+    const touched = buildTouchedRecordIds([
+      {
+        id: 1,
+        record_id: "EXP-0002",
+        record_type: "experiment",
+        action: "updated",
+        actor: actorSource,
+        actor_email: "mlee@aeolus.earth",
+        actor_name: "M Lee",
+        details: {},
+        created_at: "2026-04-10T00:00:00Z",
+      },
+    ]);
+
+    const reasons = buildDirectFocusReasonMaps({
+      projects: [],
+      directions: [],
+      questions: [],
+      experiments: [
+        makeExperiment({ id: "EXP-0001", source: actorSource }),
+        makeExperiment({ id: "EXP-0002" }),
+      ],
+      findings: [],
+      actorSource,
+      touchedRecordIds: touched,
+    });
+
+    expect(reasons.experiments.get("EXP-0001")).toBe("created");
+    expect(reasons.experiments.get("EXP-0002")).toBe("touched");
+  });
+
+  it("adds context for finding evidence, experiment ancestors, question homes, and projects", () => {
+    const project = makeProject();
+    const direction = makeDirection();
+    const question = makeQuestion();
+    const rootExperiment = makeExperiment({ id: "EXP-ROOT" });
+    const childExperiment = makeExperiment({
+      id: "EXP-CHILD",
+      parent_id: "EXP-ROOT",
+      primary_question_id: "Q-0001",
+    });
+    const finding = makeFinding({
+      id: "FIND-FOCUS",
+      source: actorSource,
+      evidence: ["EXP-CHILD"],
+    });
+
+    const focused = buildFocusedWorkspaceData({
+      projects: [project],
+      directions: [direction],
+      questions: [question],
+      experiments: [rootExperiment, childExperiment],
+      findings: [finding],
+      actorSource,
+      touchedRecordIds: buildTouchedRecordIds([]),
+    });
+
+    expect(focused.findings.map((item) => item.id)).toEqual(["FIND-FOCUS"]);
+    expect(focused.experiments.map((item) => item.id)).toEqual([
+      "EXP-ROOT",
+      "EXP-CHILD",
+    ]);
+    expect(focused.questions.map((item) => item.id)).toEqual(["Q-0001"]);
+    expect(focused.directions.map((item) => item.id)).toEqual(["DIR-0001"]);
+    expect(focused.projects.map((item) => item.id)).toEqual(["PROJ-0001"]);
+    expect(focused.reasons.findings.get("FIND-FOCUS")).toBe("created");
+    expect(focused.reasons.experiments.get("EXP-CHILD")).toBe("context");
+    expect(focused.reasons.experiments.get("EXP-ROOT")).toBe("context");
+    expect(focused.reasons.questions.get("Q-0001")).toBe("context");
+    expect(focused.reasons.directions.get("DIR-0001")).toBe("context");
+    expect(focused.reasons.projects.get("PROJ-0001")).toBe("context");
+  });
+
+  it("keeps a touched direction direct and pulls in its spawned experiment as context", () => {
+    const project = makeProject();
+    const rootExperiment = makeExperiment({ id: "EXP-SPAWN", direction_id: null });
+    const direction = makeDirection({
+      id: "DIR-TOUCHED",
+      source: "human/other",
+      spawned_from_experiment_id: "EXP-SPAWN",
+    });
+    const touched = buildTouchedRecordIds([
+      {
+        id: 1,
+        record_id: "DIR-TOUCHED",
+        record_type: "direction",
+        action: "updated",
+        actor: actorSource,
+        actor_email: "mlee@aeolus.earth",
+        actor_name: "M Lee",
+        details: {},
+        created_at: "2026-04-10T00:00:00Z",
+      },
+    ]);
+
+    const focused = buildFocusedWorkspaceData({
+      projects: [project],
+      directions: [direction],
+      questions: [],
+      experiments: [rootExperiment],
+      findings: [],
+      actorSource,
+      touchedRecordIds: touched,
+    });
+
+    expect(focused.directions.map((item) => item.id)).toEqual(["DIR-TOUCHED"]);
+    expect(focused.experiments.map((item) => item.id)).toEqual(["EXP-SPAWN"]);
+    expect(focused.reasons.directions.get("DIR-TOUCHED")).toBe("touched");
+    expect(focused.reasons.experiments.get("EXP-SPAWN")).toBe("context");
+  });
+
+  it("filters activity to the actor's work and direct-match records", () => {
+    const reasons = buildDirectFocusReasonMaps({
+      projects: [],
+      directions: [],
+      questions: [],
+      experiments: [makeExperiment({ id: "EXP-OWNED", source: actorSource })],
+      findings: [],
+      actorSource,
+      touchedRecordIds: buildTouchedRecordIds([]),
+    });
+    const entries: ActivityLogEntry[] = [
+      {
+        id: 1,
+        record_id: "EXP-OWNED",
+        record_type: "experiment",
+        action: "status_changed",
+        actor: "human/other",
+        actor_email: "other@aeolus.earth",
+        actor_name: "Other",
+        details: {},
+        created_at: "2026-04-10T00:00:00Z",
+      },
+      {
+        id: 2,
+        record_id: "DIR-0001",
+        record_type: "direction",
+        action: "updated",
+        actor: actorSource,
+        actor_email: "mlee@aeolus.earth",
+        actor_name: "M Lee",
+        details: {},
+        created_at: "2026-04-10T00:00:00Z",
+      },
+      {
+        id: 3,
+        record_id: "EXP-OTHER",
+        record_type: "experiment",
+        action: "updated",
+        actor: "human/other",
+        actor_email: "other@aeolus.earth",
+        actor_name: "Other",
+        details: {},
+        created_at: "2026-04-10T00:00:00Z",
+      },
+    ];
+
+    expect(filterActivityForFocus(entries, actorSource, reasons).map((entry) => entry.id)).toEqual([
+      1,
+      2,
+    ]);
+  });
+});

--- a/ui/src/lib/focus-mode.ts
+++ b/ui/src/lib/focus-mode.ts
@@ -1,0 +1,412 @@
+import type {
+  ActivityLogEntry,
+  DirectionSummary,
+  ExperimentSummary,
+  Finding,
+  ProjectSummary,
+  QuestionSummary,
+} from "@/types/sonde";
+
+export const FOCUS_TOUCHED_WINDOW_DAYS = 30;
+export const FOCUS_HELP_TEXT = `Created by you or touched in the last ${FOCUS_TOUCHED_WINDOW_DAYS} days.`;
+
+export type FocusDirectReason = "created" | "touched";
+export type FocusMatchReason = FocusDirectReason | "context";
+export type FocusRecordType =
+  | "project"
+  | "direction"
+  | "question"
+  | "experiment"
+  | "finding";
+
+export interface FocusRecordIds {
+  projects: Set<string>;
+  directions: Set<string>;
+  questions: Set<string>;
+  experiments: Set<string>;
+  findings: Set<string>;
+}
+
+export interface FocusReasonMaps {
+  projects: Map<string, FocusMatchReason>;
+  directions: Map<string, FocusMatchReason>;
+  questions: Map<string, FocusMatchReason>;
+  experiments: Map<string, FocusMatchReason>;
+  findings: Map<string, FocusMatchReason>;
+}
+
+export interface FocusWorkspaceData {
+  projects: ProjectSummary[];
+  directions: DirectionSummary[];
+  questions: QuestionSummary[];
+  experiments: ExperimentSummary[];
+  findings: Finding[];
+  reasons: FocusReasonMaps;
+}
+
+export interface BuildFocusedWorkspaceInput {
+  projects: ProjectSummary[];
+  directions: DirectionSummary[];
+  questions: QuestionSummary[];
+  experiments: ExperimentSummary[];
+  findings: Finding[];
+  actorSource: string;
+  touchedRecordIds: FocusRecordIds;
+}
+
+export function emptyFocusRecordIds(): FocusRecordIds {
+  return {
+    projects: new Set<string>(),
+    directions: new Set<string>(),
+    questions: new Set<string>(),
+    experiments: new Set<string>(),
+    findings: new Set<string>(),
+  };
+}
+
+export function emptyFocusReasonMaps(): FocusReasonMaps {
+  return {
+    projects: new Map<string, FocusMatchReason>(),
+    directions: new Map<string, FocusMatchReason>(),
+    questions: new Map<string, FocusMatchReason>(),
+    experiments: new Map<string, FocusMatchReason>(),
+    findings: new Map<string, FocusMatchReason>(),
+  };
+}
+
+export function focusTouchedCutoffIso(
+  days = FOCUS_TOUCHED_WINDOW_DAYS,
+  now = new Date(),
+): string {
+  return new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+export function buildTouchedRecordIds(
+  entries: ActivityLogEntry[],
+): FocusRecordIds {
+  const ids = emptyFocusRecordIds();
+
+  for (const entry of entries) {
+    if (entry.record_type === "project") {
+      ids.projects.add(entry.record_id);
+    } else if (entry.record_type === "direction") {
+      ids.directions.add(entry.record_id);
+    } else if (entry.record_type === "question") {
+      ids.questions.add(entry.record_id);
+    } else if (entry.record_type === "experiment") {
+      ids.experiments.add(entry.record_id);
+    } else if (entry.record_type === "finding") {
+      ids.findings.add(entry.record_id);
+    }
+  }
+
+  return ids;
+}
+
+export function directFocusReasonForRecord({
+  id,
+  source,
+  actorSource,
+  touchedIds,
+}: {
+  id: string;
+  source: string | null | undefined;
+  actorSource: string | null;
+  touchedIds: Set<string>;
+}): FocusDirectReason | null {
+  if (actorSource && source === actorSource) return "created";
+  if (touchedIds.has(id)) return "touched";
+  return null;
+}
+
+export function isDirectFocusReason(
+  reason: FocusMatchReason | null | undefined,
+): reason is FocusDirectReason {
+  return reason === "created" || reason === "touched";
+}
+
+export function buildDirectFocusReasonMaps({
+  projects,
+  directions,
+  questions,
+  experiments,
+  findings,
+  actorSource,
+  touchedRecordIds,
+}: BuildFocusedWorkspaceInput): FocusReasonMaps {
+  const reasons = emptyFocusReasonMaps();
+
+  for (const project of projects) {
+    const reason = directFocusReasonForRecord({
+      id: project.id,
+      source: project.source,
+      actorSource,
+      touchedIds: touchedRecordIds.projects,
+    });
+    if (reason) reasons.projects.set(project.id, reason);
+  }
+
+  for (const direction of directions) {
+    const reason = directFocusReasonForRecord({
+      id: direction.id,
+      source: direction.source,
+      actorSource,
+      touchedIds: touchedRecordIds.directions,
+    });
+    if (reason) reasons.directions.set(direction.id, reason);
+  }
+
+  for (const question of questions) {
+    const reason = directFocusReasonForRecord({
+      id: question.id,
+      source: question.source,
+      actorSource,
+      touchedIds: touchedRecordIds.questions,
+    });
+    if (reason) reasons.questions.set(question.id, reason);
+  }
+
+  for (const experiment of experiments) {
+    const reason = directFocusReasonForRecord({
+      id: experiment.id,
+      source: experiment.source,
+      actorSource,
+      touchedIds: touchedRecordIds.experiments,
+    });
+    if (reason) reasons.experiments.set(experiment.id, reason);
+  }
+
+  for (const finding of findings) {
+    const reason = directFocusReasonForRecord({
+      id: finding.id,
+      source: finding.source,
+      actorSource,
+      touchedIds: touchedRecordIds.findings,
+    });
+    if (reason) reasons.findings.set(finding.id, reason);
+  }
+
+  return reasons;
+}
+
+export function filterActivityForFocus(
+  entries: ActivityLogEntry[],
+  actorSource: string,
+  reasons: FocusReasonMaps,
+): ActivityLogEntry[] {
+  return entries.filter((entry) => {
+    if (entry.actor === actorSource) return true;
+    if (entry.record_type === "project") {
+      return isDirectFocusReason(reasons.projects.get(entry.record_id));
+    }
+    if (entry.record_type === "direction") {
+      return isDirectFocusReason(reasons.directions.get(entry.record_id));
+    }
+    if (entry.record_type === "question") {
+      return isDirectFocusReason(reasons.questions.get(entry.record_id));
+    }
+    if (entry.record_type === "experiment") {
+      return isDirectFocusReason(reasons.experiments.get(entry.record_id));
+    }
+    if (entry.record_type === "finding") {
+      return isDirectFocusReason(reasons.findings.get(entry.record_id));
+    }
+    return false;
+  });
+}
+
+export function buildFocusedWorkspaceData({
+  projects,
+  directions,
+  questions,
+  experiments,
+  findings,
+  actorSource,
+  touchedRecordIds,
+}: BuildFocusedWorkspaceInput): FocusWorkspaceData {
+  const reasons = buildDirectFocusReasonMaps({
+    projects,
+    directions,
+    questions,
+    experiments,
+    findings,
+    actorSource,
+    touchedRecordIds,
+  });
+  const included = emptyFocusRecordIds();
+
+  const projectById = new Map(projects.map((project) => [project.id, project]));
+  const directionById = new Map(
+    directions.map((direction) => [direction.id, direction]),
+  );
+  const questionById = new Map(questions.map((question) => [question.id, question]));
+  const experimentById = new Map(
+    experiments.map((experiment) => [experiment.id, experiment]),
+  );
+  const experimentsByPrimaryQuestion = new Map<string, ExperimentSummary[]>();
+
+  for (const experiment of experiments) {
+    if (!experiment.primary_question_id) continue;
+    const items =
+      experimentsByPrimaryQuestion.get(experiment.primary_question_id) ?? [];
+    items.push(experiment);
+    experimentsByPrimaryQuestion.set(experiment.primary_question_id, items);
+  }
+
+  const processedProjects = new Set<string>();
+  const processedDirections = new Set<string>();
+  const processedQuestions = new Set<string>();
+  const processedExperiments = new Set<string>();
+
+  function markReason(
+    map: Map<string, FocusMatchReason>,
+    id: string,
+    reason: FocusMatchReason,
+  ) {
+    const current = map.get(id);
+    if (!current || (current === "context" && reason !== "context")) {
+      map.set(id, reason);
+    }
+  }
+
+  function includeProject(
+    projectId: string | null | undefined,
+    reason: FocusMatchReason,
+  ) {
+    if (!projectId || !projectById.has(projectId)) return;
+    included.projects.add(projectId);
+    markReason(reasons.projects, projectId, reason);
+    if (processedProjects.has(projectId)) return;
+    processedProjects.add(projectId);
+  }
+
+  function includeDirection(
+    directionId: string | null | undefined,
+    reason: FocusMatchReason,
+  ) {
+    if (!directionId) return;
+    const direction = directionById.get(directionId);
+    if (!direction) return;
+    included.directions.add(direction.id);
+    markReason(reasons.directions, direction.id, reason);
+    if (processedDirections.has(direction.id)) return;
+    processedDirections.add(direction.id);
+
+    if (direction.parent_direction_id) {
+      includeDirection(direction.parent_direction_id, "context");
+    } else {
+      includeProject(direction.project_id, "context");
+    }
+
+    if (direction.spawned_from_experiment_id) {
+      includeExperiment(direction.spawned_from_experiment_id, "context");
+    }
+  }
+
+  function includeQuestion(
+    questionId: string | null | undefined,
+    reason: FocusMatchReason,
+  ) {
+    if (!questionId) return;
+    const question = questionById.get(questionId);
+    if (!question) return;
+    included.questions.add(question.id);
+    markReason(reasons.questions, question.id, reason);
+    if (processedQuestions.has(question.id)) return;
+    processedQuestions.add(question.id);
+
+    includeDirection(question.direction_id, "context");
+  }
+
+  function includeExperiment(
+    experimentId: string | null | undefined,
+    reason: FocusMatchReason,
+  ) {
+    if (!experimentId) return;
+    const experiment = experimentById.get(experimentId);
+    if (!experiment) return;
+    included.experiments.add(experiment.id);
+    markReason(reasons.experiments, experiment.id, reason);
+    if (processedExperiments.has(experiment.id)) return;
+    processedExperiments.add(experiment.id);
+
+    if (experiment.parent_id) {
+      includeExperiment(experiment.parent_id, "context");
+    }
+
+    if (experiment.primary_question_id) {
+      includeQuestion(experiment.primary_question_id, "context");
+    } else if (experiment.direction_id) {
+      includeDirection(experiment.direction_id, "context");
+    } else {
+      includeProject(experiment.project_id, "context");
+    }
+  }
+
+  for (const project of projects) {
+    const reason = reasons.projects.get(project.id);
+    if (isDirectFocusReason(reason)) {
+      includeProject(project.id, reason);
+    }
+  }
+
+  for (const direction of directions) {
+    const reason = reasons.directions.get(direction.id);
+    if (isDirectFocusReason(reason)) {
+      includeDirection(direction.id, reason);
+    }
+  }
+
+  for (const question of questions) {
+    const reason = reasons.questions.get(question.id);
+    if (isDirectFocusReason(reason)) {
+      includeQuestion(question.id, reason);
+    }
+  }
+
+  for (const experiment of experiments) {
+    const reason = reasons.experiments.get(experiment.id);
+    if (isDirectFocusReason(reason)) {
+      includeExperiment(experiment.id, reason);
+    }
+  }
+
+  for (const finding of findings) {
+    const reason = reasons.findings.get(finding.id);
+    if (!isDirectFocusReason(reason)) continue;
+
+    included.findings.add(finding.id);
+    markReason(reasons.findings, finding.id, reason);
+
+    for (const evidenceExperimentId of finding.evidence) {
+      includeExperiment(evidenceExperimentId, "context");
+    }
+  }
+
+  for (const experiment of experiments) {
+    if (!isDirectFocusReason(reasons.experiments.get(experiment.id))) continue;
+    if (!experiment.primary_question_id) continue;
+    includeQuestion(experiment.primary_question_id, "context");
+  }
+
+  for (const question of questions) {
+    if (!isDirectFocusReason(reasons.questions.get(question.id))) continue;
+    const linkedExperiments = experimentsByPrimaryQuestion.get(question.id) ?? [];
+    for (const experiment of linkedExperiments) {
+      includeExperiment(experiment.id, "context");
+    }
+  }
+
+  return {
+    projects: projects.filter((project) => included.projects.has(project.id)),
+    directions: directions.filter((direction) =>
+      included.directions.has(direction.id),
+    ),
+    questions: questions.filter((question) => included.questions.has(question.id)),
+    experiments: experiments.filter((experiment) =>
+      included.experiments.has(experiment.id),
+    ),
+    findings: findings.filter((finding) => included.findings.has(finding.id)),
+    reasons,
+  };
+}

--- a/ui/src/lib/prune-actions.test.ts
+++ b/ui/src/lib/prune-actions.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBulkActionPreview,
+  emptyPruneSelection,
+  intersectPruneSelection,
+  removeAppliedFromSelection,
+  togglePruneSelection,
+} from "./prune-actions";
+import type { ExperimentSummary } from "@/types/sonde";
+
+function makeExperiment(
+  id: string,
+  status: ExperimentSummary["status"],
+): ExperimentSummary {
+  return {
+    id,
+    program: "shared",
+    status,
+    source: "test",
+    content: null,
+    hypothesis: null,
+    parameters: {},
+    results: null,
+    finding: null,
+    metadata: {},
+    git_commit: null,
+    git_repo: null,
+    git_branch: null,
+    git_close_commit: null,
+    git_close_branch: null,
+    git_dirty: null,
+    code_context: null,
+    data_sources: [],
+    tags: [],
+    direction_id: null,
+    project_id: null,
+    linear_id: null,
+    related: [],
+    parent_id: null,
+    branch_type: null,
+    claimed_by: null,
+    claimed_at: null,
+    run_at: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    primary_question_id: null,
+    artifact_count: 0,
+    artifact_types: null,
+    artifact_filenames: null,
+  };
+}
+
+describe("prune-actions", () => {
+  it("toggles selection membership per kind", () => {
+    let selection = emptyPruneSelection();
+    selection = togglePruneSelection(selection, "question", "Q-0002");
+    selection = togglePruneSelection(selection, "question", "Q-0001");
+    selection = togglePruneSelection(selection, "finding", "FIND-0003");
+
+    expect(selection.questions).toEqual(["Q-0001", "Q-0002"]);
+    expect(selection.findings).toEqual(["FIND-0003"]);
+
+    selection = togglePruneSelection(selection, "question", "Q-0002");
+    expect(selection.questions).toEqual(["Q-0001"]);
+  });
+
+  it("intersects selection against the visible record sets", () => {
+    const selection = {
+      questions: ["Q-0001", "Q-0002"],
+      findings: ["FIND-0001"],
+      experiments: ["EXP-0001", "EXP-0002"],
+    };
+
+    expect(
+      intersectPruneSelection(selection, {
+        questions: new Set(["Q-0002"]),
+        findings: new Set<string>(),
+        experiments: new Set(["EXP-0001"]),
+      }),
+    ).toEqual({
+      questions: ["Q-0002"],
+      findings: [],
+      experiments: ["EXP-0001"],
+    });
+  });
+
+  it("keeps only unapplied ids after a bulk action", () => {
+    const selection = {
+      questions: [],
+      findings: ["FIND-0001", "FIND-0002"],
+      experiments: ["EXP-0001", "EXP-0002"],
+    };
+
+    expect(
+      removeAppliedFromSelection(selection, "experiment", ["EXP-0002"]),
+    ).toEqual({
+      questions: [],
+      findings: ["FIND-0001", "FIND-0002"],
+      experiments: ["EXP-0001"],
+    });
+  });
+
+  it("builds experiment bulk previews with local eligibility skips", () => {
+    const preview = buildBulkActionPreview(
+      { kind: "experiment", action: "superseded" },
+      {
+        questions: [],
+        findings: [],
+        experiments: ["EXP-0001", "EXP-0002", "EXP-0003"],
+      },
+      new Map([
+        ["EXP-0001", makeExperiment("EXP-0001", "complete")],
+        ["EXP-0002", makeExperiment("EXP-0002", "running")],
+      ]),
+    );
+
+    expect(preview.eligibleIds).toEqual(["EXP-0001"]);
+    expect(preview.skipped).toEqual([
+      {
+        id: "EXP-0002",
+        reason: "ineligible_status",
+        message: "Only complete or failed experiments can be archived.",
+        current_status: "running",
+      },
+      {
+        id: "EXP-0003",
+        reason: "not_visible",
+        message: "Experiment is no longer visible in this view.",
+      },
+    ]);
+  });
+});

--- a/ui/src/lib/prune-actions.ts
+++ b/ui/src/lib/prune-actions.ts
@@ -1,0 +1,218 @@
+import type {
+  BulkActionPreview,
+  BulkActionSkip,
+  ExperimentPruneAction,
+  ExperimentSummary,
+  PruneAction,
+  PruneSelection,
+  PruneableRecordKind,
+} from "@/types/sonde";
+
+export type BulkActionIntent =
+  | { kind: "question"; action: "delete" }
+  | { kind: "finding"; action: "delete" }
+  | { kind: "experiment"; action: ExperimentPruneAction };
+
+export function emptyPruneSelection(): PruneSelection {
+  return {
+    questions: [],
+    findings: [],
+    experiments: [],
+  };
+}
+
+export function pruneSelectionCount(selection: PruneSelection): number {
+  return (
+    selection.questions.length +
+    selection.findings.length +
+    selection.experiments.length
+  );
+}
+
+export function pruneSelectionForKind(
+  selection: PruneSelection,
+  kind: PruneableRecordKind,
+): string[] {
+  if (kind === "question") return selection.questions;
+  if (kind === "finding") return selection.findings;
+  return selection.experiments;
+}
+
+export function togglePruneSelection(
+  selection: PruneSelection,
+  kind: PruneableRecordKind,
+  id: string,
+): PruneSelection {
+  const next = new Set(pruneSelectionForKind(selection, kind));
+  if (next.has(id)) {
+    next.delete(id);
+  } else {
+    next.add(id);
+  }
+
+  if (kind === "question") {
+    return { ...selection, questions: [...next].sort() };
+  }
+  if (kind === "finding") {
+    return { ...selection, findings: [...next].sort() };
+  }
+  return { ...selection, experiments: [...next].sort() };
+}
+
+export function removeAppliedFromSelection(
+  selection: PruneSelection,
+  kind: PruneableRecordKind,
+  appliedIds: string[],
+): PruneSelection {
+  if (appliedIds.length === 0) return selection;
+  const applied = new Set(appliedIds);
+  if (kind === "question") {
+    return {
+      ...selection,
+      questions: selection.questions.filter((id) => !applied.has(id)),
+    };
+  }
+  if (kind === "finding") {
+    return {
+      ...selection,
+      findings: selection.findings.filter((id) => !applied.has(id)),
+    };
+  }
+  return {
+    ...selection,
+    experiments: selection.experiments.filter((id) => !applied.has(id)),
+  };
+}
+
+export function intersectPruneSelection(
+  selection: PruneSelection,
+  visible: {
+    questions: Set<string>;
+    findings: Set<string>;
+    experiments: Set<string>;
+  },
+): PruneSelection {
+  return {
+    questions: selection.questions.filter((id) => visible.questions.has(id)),
+    findings: selection.findings.filter((id) => visible.findings.has(id)),
+    experiments: selection.experiments.filter((id) =>
+      visible.experiments.has(id),
+    ),
+  };
+}
+
+export function samePruneSelection(
+  left: PruneSelection,
+  right: PruneSelection,
+): boolean {
+  return (
+    sameIdList(left.questions, right.questions) &&
+    sameIdList(left.findings, right.findings) &&
+    sameIdList(left.experiments, right.experiments)
+  );
+}
+
+export function isExperimentActionEligible(
+  status: ExperimentSummary["status"],
+  action: ExperimentPruneAction,
+): boolean {
+  if (action === "superseded") {
+    return status === "complete" || status === "failed";
+  }
+  return status === "open" || status === "running";
+}
+
+export function experimentActionButtonLabel(
+  action: ExperimentPruneAction,
+): string {
+  if (action === "complete") return "Mark complete";
+  if (action === "failed") return "Mark failed";
+  return "Archive";
+}
+
+export function experimentActionConfirmLabel(
+  action: ExperimentPruneAction,
+): string {
+  if (action === "complete") return "Mark selected complete";
+  if (action === "failed") return "Mark selected failed";
+  return "Archive selected";
+}
+
+export function pruneKindLabel(
+  kind: PruneableRecordKind,
+  count: number,
+): string {
+  if (kind === "question") return count === 1 ? "question" : "questions";
+  if (kind === "finding") return count === 1 ? "finding" : "findings";
+  return count === 1 ? "experiment" : "experiments";
+}
+
+export function buildBulkActionPreview(
+  intent: BulkActionIntent,
+  selection: PruneSelection,
+  experimentsById: Map<string, ExperimentSummary>,
+): BulkActionPreview {
+  if (intent.kind === "question") {
+    return {
+      kind: "question",
+      action: "delete",
+      eligibleIds: selection.questions,
+      sampleIds: selection.questions.slice(0, 6),
+      skipped: [],
+    };
+  }
+
+  if (intent.kind === "finding") {
+    return {
+      kind: "finding",
+      action: "delete",
+      eligibleIds: selection.findings,
+      sampleIds: selection.findings.slice(0, 6),
+      skipped: [],
+    };
+  }
+
+  const eligibleIds: string[] = [];
+  const skipped: BulkActionSkip[] = [];
+  for (const id of selection.experiments) {
+    const experiment = experimentsById.get(id);
+    if (!experiment) {
+      skipped.push({
+        id,
+        reason: "not_visible",
+        message: "Experiment is no longer visible in this view.",
+      });
+      continue;
+    }
+    if (!isExperimentActionEligible(experiment.status, intent.action)) {
+      skipped.push({
+        id,
+        reason: "ineligible_status",
+        message:
+          intent.action === "superseded"
+            ? "Only complete or failed experiments can be archived."
+            : "Only open or running experiments can be marked complete or failed.",
+        current_status: experiment.status,
+      });
+      continue;
+    }
+    eligibleIds.push(id);
+  }
+
+  return {
+    kind: "experiment",
+    action: intent.action,
+    eligibleIds,
+    sampleIds: eligibleIds.slice(0, 6),
+    skipped,
+  };
+}
+
+export function isDeleteAction(action: PruneAction): action is "delete" {
+  return action === "delete";
+}
+
+function sameIdList(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
+}

--- a/ui/src/routes/pages/dashboard.tsx
+++ b/ui/src/routes/pages/dashboard.tsx
@@ -4,12 +4,19 @@ import { useExperiments } from "@/hooks/use-experiments";
 import { useDirections } from "@/hooks/use-directions";
 import { useCurrentFindings } from "@/hooks/use-findings";
 import { useGlobalActivity } from "@/hooks/use-activity";
+import { useFocusMode } from "@/hooks/use-focus";
 import { useRealtimeInvalidation } from "@/hooks/use-realtime";
+import { FocusToggle } from "@/components/shared/focus-toggle";
 import { FindingConfidenceBadge } from "@/components/shared/finding-confidence-badge";
 import { FindingImportanceBadge } from "@/components/shared/finding-importance-badge";
 import { Badge } from "@/components/ui/badge";
 import { StatBlockSkeleton, Skeleton } from "@/components/ui/skeleton";
 import { RecordLink } from "@/components/shared/record-link";
+import {
+  buildDirectFocusReasonMaps,
+  filterActivityForFocus,
+  isDirectFocusReason,
+} from "@/lib/focus-mode";
 import { sortFindingsByImportanceAndRecency } from "@/lib/finding-importance";
 import { formatDateTimeShort, formatDateTime, cn } from "@/lib/utils";
 import type { ExperimentsSearch } from "@/routes/pages/experiments-list";
@@ -69,6 +76,15 @@ export default function DashboardPage() {
   const { data: directions, isLoading: loadingDir } = useDirections();
   const { data: findings, isLoading: loadingFind } = useCurrentFindings();
   const { data: activity } = useGlobalActivity(20);
+  const {
+    enabled: focusEnabled,
+    setEnabled: setFocusEnabled,
+    actorSource,
+    canFocus,
+    description: focusDescription,
+    disabledReason,
+    touchedRecordIds,
+  } = useFocusMode();
 
   useRealtimeInvalidation("experiments", ["experiments"]);
 
@@ -118,9 +134,37 @@ export default function DashboardPage() {
     );
   }
 
-  const exps = experiments ?? [];
-  const dirs = directions ?? [];
-  const finds = sortFindingsByImportanceAndRecency(findings ?? []);
+  const directFocusReasons = buildDirectFocusReasonMaps({
+    projects: [],
+    directions: directions ?? [],
+    questions: [],
+    experiments: experiments ?? [],
+    findings: findings ?? [],
+    actorSource: actorSource ?? "",
+    touchedRecordIds,
+  });
+  const focusActive = focusEnabled && canFocus;
+  const exps = focusActive
+    ? (experiments ?? []).filter((experiment) =>
+        isDirectFocusReason(directFocusReasons.experiments.get(experiment.id)),
+      )
+    : (experiments ?? []);
+  const dirs = focusActive
+    ? (directions ?? []).filter((direction) =>
+        isDirectFocusReason(directFocusReasons.directions.get(direction.id)),
+      )
+    : (directions ?? []);
+  const finds = sortFindingsByImportanceAndRecency(
+    focusActive
+      ? (findings ?? []).filter((finding) =>
+          isDirectFocusReason(directFocusReasons.findings.get(finding.id)),
+        )
+      : (findings ?? []),
+  );
+  const activityItems =
+    focusActive && actorSource
+      ? filterActivityForFocus(activity ?? [], actorSource, directFocusReasons)
+      : (activity ?? []);
 
   const running = exps.filter((e) => e.status === "running").length;
   const complete = exps.filter((e) => e.status === "complete").length;
@@ -128,9 +172,25 @@ export default function DashboardPage() {
 
   return (
     <div className="space-y-5">
-      <h1 className="text-[15px] font-semibold tracking-[-0.015em] text-text">
-        Dashboard
-      </h1>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-[15px] font-semibold tracking-[-0.015em] text-text">
+            Dashboard
+          </h1>
+          {focusActive ? (
+            <p className="mt-0.5 text-[11px] text-text-quaternary">
+              Showing only the material you created or touched recently.
+            </p>
+          ) : null}
+        </div>
+        <FocusToggle
+          enabled={focusEnabled}
+          canFocus={canFocus}
+          description={focusDescription}
+          disabledReason={disabledReason}
+          onToggle={() => setFocusEnabled(!focusEnabled)}
+        />
+      </div>
 
       <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
         <StatBlock
@@ -229,6 +289,11 @@ export default function DashboardPage() {
                 </div>
               </Link>
             ))}
+            {dirs.length === 0 && (
+              <div className="px-3 py-6 text-center text-[12px] text-text-quaternary">
+                {focusActive ? "No focused directions yet." : "No directions yet."}
+              </div>
+            )}
           </div>
         </div>
 
@@ -272,6 +337,11 @@ export default function DashboardPage() {
                 </div>
               </Link>
             ))}
+            {finds.length === 0 && (
+              <div className="px-3 py-6 text-center text-[12px] text-text-quaternary">
+                {focusActive ? "No focused findings yet." : "No findings yet."}
+              </div>
+            )}
           </div>
         </div>
 
@@ -288,7 +358,7 @@ export default function DashboardPage() {
             </Link>
           </div>
           <div>
-            {activity?.slice(0, 8).map((a) => (
+            {activityItems.slice(0, 8).map((a) => (
               <div
                 key={a.id}
                 className="flex items-start justify-between gap-2 border-b border-border-subtle px-3 py-2 transition-colors last:border-0 hover:bg-surface-hover/80"
@@ -315,9 +385,9 @@ export default function DashboardPage() {
                 </span>
               </div>
             ))}
-            {(!activity || activity.length === 0) && (
+            {activityItems.length === 0 && (
               <div className="py-6 text-center text-[12px] text-text-quaternary">
-                No activity yet
+                {focusActive ? "No focused activity yet" : "No activity yet"}
               </div>
             )}
           </div>

--- a/ui/src/routes/pages/experiments-list.tsx
+++ b/ui/src/routes/pages/experiments-list.tsx
@@ -13,9 +13,11 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { ArrowDown, ChevronRight } from "lucide-react";
 import { ROUTE_API } from "../route-ids";
 import { useExperiments, useExperimentSearch } from "@/hooks/use-experiments";
+import { useFocusMode } from "@/hooks/use-focus";
 import { useProjects } from "@/hooks/use-projects";
 import { useDirections } from "@/hooks/use-directions";
 import { useListKeyboardNav } from "@/hooks/use-keyboard";
+import { FocusToggle } from "@/components/shared/focus-toggle";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { ExperimentRowSkeleton } from "@/components/ui/skeleton";
@@ -34,6 +36,10 @@ import {
 import { useActiveProgram } from "@/stores/program";
 import type { ArtifactType, ExperimentSummary } from "@/types/sonde";
 import { experimentMatchesSearchQuery } from "@/lib/experiment-search-match";
+import {
+  buildDirectFocusReasonMaps,
+  isDirectFocusReason,
+} from "@/lib/focus-mode";
 import {
   buildTimePoints,
   isTimestampInTimeRange,
@@ -212,6 +218,15 @@ export default function ExperimentsListPage() {
   const { data: experiments, isLoading } = useExperiments();
   const { data: projects } = useProjects();
   const { data: directions } = useDirections();
+  const {
+    enabled: focusEnabled,
+    setEnabled: setFocusEnabled,
+    actorSource,
+    canFocus,
+    description: focusDescription,
+    disabledReason,
+    touchedRecordIds,
+  } = useFocusMode();
   const activeProgram = useActiveProgram();
   const navigate = routeApi.useNavigate();
   const { q, status, artifact, view, day, sort, order, from, to } =
@@ -229,13 +244,38 @@ export default function ExperimentsListPage() {
 
   const [projOpen, setProjOpen] = useState<Record<string, boolean>>({});
   const [dirOpen, setDirOpen] = useState<Record<string, boolean>>({});
+  const directFocusReasons = useMemo(
+    () =>
+      buildDirectFocusReasonMaps({
+        projects: [],
+        directions: [],
+        questions: [],
+        experiments: experiments ?? [],
+        findings: [],
+        actorSource: actorSource ?? "",
+        touchedRecordIds,
+      }),
+    [actorSource, experiments, touchedRecordIds]
+  );
+  const focusActive = focusEnabled && canFocus;
+  const baseExperiments = useMemo(
+    () =>
+      focusActive
+        ? (experiments ?? []).filter((experiment) =>
+            isDirectFocusReason(
+              directFocusReasons.experiments.get(experiment.id)
+            )
+          )
+        : (experiments ?? []),
+    [directFocusReasons.experiments, experiments, focusActive]
+  );
 
   const timePoints = useMemo(
     () =>
-      buildTimePoints(experiments ?? [], (exp) =>
+      buildTimePoints(baseExperiments, (exp) =>
         timestampFromIso(exp.created_at)
       ),
-    [experiments]
+    [baseExperiments]
   );
   const activeTimeRange = useMemo(
     () => resolveTimeRangeSelection(timePoints, from, to),
@@ -243,8 +283,7 @@ export default function ExperimentsListPage() {
   );
 
   const filtered = useMemo(() => {
-    if (!experiments) return [];
-    let result = experiments;
+    let result = baseExperiments;
     if (statusFilter !== "all") {
       result = result.filter((e) => e.status === statusFilter);
     }
@@ -270,7 +309,7 @@ export default function ExperimentsListPage() {
     }
     return result;
   }, [
-    experiments,
+    baseExperiments,
     deferredFilter,
     statusFilter,
     artifactFilter,
@@ -469,6 +508,7 @@ export default function ExperimentsListPage() {
         </div>
         <span className="text-[12px] text-text-quaternary sm:shrink-0">
           {filtered.length} result{filtered.length !== 1 ? "s" : ""}
+          {focusActive ? " in focus" : ""}
         </span>
       </div>
 
@@ -510,6 +550,14 @@ export default function ExperimentsListPage() {
             })
           }
           className="max-w-[280px]"
+        />
+        <FocusToggle
+          enabled={focusEnabled}
+          canFocus={canFocus}
+          description={focusDescription}
+          disabledReason={disabledReason}
+          onToggle={() => setFocusEnabled(!focusEnabled)}
+          compact
         />
         {timePoints.length > 0 && (
           <TimeRangeBar
@@ -637,7 +685,9 @@ export default function ExperimentsListPage() {
               <div className="space-y-4">
                 {projectTree.length === 0 ? (
                   <div className="py-10 text-center text-[13px] text-text-quaternary">
-                    No experiments match your filters.
+                    {focusActive
+                      ? "No focused experiments match your filters."
+                      : "No experiments match your filters."}
                   </div>
                 ) : (
                   projectTree.map((pg) => (
@@ -775,7 +825,9 @@ export default function ExperimentsListPage() {
           )}
           {viewMode === "list" && sortedFiltered.length === 0 && (
             <div className="py-10 text-center text-[13px] text-text-quaternary">
-              No experiments match your filters.
+              {focusActive
+                ? "No focused experiments match your filters."
+                : "No experiments match your filters."}
             </div>
           )}
       </div>

--- a/ui/src/routes/pages/finding-detail.tsx
+++ b/ui/src/routes/pages/finding-detail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type ReactNode } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getRouteApi, Link } from "@tanstack/react-router";
 import { ROUTE_API } from "../route-ids";
@@ -7,21 +7,27 @@ import {
   useUpdateFindingConfidence,
   useUpdateFindingImportance,
 } from "@/hooks/use-findings";
+import { useFocusMode } from "@/hooks/use-focus";
+import { useDeleteFindings } from "@/hooks/use-prune-mutations";
 import { useQuestionsByFinding } from "@/hooks/use-questions";
 import { useDirections } from "@/hooks/use-directions";
 import { useProjects } from "@/hooks/use-projects";
 import { useRecordActivity } from "@/hooks/use-activity";
 import { useHotkey } from "@/hooks/use-keyboard";
+import { PruneConfirmDialog } from "@/components/prune/prune-confirm-dialog";
 import { FindingConfidenceBadge } from "@/components/shared/finding-confidence-badge";
 import { FindingImportanceBadge } from "@/components/shared/finding-importance-badge";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Skeleton, DetailSectionSkeleton } from "@/components/ui/skeleton";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { MarkdownView } from "@/components/ui/markdown-view";
 import { Section, DetailRow } from "@/components/shared/detail-layout";
+import { displaySourceLabel } from "@/lib/actor-source";
 import { RecordUnavailable } from "@/components/shared/record-unavailable";
 import { RecordLink } from "@/components/shared/record-link";
 import { InlineMarkdownText } from "@/components/shared/inline-markdown-text";
+import { buildBulkActionPreview } from "@/lib/prune-actions";
 import {
   FINDING_CONFIDENCE_LEVELS,
   findingConfidenceLabel,
@@ -32,7 +38,7 @@ import {
 } from "@/lib/finding-importance";
 import { supabase } from "@/lib/supabase";
 import { cn, formatDateTime, formatDateTimeShort } from "@/lib/utils";
-import { ArrowLeft, Check } from "lucide-react";
+import { ArrowLeft, Check, Trash2 } from "lucide-react";
 import type {
   DirectionSummary,
   ExperimentSummary,
@@ -68,13 +74,16 @@ const importanceButtonStyles: Record<FindingImportance, string> = {
 export default function FindingDetailPage() {
   const { id } = routeApi.useParams();
   const nav = routeApi.useNavigate();
+  const { actorSource } = useFocusMode();
   const { data: finding, isLoading } = useFinding(id);
+  const deleteFindings = useDeleteFindings();
   const { data: linkedQuestions } = useQuestionsByFinding(id);
   const { data: projects } = useProjects();
   const { data: directions } = useDirections();
   const { data: activity } = useRecordActivity(id);
   const updateConfidence = useUpdateFindingConfidence(id);
   const updateImportance = useUpdateFindingImportance(id);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const evidenceIds = finding?.evidence ?? [];
   const { data: evidenceExperiments } = useQuery({
     queryKey: ["findings", "detail", id, "evidence-experiments", evidenceIds] as const,
@@ -151,11 +160,22 @@ export default function FindingDetailPage() {
           <FindingConfidenceBadge confidence={finding.confidence} />
           <FindingImportanceBadge importance={finding.importance} />
         </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="ml-auto"
+          onClick={() => setDeleteOpen(true)}
+        >
+          <Trash2 className="h-4 w-4" />
+          Delete
+        </Button>
         <span
           className="text-[12px] text-text-quaternary"
           title={formatDateTime(finding.valid_from)}
         >
-          {finding.source} · {formatDateTimeShort(finding.valid_from)}
+          Created by {displaySourceLabel(finding.source, actorSource)} ·{" "}
+          {formatDateTimeShort(finding.valid_from)}
         </span>
       </div>
 
@@ -225,7 +245,11 @@ export default function FindingDetailPage() {
           <Section title="Details">
             <div className="divide-y divide-border-subtle">
               <DetailRow label="Program">{finding.program}</DetailRow>
-              <DetailRow label="Source">{finding.source}</DetailRow>
+              <DetailRow label="Created by">
+                <span title={finding.source}>
+                  {displaySourceLabel(finding.source, actorSource)}
+                </span>
+              </DetailRow>
               <FindingAxisEditor
                 label="Confidence"
                 valueBadge={
@@ -322,6 +346,33 @@ export default function FindingDetailPage() {
           )}
         </div>
       </div>
+
+      <PruneConfirmDialog
+        open={deleteOpen}
+        kind="finding"
+        action="delete"
+        title={`Delete ${finding.id}?`}
+        description="This removes the finding, repairs any supersession links that depend on it, and queues linked artifacts for cleanup."
+        preview={buildBulkActionPreview(
+          { kind: "finding", action: "delete" },
+          {
+            questions: [],
+            findings: [finding.id],
+            experiments: [],
+          },
+          new Map(),
+        )}
+        isPending={deleteFindings.isPending}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={async () => {
+          const result = await deleteFindings.mutateAsync({
+            ids: [finding.id],
+          });
+          if (result.summary.applied > 0) {
+            nav({ to: "/findings" });
+          }
+        }}
+      />
     </div>
   );
 }

--- a/ui/src/routes/pages/findings-list.tsx
+++ b/ui/src/routes/pages/findings-list.tsx
@@ -1,14 +1,25 @@
-import { useCallback, useMemo, type ReactNode } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { getRouteApi } from "@tanstack/react-router";
 import { ROUTE_API } from "../route-ids";
 import type { FindingsSearch } from "../findings";
 import { useCurrentFindings } from "@/hooks/use-findings";
+import { useFocusMode } from "@/hooks/use-focus";
+import { useDeleteFindings } from "@/hooks/use-prune-mutations";
 import { useRealtimeInvalidation } from "@/hooks/use-realtime";
 import { useListKeyboardNav } from "@/hooks/use-keyboard";
+import { PruneConfirmDialog } from "@/components/prune/prune-confirm-dialog";
+import { FocusToggle } from "@/components/shared/focus-toggle";
 import { FindingConfidenceBadge } from "@/components/shared/finding-confidence-badge";
 import { FindingImportanceBadge } from "@/components/shared/finding-importance-badge";
+import { Button } from "@/components/ui/button";
 import { TimeRangeBar } from "@/components/shared/time-range-bar";
 import { ListRowSkeleton } from "@/components/ui/skeleton";
+import { displaySourceLabel } from "@/lib/actor-source";
+import {
+  buildDirectFocusReasonMaps,
+  isDirectFocusReason,
+} from "@/lib/focus-mode";
+import { buildBulkActionPreview } from "@/lib/prune-actions";
 import {
   FINDING_CONFIDENCE_LEVELS,
   findingConfidenceLabel,
@@ -30,6 +41,7 @@ import {
 } from "@/lib/finding-time-range";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import type { Finding, FindingConfidence, FindingImportance } from "@/types/sonde";
+import { Trash2 } from "lucide-react";
 
 const routeApi = getRouteApi(ROUTE_API.authFindings);
 
@@ -45,6 +57,17 @@ export default function FindingsListPage() {
   const navigate = routeApi.useNavigate();
   const { confidence, importance, from, to } = routeApi.useSearch();
   const { data: findings, isLoading } = useCurrentFindings();
+  const {
+    enabled: focusEnabled,
+    setEnabled: setFocusEnabled,
+    actorSource,
+    canFocus,
+    description: focusDescription,
+    disabledReason,
+    touchedRecordIds,
+  } = useFocusMode();
+  const deleteFindings = useDeleteFindings();
+  const [pendingDelete, setPendingDelete] = useState<Finding | null>(null);
   useRealtimeInvalidation("findings", ["findings"]);
   const handleClick = useCallback(
     (id: string) => navigate({ to: "/findings/$id", params: { id } }),
@@ -70,9 +93,32 @@ export default function FindingsListPage() {
     () => new Set(activeImportance),
     [activeImportance]
   );
+  const directFocusReasons = useMemo(
+    () =>
+      buildDirectFocusReasonMaps({
+        projects: [],
+        directions: [],
+        questions: [],
+        experiments: [],
+        findings: findings ?? [],
+        actorSource: actorSource ?? "",
+        touchedRecordIds,
+      }),
+    [actorSource, findings, touchedRecordIds]
+  );
+  const focusActive = focusEnabled && canFocus;
+  const baseFindings = useMemo(
+    () =>
+      focusActive
+        ? (findings ?? []).filter((finding) =>
+            isDirectFocusReason(directFocusReasons.findings.get(finding.id))
+          )
+        : (findings ?? []),
+    [directFocusReasons.findings, findings, focusActive]
+  );
   const timePoints = useMemo(
-    () => buildFindingTimePoints(findings ?? []),
-    [findings]
+    () => buildFindingTimePoints(baseFindings),
+    [baseFindings]
   );
   const activeTimeRange = useMemo(
     () => resolveFindingTimeRangeSelection(timePoints, from, to),
@@ -81,9 +127,10 @@ export default function FindingsListPage() {
   const hasActiveFilter =
     activeConfidence.length > 0 ||
     activeImportance.length > 0 ||
-    activeTimeRange.isActive;
+    activeTimeRange.isActive ||
+    focusActive;
   const items = useMemo(() => {
-    const source = sortFindingsByImportanceAndRecency(findings ?? []);
+    const source = sortFindingsByImportanceAndRecency(baseFindings);
     return source.filter((finding) => {
       const confidenceMatch =
         activeConfidenceSet.size === 0 ||
@@ -94,7 +141,7 @@ export default function FindingsListPage() {
       const timeMatch = isFindingInTimeRange(finding, activeTimeRange);
       return confidenceMatch && importanceMatch && timeMatch;
     });
-  }, [activeConfidenceSet, activeImportanceSet, activeTimeRange, findings]);
+  }, [activeConfidenceSet, activeImportanceSet, activeTimeRange, baseFindings]);
   const { focusedIndex } = useListKeyboardNav(items, handleSelect);
 
   const toggleConfidence = useCallback(
@@ -218,12 +265,20 @@ export default function FindingsListPage() {
         </h1>
         <span className="text-[12px] text-text-quaternary">
           {items.length}
-          {hasActiveFilter ? ` of ${findings?.length ?? 0}` : ""}{" "}
+          {hasActiveFilter ? ` of ${baseFindings.length}` : ""}{" "}
           current
         </span>
       </div>
 
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+        <FocusToggle
+          enabled={focusEnabled}
+          canFocus={canFocus}
+          description={focusDescription}
+          disabledReason={disabledReason}
+          onToggle={() => setFocusEnabled(!focusEnabled)}
+          compact
+        />
         <FilterAxisBar
           label="Confidence"
           clearLabel="Any"
@@ -279,42 +334,94 @@ export default function FindingsListPage() {
         {items.map((f, idx) => (
           <div
             key={f.id}
-            onClick={() => handleClick(f.id)}
-            className={`flex cursor-pointer items-start gap-4 border-b border-border-subtle px-3 py-2.5 transition-colors last:border-0 hover:bg-surface-hover ${focusedIndex === idx ? "ring-1 ring-inset ring-accent bg-surface-hover" : ""}`}
+            className={`group flex items-start gap-3 border-b border-border-subtle px-3 py-2.5 transition-colors last:border-0 hover:bg-surface-hover ${focusedIndex === idx ? "ring-1 ring-inset ring-accent bg-surface-hover" : ""}`}
           >
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <span className="font-mono text-[11px] text-text-quaternary">
-                  {f.id}
-                </span>
-                <FindingConfidenceBadge confidence={f.confidence} />
-                <FindingImportanceBadge importance={f.importance} />
+            <button
+              type="button"
+              onClick={() => handleClick(f.id)}
+              className="flex min-w-0 flex-1 items-start gap-4 text-left"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-[11px] text-text-quaternary">
+                    {f.id}
+                  </span>
+                  <FindingConfidenceBadge confidence={f.confidence} />
+                  <FindingImportanceBadge importance={f.importance} />
+                </div>
+                <p className="mt-0.5 text-[13px] font-medium text-text">
+                  {f.topic}
+                </p>
+                <p className="mt-0.5 line-clamp-2 text-[12px] leading-relaxed text-text-tertiary">
+                  {f.finding}
+                </p>
+                <p
+                  className="mt-1 text-[11px] text-text-quaternary"
+                  title={f.source}
+                >
+                  Created by {displaySourceLabel(f.source, actorSource)}
+                </p>
               </div>
-              <p className="mt-0.5 text-[13px] font-medium text-text">
-                {f.topic}
-              </p>
-              <p className="mt-0.5 line-clamp-2 text-[12px] leading-relaxed text-text-tertiary">
-                {f.finding}
-              </p>
-            </div>
-            <div className="shrink-0 text-right">
-              <p className="text-[11px] text-text-quaternary">
-                {f.evidence.length} exp{f.evidence.length !== 1 ? "s" : ""}
-              </p>
-              <p className="text-[11px] text-text-quaternary">
-                {formatRelativeTime(f.valid_from)}
-              </p>
-            </div>
+              <div className="shrink-0 text-right">
+                <p className="text-[11px] text-text-quaternary">
+                  {f.evidence.length} exp{f.evidence.length !== 1 ? "s" : ""}
+                </p>
+                <p className="text-[11px] text-text-quaternary">
+                  {formatRelativeTime(f.valid_from)}
+                </p>
+              </div>
+            </button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="mt-0.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+              aria-label={`Delete ${f.id}`}
+              onClick={() => setPendingDelete(f)}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
           </div>
         ))}
         {items.length === 0 && (
           <div className="py-10 text-center text-[13px] text-text-quaternary">
-            {hasActiveFilter
-              ? "No findings match the selected confidence, importance, and time filters."
-              : "No current findings."}
+            {focusActive
+              ? "No focused findings match the selected filters."
+              : hasActiveFilter
+                ? "No findings match the selected confidence, importance, and time filters."
+                : "No current findings."}
           </div>
         )}
       </div>
+
+      {pendingDelete ? (
+        <PruneConfirmDialog
+          open
+          kind="finding"
+          action="delete"
+          title={`Delete ${pendingDelete.id}?`}
+          description="This removes the finding, repairs supersession links if needed, and queues any linked artifacts for cleanup."
+          preview={buildBulkActionPreview(
+            { kind: "finding", action: "delete" },
+            {
+              questions: [],
+              findings: [pendingDelete.id],
+              experiments: [],
+            },
+            new Map(),
+          )}
+          isPending={deleteFindings.isPending}
+          onClose={() => setPendingDelete(null)}
+          onConfirm={async () => {
+            const result = await deleteFindings.mutateAsync({
+              ids: [pendingDelete.id],
+            });
+            if (result.summary.applied > 0) {
+              setPendingDelete(null);
+            }
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/ui/src/routes/pages/question-detail.tsx
+++ b/ui/src/routes/pages/question-detail.tsx
@@ -1,15 +1,20 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getRouteApi, Link } from "@tanstack/react-router";
 import { ROUTE_API } from "../route-ids";
+import { displaySourceLabel } from "@/lib/actor-source";
 import { supabase } from "@/lib/supabase";
+import { useFocusMode } from "@/hooks/use-focus";
+import { useDeleteQuestions } from "@/hooks/use-prune-mutations";
 import { useQuestion } from "@/hooks/use-questions";
 import { useDirection } from "@/hooks/use-directions";
 import { useRecordActivity } from "@/hooks/use-activity";
 import { useHotkey } from "@/hooks/use-keyboard";
+import { PruneConfirmDialog } from "@/components/prune/prune-confirm-dialog";
 import { FindingConfidenceBadge } from "@/components/shared/finding-confidence-badge";
 import { FindingImportanceBadge } from "@/components/shared/finding-importance-badge";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Skeleton,
   DetailSectionSkeleton,
@@ -19,10 +24,11 @@ import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Section, DetailRow } from "@/components/shared/detail-layout";
 import { RecordUnavailable } from "@/components/shared/record-unavailable";
 import { RecordLink } from "@/components/shared/record-link";
+import { buildBulkActionPreview } from "@/lib/prune-actions";
 import { sortFindingsByImportanceAndRecency } from "@/lib/finding-importance";
 import { formatDateTime, formatDateTimeShort } from "@/lib/utils";
 import type { ExperimentSummary, Finding } from "@/types/sonde";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Trash2 } from "lucide-react";
 
 const routeApi = getRouteApi(ROUTE_API.authQuestionDetail);
 
@@ -35,9 +41,12 @@ function statusVariant(status: string): "complete" | "running" | "default" {
 export default function QuestionDetailPage() {
   const { id } = routeApi.useParams();
   const navigate = routeApi.useNavigate();
+  const { actorSource } = useFocusMode();
   const { data: question, isLoading } = useQuestion(id);
   const { data: direction } = useDirection(question?.direction_id ?? "");
   const { data: activity } = useRecordActivity(id);
+  const deleteQuestions = useDeleteQuestions();
+  const [deleteOpen, setDeleteOpen] = useState(false);
   useHotkey(
     "Escape",
     useCallback(() => navigate({ to: "/questions" }), [navigate]),
@@ -156,10 +165,21 @@ export default function QuestionDetailPage() {
             {question.status}
           </Badge>
         </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="ml-auto"
+          onClick={() => setDeleteOpen(true)}
+        >
+          <Trash2 className="h-4 w-4" />
+          Delete
+        </Button>
         <span
           className="text-[12px] text-text-quaternary"
           title={formatDateTime(question.created_at)}
         >
+          Created by {displaySourceLabel(question.source, actorSource)} ·{" "}
           {formatDateTimeShort(question.created_at)}
         </span>
       </div>
@@ -218,7 +238,11 @@ export default function QuestionDetailPage() {
                   "—"
                 )}
               </DetailRow>
-              <DetailRow label="Source">{question.source}</DetailRow>
+              <DetailRow label="Created by">
+                <span title={question.source}>
+                  {displaySourceLabel(question.source, actorSource)}
+                </span>
+              </DetailRow>
               <DetailRow label="Experiments">
                 {question.linked_experiment_count}
               </DetailRow>
@@ -249,6 +273,33 @@ export default function QuestionDetailPage() {
           )}
         </div>
       </div>
+
+      <PruneConfirmDialog
+        open={deleteOpen}
+        kind="question"
+        action="delete"
+        title={`Delete ${question.id}?`}
+        description="This removes the question from the question inbox and linked question views. Experiments and findings remain available."
+        preview={buildBulkActionPreview(
+          { kind: "question", action: "delete" },
+          {
+            questions: [question.id],
+            findings: [],
+            experiments: [],
+          },
+          new Map(),
+        )}
+        isPending={deleteQuestions.isPending}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={async () => {
+          const result = await deleteQuestions.mutateAsync({
+            ids: [question.id],
+          });
+          if (result.summary.applied > 0) {
+            navigate({ to: "/questions" });
+          }
+        }}
+      />
     </div>
   );
 }

--- a/ui/src/routes/pages/questions.tsx
+++ b/ui/src/routes/pages/questions.tsx
@@ -1,11 +1,23 @@
 import { Link } from "@tanstack/react-router";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { useFocusMode } from "@/hooks/use-focus";
 import { useQuestions } from "@/hooks/use-questions";
 import { useDirections } from "@/hooks/use-directions";
+import { useDeleteQuestions } from "@/hooks/use-prune-mutations";
+import { FocusToggle } from "@/components/shared/focus-toggle";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { PruneConfirmDialog } from "@/components/prune/prune-confirm-dialog";
 import { ListRowSkeleton } from "@/components/ui/skeleton";
+import { displaySourceLabel } from "@/lib/actor-source";
+import {
+  buildDirectFocusReasonMaps,
+  isDirectFocusReason,
+} from "@/lib/focus-mode";
+import { buildBulkActionPreview } from "@/lib/prune-actions";
 import { formatRelativeTime } from "@/lib/utils";
 import type { QuestionStatus, QuestionSummary } from "@/types/sonde";
+import { Trash2 } from "lucide-react";
 
 const STATUS_ORDER: QuestionStatus[] = [
   "open",
@@ -25,45 +37,100 @@ function statusVariant(
 function QuestionRow({
   question,
   directionLabel,
+  actorSource,
+  onDelete,
 }: {
   question: QuestionSummary;
   directionLabel: string;
+  actorSource: string | null;
+  onDelete: (question: QuestionSummary) => void;
 }) {
   return (
-    <Link
-      to="/questions/$id"
-      params={{ id: question.id }}
-      className="flex items-start gap-4 border-b border-border-subtle px-3 py-2.5 transition-colors last:border-0 hover:bg-surface-hover"
-    >
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="font-mono text-[11px] text-text-quaternary">
-            {question.id}
-          </span>
-          <Badge variant={statusVariant(question.status)}>
-            {question.status}
-          </Badge>
-          <span className="text-[11px] text-text-quaternary">
-            {directionLabel}
-          </span>
+    <div className="group flex items-start gap-3 border-b border-border-subtle px-3 py-2.5 transition-colors last:border-0 hover:bg-surface-hover">
+      <Link
+        to="/questions/$id"
+        params={{ id: question.id }}
+        className="flex min-w-0 flex-1 items-start gap-4"
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-[11px] text-text-quaternary">
+              {question.id}
+            </span>
+            <Badge variant={statusVariant(question.status)}>
+              {question.status}
+            </Badge>
+            <span className="text-[11px] text-text-quaternary">
+              {directionLabel}
+            </span>
+          </div>
+          <p className="mt-0.5 text-[13px] text-text">{question.question}</p>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-text-quaternary">
+            <span>{question.linked_experiment_count} experiments</span>
+            <span>{question.linked_finding_count} findings</span>
+            {question.raised_by && <span>raised by {question.raised_by}</span>}
+            <span title={question.source}>
+              created by {displaySourceLabel(question.source, actorSource)}
+            </span>
+          </div>
         </div>
-        <p className="mt-0.5 text-[13px] text-text">{question.question}</p>
-        <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-text-quaternary">
-          <span>{question.linked_experiment_count} experiments</span>
-          <span>{question.linked_finding_count} findings</span>
-          {question.raised_by && <span>raised by {question.raised_by}</span>}
-        </div>
-      </div>
-      <span className="shrink-0 text-[11px] text-text-quaternary">
-        {formatRelativeTime(question.updated_at)}
-      </span>
-    </Link>
+        <span className="shrink-0 text-[11px] text-text-quaternary">
+          {formatRelativeTime(question.updated_at)}
+        </span>
+      </Link>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="mt-0.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+        aria-label={`Delete ${question.id}`}
+        onClick={() => onDelete(question)}
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+    </div>
   );
 }
 
 export default function QuestionsPage() {
   const { data: questions, isLoading } = useQuestions();
   const { data: directions } = useDirections();
+  const {
+    enabled: focusEnabled,
+    setEnabled: setFocusEnabled,
+    actorSource,
+    canFocus,
+    description: focusDescription,
+    disabledReason,
+    touchedRecordIds,
+  } = useFocusMode();
+  const deleteQuestions = useDeleteQuestions();
+  const [pendingDelete, setPendingDelete] = useState<QuestionSummary | null>(
+    null,
+  );
+  const directFocusReasons = useMemo(
+    () =>
+      buildDirectFocusReasonMaps({
+        projects: [],
+        directions: [],
+        questions: questions ?? [],
+        experiments: [],
+        findings: [],
+        actorSource: actorSource ?? "",
+        touchedRecordIds,
+      }),
+    [actorSource, questions, touchedRecordIds],
+  );
+  const focusActive = focusEnabled && canFocus;
+  const visibleQuestions = useMemo(
+    () =>
+      focusActive
+        ? (questions ?? []).filter((question) =>
+            isDirectFocusReason(directFocusReasons.questions.get(question.id)),
+          )
+        : (questions ?? []),
+    [directFocusReasons.questions, focusActive, questions],
+  );
 
   const directionLabelById = useMemo(() => {
     const map = new Map<string, string>();
@@ -76,12 +143,12 @@ export default function QuestionsPage() {
   const grouped = useMemo(() => {
     const buckets = new Map<QuestionStatus, QuestionSummary[]>();
     for (const status of STATUS_ORDER) buckets.set(status, []);
-    for (const question of questions ?? []) {
+    for (const question of visibleQuestions) {
       const list = buckets.get(question.status);
       if (list) list.push(question);
     }
     return buckets;
-  }, [questions]);
+  }, [visibleQuestions]);
 
   if (isLoading) {
     return (
@@ -107,9 +174,18 @@ export default function QuestionsPage() {
           Questions
         </h1>
         <span className="text-[12px] text-text-quaternary">
-          {questions?.length ?? 0} total
+          {visibleQuestions.length}
+          {focusActive ? ` of ${questions?.length ?? 0}` : ""} total
         </span>
       </div>
+      <FocusToggle
+        enabled={focusEnabled}
+        canFocus={canFocus}
+        description={focusDescription}
+        disabledReason={disabledReason}
+        onToggle={() => setFocusEnabled(!focusEnabled)}
+        compact
+      />
 
       {STATUS_ORDER.map((status) => {
         const items = grouped.get(status) ?? [];
@@ -132,6 +208,8 @@ export default function QuestionsPage() {
                 <QuestionRow
                   key={question.id}
                   question={question}
+                  actorSource={actorSource}
+                  onDelete={setPendingDelete}
                   directionLabel={
                     (question.direction_id &&
                       directionLabelById.get(question.direction_id)) ||
@@ -144,11 +222,40 @@ export default function QuestionsPage() {
         );
       })}
 
-      {(questions?.length ?? 0) === 0 && (
+      {visibleQuestions.length === 0 && (
         <div className="rounded-[8px] border border-border bg-surface py-10 text-center text-[13px] text-text-quaternary">
-          No questions yet.
+          {focusActive ? "No focused questions yet." : "No questions yet."}
         </div>
       )}
+
+      {pendingDelete ? (
+        <PruneConfirmDialog
+          open
+          kind="question"
+          action="delete"
+          title={`Delete ${pendingDelete.id}?`}
+          description="This removes the question from the question inbox and linked views. Experiments and findings stay in place."
+          preview={buildBulkActionPreview(
+            { kind: "question", action: "delete" },
+            {
+              questions: [pendingDelete.id],
+              findings: [],
+              experiments: [],
+            },
+            new Map(),
+          )}
+          isPending={deleteQuestions.isPending}
+          onClose={() => setPendingDelete(null)}
+          onConfirm={async () => {
+            const result = await deleteQuestions.mutateAsync({
+              ids: [pendingDelete.id],
+            });
+            if (result.summary.applied > 0) {
+              setPendingDelete(null);
+            }
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/ui/src/routes/pages/tree-page.tsx
+++ b/ui/src/routes/pages/tree-page.tsx
@@ -14,19 +14,44 @@ import { useQuestions } from "@/hooks/use-questions";
 import { useProjects } from "@/hooks/use-projects";
 import { usePrograms } from "@/hooks/use-programs";
 import { useFindings } from "@/hooks/use-findings";
+import { useFocusMode } from "@/hooks/use-focus";
+import { FocusToggle } from "@/components/shared/focus-toggle";
+import {
+  useDeleteFindings,
+  useDeleteQuestions,
+  useTransitionExperiments,
+} from "@/hooks/use-prune-mutations";
 import { useActiveProgram } from "@/stores/program";
+import { PruneActionBar } from "@/components/prune/prune-action-bar";
+import { PruneConfirmDialog } from "@/components/prune/prune-confirm-dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   ResearchTree,
   type TreeNavigateTarget,
 } from "@/components/visualizations/research-tree";
+import {
+  buildBulkActionPreview,
+  emptyPruneSelection,
+  experimentActionConfirmLabel,
+  intersectPruneSelection,
+  isExperimentActionEligible,
+  removeAppliedFromSelection,
+  samePruneSelection,
+  togglePruneSelection,
+  type BulkActionIntent,
+} from "@/lib/prune-actions";
+import {
+  buildFocusedWorkspaceData,
+  isDirectFocusReason,
+} from "@/lib/focus-mode";
 import { buildTimelineVisibleTreeData } from "@/lib/tree-timeline-visibility";
 import { formatDateTimeShort } from "@/lib/utils";
-import { Pause, Play } from "lucide-react";
+import { CheckSquare2, Pause, Play } from "lucide-react";
 import type {
   DirectionSummary,
   ExperimentSummary,
   Finding,
+  PruneSelection,
   ProjectSummary,
   QuestionSummary,
 } from "@/types/sonde";
@@ -83,12 +108,31 @@ export default function TreePage() {
   const { data: projects, isLoading: loadingProj } = useProjects();
   const { data: findings, isLoading: loadingFindings } = useFindings();
   const { data: programs } = usePrograms();
+  const {
+    enabled: focusEnabled,
+    setEnabled: setFocusEnabled,
+    actorSource,
+    canFocus,
+    description: focusDescription,
+    disabledReason,
+    touchedRecordIds,
+  } = useFocusMode();
   const activeProgram = useActiveProgram();
   const navigate = routeApi.useNavigate();
   const [viewMode, setViewMode] = useState<"tree" | "map">("tree");
   const [timelineIndex, setTimelineIndex] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const [timelineSpeedIndex, setTimelineSpeedIndex] = useState(1);
+  const [manageMode, setManageMode] = useState(false);
+  const [selection, setSelection] = useState<PruneSelection>(
+    emptyPruneSelection(),
+  );
+  const [pendingAction, setPendingAction] = useState<BulkActionIntent | null>(
+    null,
+  );
+  const deleteQuestions = useDeleteQuestions();
+  const deleteFindings = useDeleteFindings();
+  const transitionExperiments = useTransitionExperiments();
 
   const programLabel =
     programs?.find((p) => p.id === activeProgram)?.name ?? activeProgram;
@@ -155,11 +199,117 @@ export default function TreePage() {
     [projects, directions, questions, experiments, findings, timelineCutoff],
   );
 
-  const visibleProjects = visibleTreeData.projects;
-  const visibleDirections = visibleTreeData.directions;
-  const visibleQuestions = visibleTreeData.questions;
-  const visibleExperiments = visibleTreeData.experiments;
-  const visibleFindings = visibleTreeData.findings;
+  const focusActive = focusEnabled && canFocus && !!actorSource;
+  const focusedTreeData = useMemo(
+    () =>
+      focusActive
+        ? buildFocusedWorkspaceData({
+            projects: visibleTreeData.projects,
+            directions: visibleTreeData.directions,
+            questions: visibleTreeData.questions,
+            experiments: visibleTreeData.experiments,
+            findings: visibleTreeData.findings,
+            actorSource,
+            touchedRecordIds,
+          })
+        : null,
+    [actorSource, focusActive, touchedRecordIds, visibleTreeData],
+  );
+
+  const visibleProjects = focusedTreeData?.projects ?? visibleTreeData.projects;
+  const visibleDirections =
+    focusedTreeData?.directions ?? visibleTreeData.directions;
+  const visibleQuestions =
+    focusedTreeData?.questions ?? visibleTreeData.questions;
+  const visibleExperiments =
+    focusedTreeData?.experiments ?? visibleTreeData.experiments;
+  const visibleFindings = focusedTreeData?.findings ?? visibleTreeData.findings;
+  const focusReasons = focusedTreeData?.reasons ?? null;
+  const visibleExperimentIds = useMemo(
+    () => new Set(visibleExperiments.map((item) => item.id)),
+    [visibleExperiments],
+  );
+  const visibleQuestionIds = useMemo(
+    () => new Set(visibleQuestions.map((item) => item.id)),
+    [visibleQuestions],
+  );
+  const visibleFindingIds = useMemo(
+    () => new Set(visibleFindings.map((item) => item.id)),
+    [visibleFindings],
+  );
+  const selectableExperimentIds = useMemo(
+    () =>
+      focusActive && focusReasons
+        ? new Set(
+            visibleExperiments
+              .filter((item) =>
+                isDirectFocusReason(focusReasons.experiments.get(item.id)),
+              )
+              .map((item) => item.id),
+          )
+        : visibleExperimentIds,
+    [focusActive, focusReasons, visibleExperimentIds, visibleExperiments],
+  );
+  const selectableQuestionIds = useMemo(
+    () =>
+      focusActive && focusReasons
+        ? new Set(
+            visibleQuestions
+              .filter((item) =>
+                isDirectFocusReason(focusReasons.questions.get(item.id)),
+              )
+              .map((item) => item.id),
+          )
+        : visibleQuestionIds,
+    [focusActive, focusReasons, visibleQuestionIds, visibleQuestions],
+  );
+  const selectableFindingIds = useMemo(
+    () =>
+      focusActive && focusReasons
+        ? new Set(
+            visibleFindings
+              .filter((item) =>
+                isDirectFocusReason(focusReasons.findings.get(item.id)),
+              )
+              .map((item) => item.id),
+          )
+        : visibleFindingIds,
+    [focusActive, focusReasons, visibleFindingIds, visibleFindings],
+  );
+  const visibleExperimentsById = useMemo(
+    () => new Map(visibleExperiments.map((item) => [item.id, item])),
+    [visibleExperiments],
+  );
+  const experimentSelectionEligibility = useMemo(
+    () => ({
+      complete: selection.experiments.filter((id) => {
+        const experiment = visibleExperimentsById.get(id);
+        return experiment
+          ? isExperimentActionEligible(experiment.status, "complete")
+          : false;
+      }).length,
+      failed: selection.experiments.filter((id) => {
+        const experiment = visibleExperimentsById.get(id);
+        return experiment
+          ? isExperimentActionEligible(experiment.status, "failed")
+          : false;
+      }).length,
+      superseded: selection.experiments.filter((id) => {
+        const experiment = visibleExperimentsById.get(id);
+        return experiment
+          ? isExperimentActionEligible(experiment.status, "superseded")
+          : false;
+      }).length,
+    }),
+    [selection.experiments, visibleExperimentsById],
+  );
+  const pendingPreview = useMemo(
+    () =>
+      pendingAction
+        ? buildBulkActionPreview(pendingAction, selection, visibleExperimentsById)
+        : null,
+    [pendingAction, selection, visibleExperimentsById],
+  );
 
   const handleNodeClick = useCallback(
     (id: string) => {
@@ -213,6 +363,129 @@ export default function TreePage() {
     [navigate],
   );
 
+  const toggleQuestionSelection = useCallback((questionId: string) => {
+    if (
+      focusActive &&
+      focusReasons &&
+      !isDirectFocusReason(focusReasons.questions.get(questionId))
+    ) {
+      return;
+    }
+    setSelection((prev) =>
+      togglePruneSelection(prev, "question", questionId),
+    );
+  }, [focusActive, focusReasons]);
+
+  const toggleExperimentSelection = useCallback((experimentId: string) => {
+    if (
+      focusActive &&
+      focusReasons &&
+      !isDirectFocusReason(focusReasons.experiments.get(experimentId))
+    ) {
+      return;
+    }
+    setSelection((prev) =>
+      togglePruneSelection(prev, "experiment", experimentId),
+    );
+  }, [focusActive, focusReasons]);
+
+  const toggleFindingSelection = useCallback((findingId: string) => {
+    if (
+      focusActive &&
+      focusReasons &&
+      !isDirectFocusReason(focusReasons.findings.get(findingId))
+    ) {
+      return;
+    }
+    setSelection((prev) => togglePruneSelection(prev, "finding", findingId));
+  }, [focusActive, focusReasons]);
+
+  useEffect(() => {
+    setSelection(emptyPruneSelection());
+    setPendingAction(null);
+    setManageMode(false);
+  }, [activeProgram]);
+
+  useEffect(() => {
+    if (manageMode) return;
+    setPendingAction(null);
+    setSelection((prev) =>
+      samePruneSelection(prev, emptyPruneSelection())
+        ? prev
+        : emptyPruneSelection(),
+    );
+  }, [manageMode]);
+
+  useEffect(() => {
+    if (!manageMode) return;
+    setSelection((prev) => {
+      const next = intersectPruneSelection(prev, {
+        questions: selectableQuestionIds,
+        findings: selectableFindingIds,
+        experiments: selectableExperimentIds,
+      });
+      return samePruneSelection(prev, next) ? prev : next;
+    });
+  }, [
+    manageMode,
+    selectableExperimentIds,
+    selectableFindingIds,
+    selectableQuestionIds,
+  ]);
+
+  const handleConfirmAction = useCallback(async () => {
+    if (!pendingAction || !pendingPreview) return;
+
+    if (pendingAction.kind === "question") {
+      const result = await deleteQuestions.mutateAsync({
+        ids: pendingPreview.eligibleIds,
+      });
+      setSelection((prev) =>
+        removeAppliedFromSelection(
+          prev,
+          "question",
+          result.applied.map((item) => item.id),
+        ),
+      );
+      setPendingAction(null);
+      return;
+    }
+
+    if (pendingAction.kind === "finding") {
+      const result = await deleteFindings.mutateAsync({
+        ids: pendingPreview.eligibleIds,
+      });
+      setSelection((prev) =>
+        removeAppliedFromSelection(
+          prev,
+          "finding",
+          result.applied.map((item) => item.id),
+        ),
+      );
+      setPendingAction(null);
+      return;
+    }
+
+    const result = await transitionExperiments.mutateAsync({
+      ids: pendingPreview.eligibleIds,
+      status: pendingAction.action,
+    });
+    setSelection((prev) =>
+      removeAppliedFromSelection(
+        prev,
+        "experiment",
+        result.applied.map((item) => item.id),
+      ),
+    );
+    setPendingAction(null);
+  }, [
+    deleteFindings,
+    deleteQuestions,
+    pendingAction,
+    pendingPreview,
+    transitionExperiments,
+  ]);
+
   const isLoading =
     loadingExp ||
     loadingDir ||
@@ -232,43 +505,78 @@ export default function TreePage() {
           <h1 className="text-[15px] font-semibold tracking-[-0.015em] text-text">
             Research tree
           </h1>
-          <div
-            className="flex shrink-0 rounded-[6px] border border-border bg-surface p-0.5"
-            role="tablist"
-            aria-label="View mode"
-          >
+          <div className="flex flex-wrap items-center gap-2">
+            <FocusToggle
+              enabled={focusEnabled}
+              canFocus={canFocus}
+              description={focusDescription}
+              disabledReason={disabledReason}
+              onToggle={() => setFocusEnabled(!focusEnabled)}
+              compact
+            />
             <button
               type="button"
-              role="tab"
-              aria-selected={viewMode === "tree"}
               className={
-                viewMode === "tree"
-                  ? "rounded-[4px] bg-surface-raised px-2.5 py-1 text-[11px] font-medium text-text shadow-sm"
-                  : "rounded-[4px] px-2.5 py-1 text-[11px] font-medium text-text-tertiary hover:text-text-secondary"
+                manageMode
+                  ? "inline-flex items-center gap-1.5 rounded-[6px] border border-accent/30 bg-accent/10 px-2.5 py-1 text-[11px] font-medium text-accent"
+                  : "inline-flex items-center gap-1.5 rounded-[6px] border border-border bg-surface-raised px-2.5 py-1 text-[11px] font-medium text-text-secondary hover:bg-surface-hover"
               }
-              onClick={() => setViewMode("tree")}
+              onClick={() => setManageMode((prev) => !prev)}
             >
-              Tree
+              <CheckSquare2 className="h-3.5 w-3.5" />
+              {manageMode ? "Manage on" : "Manage"}
             </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={viewMode === "map"}
-              className={
-                viewMode === "map"
-                  ? "rounded-[4px] bg-surface-raised px-2.5 py-1 text-[11px] font-medium text-text shadow-sm"
-                  : "rounded-[4px] px-2.5 py-1 text-[11px] font-medium text-text-tertiary hover:text-text-secondary"
-              }
-              onClick={() => setViewMode("map")}
+            <div
+              className="flex shrink-0 rounded-[6px] border border-border bg-surface p-0.5"
+              role="tablist"
+              aria-label="View mode"
             >
-              Map
-            </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={viewMode === "tree"}
+                className={
+                  viewMode === "tree"
+                    ? "rounded-[4px] bg-surface-raised px-2.5 py-1 text-[11px] font-medium text-text shadow-sm"
+                    : "rounded-[4px] px-2.5 py-1 text-[11px] font-medium text-text-tertiary hover:text-text-secondary"
+                }
+                onClick={() => setViewMode("tree")}
+              >
+                Tree
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={viewMode === "map"}
+                className={
+                  viewMode === "map"
+                    ? "rounded-[4px] bg-surface-raised px-2.5 py-1 text-[11px] font-medium text-text shadow-sm"
+                    : "rounded-[4px] px-2.5 py-1 text-[11px] font-medium text-text-tertiary hover:text-text-secondary"
+                }
+                onClick={() => setViewMode("map")}
+              >
+                Map
+              </button>
+            </div>
           </div>
         </div>
         <p className="mt-1 text-[12px] text-text-secondary">
           Program → project → direction → question → experiment. Findings stay
           attached to the experiments that support them.
         </p>
+        {focusActive ? (
+          <p className="mt-1 text-[11px] text-text-quaternary">
+            Focus mode keeps direct matches bright and shows container context
+            in a muted style so the structure still makes sense.
+          </p>
+        ) : null}
+        {manageMode ? (
+          <p className="mt-1 text-[11px] text-accent">
+            Manage mode is on. Click questions, experiments, and finding
+            chips/nodes to select them. Use the inline Open buttons to inspect a
+            record without leaving selection mode.
+          </p>
+        ) : null}
         <p className="mt-1 text-[11px] text-text-quaternary">
           Program:{" "}
           <span className="font-medium text-text-secondary">
@@ -375,6 +683,13 @@ export default function TreePage() {
               findings={visibleFindings}
               questions={visibleQuestions}
               expansionResetKey={activeProgram}
+              manageMode={manageMode}
+              selection={selection}
+              focusMode={focusActive}
+              focusReasons={focusReasons}
+              onToggleQuestionSelection={toggleQuestionSelection}
+              onToggleExperimentSelection={toggleExperimentSelection}
+              onToggleFindingSelection={toggleFindingSelection}
               onNavigate={handleTreeNavigate}
             />
           ) : (
@@ -396,6 +711,13 @@ export default function TreePage() {
                 onProjectNavigate={handleProjectNavigate}
                 onDirectionNavigate={handleDirectionNavigate}
                 onFindingNavigate={handleFindingNavigate}
+                manageMode={manageMode}
+                selection={selection}
+                focusMode={focusActive}
+                focusReasons={focusReasons}
+                onToggleQuestionSelection={toggleQuestionSelection}
+                onToggleExperimentSelection={toggleExperimentSelection}
+                onToggleFindingSelection={toggleFindingSelection}
               />
             </Suspense>
           )
@@ -405,6 +727,50 @@ export default function TreePage() {
           </div>
         )}
       </div>
+
+      {manageMode ? (
+        <PruneActionBar
+          selection={selection}
+          eligibleExperimentCounts={experimentSelectionEligibility}
+          onAction={setPendingAction}
+          onClear={() => setSelection(emptyPruneSelection())}
+          onExit={() => setManageMode(false)}
+        />
+      ) : null}
+
+      {pendingAction && pendingPreview ? (
+        <PruneConfirmDialog
+          open
+          kind={pendingAction.kind}
+          action={pendingAction.action}
+          title={
+            pendingAction.kind === "question"
+              ? "Delete selected questions?"
+              : pendingAction.kind === "finding"
+                ? "Delete selected findings?"
+                : pendingAction.action === "superseded"
+                  ? "Archive selected experiments?"
+                  : `${experimentActionConfirmLabel(pendingAction.action)}?`
+          }
+          description={
+            pendingAction.kind === "question"
+              ? "Questions will be removed from the question inbox and linked tree/map views."
+              : pendingAction.kind === "finding"
+                ? "Findings will be removed, supersession links will be repaired, and linked artifacts will be queued for cleanup."
+                : pendingAction.action === "superseded"
+                  ? "Only complete or failed experiments can be archived in this pass."
+                  : "Only open or running experiments are eligible for close-out from this bulk workflow."
+          }
+          preview={pendingPreview}
+          isPending={
+            deleteQuestions.isPending ||
+            deleteFindings.isPending ||
+            transitionExperiments.isPending
+          }
+          onClose={() => setPendingAction(null)}
+          onConfirm={handleConfirmAction}
+        />
+      ) : null}
     </div>
   );
 }

--- a/ui/src/stores/focus.ts
+++ b/ui/src/stores/focus.ts
@@ -1,0 +1,37 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+const FOCUS_PERSIST_VERSION = 1;
+
+interface FocusState {
+  enabled: boolean;
+  setEnabled: (enabled: boolean) => void;
+  toggleEnabled: () => void;
+}
+
+export const useFocusStore = create<FocusState>()(
+  persist(
+    (set) => ({
+      enabled: true,
+      setEnabled: (enabled) => set({ enabled }),
+      toggleEnabled: () => set((state) => ({ enabled: !state.enabled })),
+    }),
+    {
+      name: "sonde-focus-mode",
+      version: FOCUS_PERSIST_VERSION,
+      migrate: (persistedState: unknown, version: number) => {
+        if (version >= FOCUS_PERSIST_VERSION) return persistedState;
+        return {
+          ...(persistedState as Partial<FocusState> | null),
+          enabled: true,
+        };
+      },
+    },
+  ),
+);
+
+export const useFocusEnabled = () => useFocusStore((state) => state.enabled);
+export const useSetFocusEnabled = () =>
+  useFocusStore((state) => state.setEnabled);
+export const useToggleFocusEnabled = () =>
+  useFocusStore((state) => state.toggleEnabled);

--- a/ui/src/types/sonde.ts
+++ b/ui/src/types/sonde.ts
@@ -55,6 +55,12 @@ export type RecordType =
   | "direction"
   | "project";
 
+export type PruneableRecordKind = "question" | "finding" | "experiment";
+
+export type ExperimentPruneAction = "complete" | "failed" | "superseded";
+
+export type PruneAction = "delete" | ExperimentPruneAction;
+
 export interface RepoSnapshot {
   name: string;
   remote: string;
@@ -296,6 +302,56 @@ export interface ActivityLogEntry {
   actor_name: string | null;
   details: Record<string, unknown>;
   created_at: string;
+}
+
+export interface PruneSelection {
+  questions: string[];
+  findings: string[];
+  experiments: string[];
+}
+
+export interface BulkActionSkip {
+  id: string;
+  reason: string;
+  message: string;
+  current_status?: ExperimentStatus | null;
+}
+
+export interface BulkActionSummary {
+  requested: number;
+  applied: number;
+  skipped: number;
+}
+
+export interface BulkActionResult<TApplied> {
+  applied: TApplied[];
+  skipped: BulkActionSkip[];
+  summary: BulkActionSummary;
+}
+
+export interface BulkDeleteQuestionApplied {
+  id: string;
+}
+
+export interface BulkDeleteFindingApplied {
+  id: string;
+  artifact_count: number;
+  supersedes: string | null;
+  superseded_by: string | null;
+}
+
+export interface BulkTransitionExperimentApplied {
+  id: string;
+  from: ExperimentStatus;
+  to: ExperimentStatus;
+}
+
+export interface BulkActionPreview {
+  kind: PruneableRecordKind;
+  action: PruneAction;
+  eligibleIds: string[];
+  sampleIds: string[];
+  skipped: BulkActionSkip[];
 }
 
 export interface ExperimentReview {


### PR DESCRIPTION
## Summary
- Bulk prune/close UX (action bar + confirm dialog) wired into questions, findings, experiments, directions, and the research tree
- New focus toggle to narrow views to active work, backed by a shared store + pure focus-mode logic with tests
- Supporting migration (`20260423000001_ui_prune_bulk_close.sql`), prune-mutation hooks, actor-source util, and a refactor of the experiment-graph into a pure, tested graph-builder

## Test plan
- [ ] UI: bulk-close flows on questions, findings, experiments, directions
- [ ] UI: focus toggle hides/reveals expected nodes across list + tree views
- [ ] UI: research-tree renders with no orphan edges after prune
- [ ] `pnpm test` for `focus-mode`, `prune-actions`, and `graph-builder` unit tests
- [ ] Supabase migration applies cleanly on a fresh DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)